### PR TITLE
Add 7 LLMOps entries + fix 'Newest first' sort

### DIFF
--- a/src/components/islands/LLMOpsFilter.tsx
+++ b/src/components/islands/LLMOpsFilter.tsx
@@ -26,6 +26,8 @@ export interface LLMOpsIndexItem {
   llmopsTags: string[];
   industryTags: string | null;
   year: number | null;
+  /** Epoch ms for when the entry was added to the DB (derived from provenance). */
+  addedAt: number | null;
   link: string | null;
 }
 
@@ -175,10 +177,13 @@ function sortItems(items: ProcessedItem[], sort: SortMode, q: string): Processed
   const sorted = [...items];
   switch (sort) {
     case "newest":
+      // Order by when an entry was added to our DB, not the source material's year
+      // (a 2024 blog post added yesterday should rank above a 2024 post added a year ago).
       sorted.sort((a, b) => {
-        const yearDiff = (b.year ?? 0) - (a.year ?? 0);
-        if (yearDiff !== 0) return yearDiff;
-        return a.title.localeCompare(b.title);
+        const ta = a.addedAt ?? 0;
+        const tb = b.addedAt ?? 0;
+        if (tb !== ta) return tb - ta;
+        return a.slug.localeCompare(b.slug);
       });
       break;
     case "az":

--- a/src/content/llmops-database/ai-agent-optimization-using-claude-to-systematically-improve-memory-extraction-quality.md
+++ b/src/content/llmops-database/ai-agent-optimization-using-claude-to-systematically-improve-memory-extraction-quality.md
@@ -1,0 +1,174 @@
+---
+title: "AI Agent Optimization: Using Claude to Systematically Improve Memory Extraction Quality"
+slug: "ai-agent-optimization-using-claude-to-systematically-improve-memory-extraction-quality"
+draft: false
+llmopsTags:
+  - "code-generation"
+  - "chatbot"
+  - "prompt-engineering"
+  - "agent-based"
+  - "multi-agent-systems"
+  - "evals"
+  - "few-shot"
+  - "system-prompts"
+  - "langchain"
+  - "pytorch"
+  - "open-source"
+  - "fastapi"
+  - "anthropic"
+industryTags: "tech"
+company: "Lerim"
+summary: "Lerim, an open-source memory system for coding agents, faced challenges with memory extraction quality and accuracy. The solution involved using Claude Code (Opus 4.6) in an AutoResearch pattern to systematically optimize Lerim's prompts, DSPy signatures, tool descriptions, and schema definitions through automated experiments with comprehensive evaluation harnesses. Over two optimization rounds comprising 24 experiments, the system achieved a 41% improvement in composite quality score, with the single biggest win coming from a one-line code change (switching from dspy.Predict to dspy.ChainOfThought). The experiments revealed that schema-level changes outperformed prompt engineering, that positive guidance beats restrictive rules, and that component-level optimizations cascade into end-to-end improvements across the entire system."
+link: "https://kargarisaac.medium.com/one-line-of-code-41-better-memory-when-one-ai-agent-optimizes-another-da2396bc501b"
+year: 2026
+seo:
+  title: "Lerim: AI Agent Optimization: Using Claude to Systematically Improve Memory Extraction Quality - ZenML LLMOps Database"
+  description: "Lerim, an open-source memory system for coding agents, faced challenges with memory extraction quality and accuracy. The solution involved using Claude Code (Opus 4.6) in an AutoResearch pattern to systematically optimize Lerim's prompts, DSPy signatures, tool descriptions, and schema definitions through automated experiments with comprehensive evaluation harnesses. Over two optimization rounds comprising 24 experiments, the system achieved a 41% improvement in composite quality score, with the single biggest win coming from a one-line code change (switching from dspy.Predict to dspy.ChainOfThought). The experiments revealed that schema-level changes outperformed prompt engineering, that positive guidance beats restrictive rules, and that component-level optimizations cascade into end-to-end improvements across the entire system."
+  canonical: "https://www.zenml.io/llmops-database/ai-agent-optimization-using-claude-to-systematically-improve-memory-extraction-quality"
+  ogTitle: "Lerim: AI Agent Optimization: Using Claude to Systematically Improve Memory Extraction Quality - ZenML LLMOps Database"
+  ogDescription: "Lerim, an open-source memory system for coding agents, faced challenges with memory extraction quality and accuracy. The solution involved using Claude Code (Opus 4.6) in an AutoResearch pattern to systematically optimize Lerim's prompts, DSPy signatures, tool descriptions, and schema definitions through automated experiments with comprehensive evaluation harnesses. Over two optimization rounds comprising 24 experiments, the system achieved a 41% improvement in composite quality score, with the single biggest win coming from a one-line code change (switching from dspy.Predict to dspy.ChainOfThought). The experiments revealed that schema-level changes outperformed prompt engineering, that positive guidance beats restrictive rules, and that component-level optimizations cascade into end-to-end improvements across the entire system."
+notion:
+  pageId: "33ef8dff-2538-80b5-9c02-df3152e2ad33"
+  databaseId: "1a9eaa1f57dd47d5af958caa57742b6b"
+  createdTime: "2026-04-10T07:07:00.000Z"
+  lastEditedTime: "2026-04-10T07:07:00.000Z"
+  publishedAt: "2026-04-14T08:51:01Z"
+---
+
+## Overview
+
+This case study documents a sophisticated meta-optimization experiment where one AI agent (Claude Code with Opus 4.6) systematically optimized another AI agent system (Lerim's memory extraction pipeline running on MiniMax M2.5). The experiment, conducted in March-April 2026, demonstrates advanced LLMOps practices including automated evaluation harnesses, multi-dimensional quality metrics, systematic experimentation with keep/revert discipline, and the surprising effectiveness of cross-model optimization.
+
+Lerim is an open-source system designed to solve a fundamental problem in coding agent workflows: session memory persistence. Coding agents like Claude and Cursor forget architectural decisions, debugging workarounds, and learned patterns between sessions. Lerim watches coding sessions, extracts actionable memories (decisions and learnings), and makes those memories available across all future sessions with any agent. Under the hood, it operates as an agentic system with multiple tools managing memory extraction, deduplication, search, and maintenance in the background.
+
+The challenge the developer faced was uncertainty about the quality of memory extraction and deduplication accuracy. While the system functioned, there was no systematic understanding of where improvements could be made or what changes would actually move quality metrics. This led to the core experiment: could an AI agent autonomously improve another AI agent's performance through systematic optimization?
+
+## Technical Architecture and Optimization Surface
+
+Lerim's architecture presented multiple optimization surfaces across several layers. The extraction pipeline used DSPy signatures with docstrings that instructed the extraction LLM. System prompts guided the overall agent behavior. Tool descriptions influenced which tools the agent selected during operation. Pydantic schema field descriptions shaped the output format and structure. Post-extraction filters gated quality by rejecting candidates that didn't meet certain thresholds.
+
+The evaluation framework operated at two distinct levels. Component-level evaluation tested each dimension independently against golden test cases, running in approximately 15 minutes per experiment. This fast feedback loop enabled the optimization process. End-to-end lifecycle evaluation ran sequential syncs of three sessions followed by a maintenance cycle, testing how memories accumulated over time, how deduplication worked across sessions, and whether maintenance decisions actually improved the memory store. This slower evaluation (approximately 7 minutes) validated that component-level gains translated to real-world improvements.
+
+The composite evaluation metric combined multiple dimensions. Extraction quality measured whether each extracted memory was atomic and actionable. Search relevance evaluated whether the right memories surfaced for given queries. Deduplication accuracy assessed whether the system correctly identified duplicate memories versus genuinely new information. Maintain precision measured whether the maintenance cycle correctly preserved valuable memories while removing obsolete ones. The composite score weighted these dimensions to produce a single optimization target.
+
+## The AutoResearch Pattern: Agent Optimizing Agent
+
+The optimization approach adapted Andrej Karpathy's AutoResearch pattern, but instead of an AI agent optimizing a training script, this implementation had Claude Code optimizing Lerim's agents, prompts, and tools. The setup followed a three-component pattern that maintained clear separation of concerns and prevented the optimizer from gaming the evaluation.
+
+The first component was program.md, which contained human-written directives specifying which files Claude Code could modify, what the evaluation metric measured, and what constraints to follow. A critical constraint was "don't overfit to the golden cases" - the optimizer needed to find generalizable improvements, not just memorize test cases.
+
+The second component was the modifiable code itself: Lerim's prompts, tool descriptions, DSPy signatures, schema definitions, and the entire evaluation harness. Claude Code had full edit access to these components and could experiment freely.
+
+The third component was the immutable evaluator, which Claude Code could not modify. This evaluator ran Lerim's full pipeline against 15 golden test cases (later expanded to 327 cases in Round 2) and produced the composite quality score. The immutability was critical - it prevented the optimizer from simply rewriting the evaluation to make its changes look better.
+
+Each optimization loop ran approximately 30 minutes. Claude Code would modify a prompt or signature, the evaluator would run Lerim's full pipeline against the golden cases, scores would be computed, and Claude Code would decide whether the change improved the system. The keep/revert discipline was essential: changes that improved the score were kept, changes that hurt or showed no improvement were immediately reverted. This prevented the accumulation of noise and ensured the codebase only improved.
+
+Notably, this represents cross-model optimization: Claude Opus 4.6 optimizing a system running on MiniMax M2.5. The optimizer and the optimized are different models from different companies, which means improvements represent genuine capability gains rather than self-reinforcing biases that might emerge from a model optimizing itself.
+
+## Round 1: Component-Level Optimization Results
+
+Round 1 consisted of 14 experiments run over 4.5 hours. Seven experiments were kept and seven were discarded. The composite quality score improved from baseline to a final score representing a 41% overall improvement. Different dimensions showed varying levels of improvement.
+
+Extraction quality improved modestly, indicating the base extraction was already reasonably good. Search relevance showed moderate improvement. The most dramatic improvement came in deduplication accuracy, which jumped from 0.28 to 0.72. Before optimization, the agent classified most candidates as "add" even when nearly identical memories already existed in the store. After optimization, the system correctly identified duplicates and appropriately updated existing memories instead of creating redundant entries. Maintain precision remained relatively stable, starting high and maintaining that level.
+
+However, the deduplication accuracy metric showed high volatility across experiments, sometimes swinging between 0.17 and 0.72 even with identical code. This variance stemmed from LLM non-determinism in the classification step. The optimization didn't eliminate variance but shifted the entire distribution upward so even "bad" runs performed better than the old baseline.
+
+## The Most Impactful Change: One Line of Code
+
+The single biggest win came from Experiment 010, which changed one line: `dspy.Predict(MemoryExtractSignature)` became `dspy.ChainOfThought(MemoryExtractSignature)`. This single import swap gave the extraction LLM a reasoning scratchpad before producing structured output. The result was better-quality candidates with more consistent titles and richer bodies. This single change accounted for nearly half the total improvement across all metrics.
+
+What makes this particularly remarkable is that Claude Code discovered this independently. It read the DSPy extraction pipeline code, noticed it was using bare `Predict`, hypothesized that `ChainOfThought` would improve reasoning quality for a complex extraction task, made the change, and confirmed the improvement through evaluation. This demonstrates the AI agent genuinely understanding the design tradeoff rather than randomly trying changes.
+
+## Key Lessons from Successful Experiments
+
+Several patterns emerged from the successful experiments that have broader implications for LLMOps practice. Schema field descriptions consistently outperformed prompt-level changes in impact. The `MemoryCandidate` Pydantic model's `title` field initially had a minimal four-word description: "Short memory title." Claude Code changed this to describe the expected format explicitly: start with a verb or noun phrase, maximum 10 words, self-contained. The LLM immediately began producing more consistent, descriptive titles. This improvement cascaded into better deduplication accuracy because title matching improved. The lesson here is that the 20 words controlling output format in the schema had more impact than 50 lines of prompt engineering. The LLM's output specification matters more than its instruction.
+
+Explicit thresholds consistently beat vague language. The original sync prompt used language like "top_similarity very high" for no_op classification. Claude Code replaced this with concrete numerical thresholds: 0.7 for no_op classification, 0.4 for the update/add boundary. Classification consistency improved immediately. LLMs handle concrete criteria better than interpreting subjective descriptors.
+
+Component-level changes cascade through the entire system in non-obvious ways. The ChainOfThought change for extraction improved extraction quality directly, which produced better candidates, which made deduplication easier to perform accurately, which improved deduplication accuracy. A single upstream change rippled through multiple downstream metrics. Understanding these second-order effects is precisely why comprehensive evaluation harnesses are essential in LLMOps.
+
+## Failed Experiments and Negative Results
+
+Half the experiments failed, and these failures provided valuable lessons. ChainOfThought applied to summarization actually hurt performance. While it worked brilliantly for extraction, applying the same technique to summarization disrupted the existing cascade. Tool description changes affected multiple flows unpredictably - changing a tool description to optimize one use case degraded performance in other contexts where that tool was used.
+
+Restrictive extraction rules consistently backfired. Attempts to add "don't extract X" rules or skip lists reduced recall without improving precision. The LLM became overly cautious and started missing real decisions. This pattern repeated across experiments: negative guidance ("don't do X") performed worse than positive guidance ("good examples look like Y").
+
+Body format guidance changes modified output enough to break fuzzy matching logic elsewhere in the system. This highlights the brittleness that can emerge in agentic systems - changes that seem local can have global effects through subtle format shifts.
+
+The experiment log of failed changes proved as valuable as the kept changes. Each failure narrowed the search space. "Don't change tool descriptions in isolation" became knowledge that prevented future mistakes and wasted experiments.
+
+## End-to-End Validation
+
+After component-level optimization, running the full lifecycle evaluation on both original and optimized code verified that gains held up end-to-end. Extraction quality improved, search relevance improved, and deduplication accuracy improved - all consistent with component-level measurements.
+
+The biggest surprise came from maintenance quality, which improved by 29% even though the maintenance prompt itself was never directly optimized. This demonstrates cascade effects at the system level: better extraction quality from ChainOfThought produced higher-quality memories, which the maintain judge scored more favorably. Component-level optimization in one part of the pipeline cascaded into end-to-end improvement in a completely different part of the system that was never directly touched.
+
+## Round 2: Optimizing for the Right Thing
+
+After achieving 41% improvement and seven successful experiments, the developer compared Lerim's actual output to Claude Code's native `~/.claude/` memory files and discovered a quality gap. Claude Code's memory store contained 15 curated files, each atomic, actionable, and context-independent - things like "user prefers tabs," "always explain before coding," "never drop Codex support." Every memory would meaningfully change how an agent behaves in future sessions.
+
+Lerim, despite its improved scores, had 50+ active memories. Many were research dumps ("7 trace format investigation notes"), code-derivable facts ("the CTE uses ROW_NUMBER() OVER PARTITION BY repo_path"), or implementation details just describing what the code does. The system scored well on evaluation but produced memories of limited practical value.
+
+The realization was that the evaluation was measuring the wrong thing. The metrics rewarded recall (did you find everything?) but didn't adequately penalize over-extraction (did you extract garbage?). A system that extracts everything scores well on completeness but produces memories no agent would actually use.
+
+## Round 2: Evaluation Recalibration
+
+The developer recalibrated the evaluation framework substantially. A new quality_alignment dimension was added to the judge, specifically measuring whether each memory was atomic, actionable, context-independent, and structured with WHY + HOW TO APPLY sections. The composite score reweighting made precision (25%) and quality_alignment (25%) account for half the total score, while completeness dropped to just 15%.
+
+A much larger golden dataset was built: 327 cases across 20 categories. This included 70 negative cases where the correct answer is zero memories (sessions with no extractable decisions), and 50 mixed cases with 1-2 real decisions buried in implementation noise. This tests the system's ability to discriminate signal from noise, not just extract everything it sees.
+
+A tiered evaluation strategy emerged: 30-case fast evaluation (~15 minutes) for each experiment's quick feedback, with full 327-case evaluation (~4 hours) run at checkpoints to catch overfitting. This balanced optimization speed with generalization validation.
+
+## Round 2: Results and Lessons
+
+Round 2 ran 10 experiments with 3 kept and 7 discarded. Extraction quality improved from 0.819 to 0.847, a 3.4% gain. The improvements were smaller than Round 1 but targeted at what actually matters: the quality of extracted memories rather than just the quantity.
+
+The successful changes included adding quality criteria directly into the extraction signature. A "QUALITY BAR" section in the DSPy signature - specifying atomic, actionable, context-independent, structured, durable - gave the extraction LLM a clear standard to evaluate against. This is positive guidance: "here's what good looks like."
+
+Body structure specification helped: changing the schema's body field description from "Include WHY, alternatives, context" to "Lead with rule/fact, then WHY, then HOW TO APPLY" produced more structured, actionable memory bodies. This reinforces the Round 1 lesson that the LLM's output specification matters more than its instruction. Adding one good positive example with the WHY/HOW TO APPLY structure reinforced the pattern without causing regression.
+
+## The Universal Failure Pattern: Restrictive Rules
+
+Across five separate experiments spanning both rounds, restrictive rules consistently backfired. Every attempt to add "avoid extracting" lists, "skip if" conditions, "don't extract code snippets," negative examples, or "exclude X" rules resulted in regression. The pattern is unambiguous and has clear implications for LLMOps practice.
+
+The lesson crystallized: tell the LLM what good looks like, never tell it what to avoid. Negative examples, skip lists, and "don't do X" directives reduce recall without improving precision. The LLM becomes cautious and starts missing real decisions. Positive guidance consistently outperforms negative constraints.
+
+One particularly instructive failure: softening the "default to no_op when uncertain" rule to "only no_op when same specific facts" crashed maintain performance from 1.000 to 0.667. This was the first time maintain quality ever regressed. The conservative deduplication default prevents memory store flooding. Weakening it proved catastrophic. This highlights that some defaults serve as critical guardrails even if they seem overly conservative.
+
+Sync agent changes proved dangerous. Modifying dedup classification language in the sync agent's signature affected extraction quality even though the change targeted deduplication. The sync agent controls the entire flow - touching it has unpredictable second-order effects across the system.
+
+## The AutoResearch Skill: Generalizing the Pattern
+
+After two rounds, the developer packaged the entire optimization pattern into a reusable Claude Code skill. Running `/autoresearch 100` starts the optimization loop autonomously - the agent reads program.md for the objective, iterates through hypothesize-edit-eval-keep/revert cycles, and logs everything.
+
+The key architectural insight is separating the method from the objective. The skill encodes the AutoResearch pattern (how to optimize) while program.md encodes the objective (what to optimize). Changing the objective while running the same skill enables different optimization targets. Round 1 optimized for pipeline quality. Round 2 optimized for extraction precision. Same skill, different program.md, different results.
+
+## Diminishing Returns and Optimization Ceilings
+
+Round 1 achieved 41% improvement by finding low-hanging fruit - the extraction pipeline was using a basic `Predict` call instead of `ChainOfThought`. Round 2 squeezed out 3.4% gains by teaching the LLM what quality looks like through better specifications. The diminishing returns suggest the prompt and configuration are approaching their ceiling for MiniMax M2.5.
+
+This has important implications for LLMOps: there's a limit to how much optimization can improve a given model's performance on a given task. At some point, further improvement requires either better models, architectural changes, or fundamentally different approaches rather than continued prompt tuning.
+
+## Post-Experiment Refactoring
+
+A week after writing the initial report, the developer rebuilt substantial portions of the system. The experiment's numbers remained valid and the lessons held, but writing the detailed case study forced a comparison between Lerim's extracted memories and Claude Code's native memory store. Even after 41% improvement, the output still didn't match the quality of memories the developer actually wanted in sessions. The experiment had taught how to optimize but hadn't captured what good truly looked like at a level the judge could reliably measure.
+
+The judge was completely rebuilt as a DSPy-native, two-layer metric. The original composite score weighted extraction/search/dedup/maintain against golden cases. The new metric became simpler and more honest: a deterministic layer (25%) checks structure, format, and content heuristics, while an LLM judge layer (75%) scores quality (split into worth_keeping, type_correct, well_structured), recall, and precision.
+
+The memory architecture moved to version 2: flat directory with a four-type schema. The original decisions/learnings split was eliminated. Memories now live in a flat directory with frontmatter type fields of user, feedback, project, or reference. The split had been an artifact of early thinking about "what kinds of things coding agents should remember" rather than a distinction the extractor could reliably make. Collapsing it simplified deduplication, eliminated a class of misclassifications, and let the judge focus on content quality instead of directory placement.
+
+The extraction and summarization pipelines were deleted as separate components. Both are now handled by the agent itself via its tools rather than separate pipeline stages. The developer is working on more careful agent and tool design with plans for another round of experiments.
+
+## Broader LLMOps Implications
+
+This case study demonstrates several advanced LLMOps practices with broader applicability. Cross-model optimization works: one model can effectively optimize another model's performance through systematic experimentation. The fact that Claude Opus 4.6 could improve a MiniMax M2.5-based system suggests this approach generalizes across model families.
+
+The 50% failure rate in experiments is normal and valuable. Each failure narrowed the search space and prevented future mistakes. In production LLMOps, failed experiments should be logged and analyzed as carefully as successful ones.
+
+Evaluation harnesses are essential for complex agentic systems. Without comprehensive multi-dimensional evaluation, it's impossible to understand second-order effects where changes in one component cascade through the entire system. Component-level and end-to-end evaluation serve different purposes and both are necessary.
+
+The hierarchy of impact for LLM configuration appears to be: architectural changes (ChainOfThought vs Predict) > schema specifications > concrete thresholds > prompt engineering > negative constraints. This suggests where LLMOps teams should focus optimization effort.
+
+The developer's willingness to rebuild the system after discovering evaluation misalignment demonstrates important LLMOps maturity: optimizing for the wrong metric produces systems that score well but fail in practice. Getting the evaluation right matters more than optimization speed.
+
+This case study represents sophisticated meta-level LLMOps: using AI agents to improve AI agents through systematic experimentation, comprehensive evaluation, and disciplined iteration. The approach, tooling, and lessons learned provide a template for optimizing other agentic systems in production.

--- a/src/content/llmops-database/ai-agents-for-documenting-tribal-knowledge-in-large-scale-data-pipelines.md
+++ b/src/content/llmops-database/ai-agents-for-documenting-tribal-knowledge-in-large-scale-data-pipelines.md
@@ -1,0 +1,137 @@
+---
+title: "AI Agents for Documenting Tribal Knowledge in Large-Scale Data Pipelines"
+slug: "ai-agents-for-documenting-tribal-knowledge-in-large-scale-data-pipelines"
+draft: false
+llmopsTags:
+  - "code-generation"
+  - "data-analysis"
+  - "document-processing"
+  - "multi-agent-systems"
+  - "agent-based"
+  - "prompt-engineering"
+  - "system-prompts"
+  - "evals"
+  - "error-handling"
+  - "token-optimization"
+  - "orchestration"
+  - "documentation"
+  - "cicd"
+  - "monitoring"
+  - "databases"
+  - "meta"
+industryTags: "tech"
+company: "Meta"
+summary: "Meta faced challenges deploying AI coding assistants to work on their large-scale data processing pipeline spanning four repositories, three programming languages, and over 4,100 files. The AI agents lacked understanding of the codebase's tribal knowledge—undocumented design patterns, cross-module dependencies, and naming conventions that existed only in engineers' heads. To solve this, Meta built a pre-compute engine consisting of 50+ specialized AI agents that systematically analyzed the entire codebase and produced 59 concise context files encoding critical domain knowledge. This increased AI context coverage from 5% to 100% of code modules, documented over 50 non-obvious patterns, and reduced AI agent tool calls by approximately 40% per task. The system includes automated self-maintenance that periodically validates file paths, detects coverage gaps, and auto-fixes stale references, ensuring the context layer remains current as the codebase evolves."
+link: "https://engineering.fb.com/2026/04/06/developer-tools/how-meta-used-ai-to-map-tribal-knowledge-in-large-scale-data-pipelines/"
+year: 2026
+seo:
+  title: "Meta: AI Agents for Documenting Tribal Knowledge in Large-Scale Data Pipelines - ZenML LLMOps Database"
+  description: "Meta faced challenges deploying AI coding assistants to work on their large-scale data processing pipeline spanning four repositories, three programming languages, and over 4,100 files. The AI agents lacked understanding of the codebase's tribal knowledge—undocumented design patterns, cross-module dependencies, and naming conventions that existed only in engineers' heads. To solve this, Meta built a pre-compute engine consisting of 50+ specialized AI agents that systematically analyzed the entire codebase and produced 59 concise context files encoding critical domain knowledge. This increased AI context coverage from 5% to 100% of code modules, documented over 50 non-obvious patterns, and reduced AI agent tool calls by approximately 40% per task. The system includes automated self-maintenance that periodically validates file paths, detects coverage gaps, and auto-fixes stale references, ensuring the context layer remains current as the codebase evolves."
+  canonical: "https://www.zenml.io/llmops-database/ai-agents-for-documenting-tribal-knowledge-in-large-scale-data-pipelines"
+  ogTitle: "Meta: AI Agents for Documenting Tribal Knowledge in Large-Scale Data Pipelines - ZenML LLMOps Database"
+  ogDescription: "Meta faced challenges deploying AI coding assistants to work on their large-scale data processing pipeline spanning four repositories, three programming languages, and over 4,100 files. The AI agents lacked understanding of the codebase's tribal knowledge—undocumented design patterns, cross-module dependencies, and naming conventions that existed only in engineers' heads. To solve this, Meta built a pre-compute engine consisting of 50+ specialized AI agents that systematically analyzed the entire codebase and produced 59 concise context files encoding critical domain knowledge. This increased AI context coverage from 5% to 100% of code modules, documented over 50 non-obvious patterns, and reduced AI agent tool calls by approximately 40% per task. The system includes automated self-maintenance that periodically validates file paths, detects coverage gaps, and auto-fixes stale references, ensuring the context layer remains current as the codebase evolves."
+notion:
+  pageId: "341f8dff-2538-80a2-a248-e3e53af03da0"
+  databaseId: "1a9eaa1f57dd47d5af958caa57742b6b"
+  createdTime: "2026-04-13T07:02:00.000Z"
+  lastEditedTime: "2026-04-13T07:03:00.000Z"
+  publishedAt: "2026-04-14T08:50:14Z"
+---
+
+## Overview
+
+Meta's case study demonstrates a sophisticated approach to deploying AI coding assistants in production for a complex, proprietary codebase. The company operates large-scale data processing pipelines that span multiple repositories, programming languages (Python, C++, and Hack), and thousands of files. When Meta attempted to extend their existing AI-powered operational systems to handle development tasks, they encountered a fundamental limitation: the AI agents lacked the contextual understanding necessary to make correct code modifications in their config-as-code architecture.
+
+The solution involved building what Meta calls a "pre-compute engine"—a multi-agent system comprising over 50 specialized AI agents working in orchestrated phases to systematically document tribal knowledge. This knowledge, which previously existed only in engineers' minds and scattered code comments, was distilled into 59 concise, structured context files. The approach is noteworthy for its emphasis on quality assurance, automated self-maintenance, and the "compass, not encyclopedia" design principle that prioritizes actionable guidance over exhaustive documentation.
+
+## The Problem Context
+
+Meta's data pipeline represents a particularly challenging environment for AI coding assistants. The architecture is config-as-code, meaning that Python configurations, C++ services, and Hack automation scripts work together across multiple repositories in tightly coupled ways. A single seemingly simple task—such as onboarding a new data field—requires touching six different subsystems: configuration registries, routing logic, DAG composition, validation rules, C++ code generation, and automation scripts. All of these must remain synchronized.
+
+The company had already successfully deployed AI-powered systems for operational tasks such as scanning dashboards, pattern-matching against historical incidents, and suggesting mitigations. However, when they attempted to extend this capability to development tasks, the systems failed in subtle but critical ways. The AI agents would compile syntactically correct code that was semantically wrong because they lacked understanding of domain-specific constraints and patterns.
+
+Specific examples of tribal knowledge that caused failures included configuration modes that use different field names for the same operation (swapping them produces silent incorrect output), dozens of "deprecated" enum values that must never be removed due to serialization compatibility requirements, hidden intermediate naming conventions where one pipeline stage outputs a temporary field name that downstream stages rename, and append-only identifier rules where removing supposedly deprecated values breaks backward compatibility. None of this critical knowledge was documented in any accessible form.
+
+## The Multi-Agent Architecture
+
+Meta's solution employs a sophisticated multi-agent orchestration approach using large-context-window models. The system operates in distinct phases, with over 50 specialized tasks coordinated in a single session. The architecture includes several agent types, each with specific responsibilities:
+
+**Explorer agents** (two agents) mapped the overall codebase structure to understand the repository layout and identify modules requiring analysis. **Module analysts** (11 agents) performed the core knowledge extraction work by reading every file and answering five standardized questions for each module. **Writer agents** (two agents) generated the actual context files from the analyzed information. **Critic agents** (10+ agents running three independent rounds) performed quality review to ensure accuracy and completeness. **Fixer agents** (four agents) applied corrections identified during the critic passes. **Upgrader agents** (eight agents) refined the routing layer that directs queries to appropriate context. **Prompt testers** (three agents) validated 55+ queries across five different engineer personas. **Gap-filler agents** (four agents) covered remaining directories that might have been missed. **Final critic agents** (three agents) ran integration tests to ensure end-to-end coherence.
+
+This orchestration approach represents a production-grade implementation of multi-agent systems, with clear separation of concerns and quality gates between phases. The five standardized questions that module analysts answer provide a structured framework for knowledge extraction: What does this module configure? What are the common modification patterns? What are the non-obvious patterns that cause build failures? What are the cross-module dependencies? What tribal knowledge is buried in code comments?
+
+Meta notes that the fifth question—extracting tribal knowledge from code comments—yielded the deepest insights. This phase uncovered over 50 non-obvious patterns that were critical for correct code generation but had never been formally documented.
+
+## The Context File Design
+
+The context files follow what Meta calls the "compass, not encyclopedia" principle. Each file is deliberately constrained to 25–35 lines (approximately 1,000 tokens) and follows a four-section structure: Quick Commands (copy-paste operations for common tasks), Key Files (the 3–5 files actually needed for most work), Non-Obvious Patterns (the tribal knowledge that causes subtle failures), and See Also (cross-references to related context).
+
+This design philosophy directly addresses the challenge of context window efficiency. All 59 context files together consume less than 0.1% of a modern model's context window, making them practical to include when relevant without significantly impacting the agent's ability to reason about actual code. The constraint of keeping files concise forces prioritization of truly actionable information over comprehensive but less useful documentation.
+
+Beyond individual context files, Meta built supporting infrastructure including a cross-repo dependency index and data flow maps. These artifacts convert complex multi-file explorations (consuming approximately 6,000 tokens) into single graph lookups (consuming approximately 200 tokens). In config-as-code architectures where a single field change can ripple across six subsystems, this compression of dependency information significantly improves agent efficiency.
+
+## Quality Assurance and Validation
+
+Meta implemented rigorous quality assurance processes, reflecting an understanding that low-quality AI-generated context can be worse than no context at all. The three rounds of independent critic agents improved quality scores from 3.65 to 4.20 out of 5.0 on their internal rubric. All referenced file paths were verified programmatically, achieving zero hallucinations in the final output.
+
+The validation approach also included prompt testing across 55+ queries representing five different engineer personas, with a 100% core pass rate on these test cases. This suggests systematic testing of the context files against realistic usage scenarios rather than simply generating content and hoping it works.
+
+Meta's emphasis on verification is particularly important given recent academic research showing that AI-generated context files can actually decrease agent success rates in some scenarios. The company directly addresses this research, noting that the studies evaluated well-known open-source repositories (Django, matplotlib) where models already have significant knowledge from pretraining. In those cases, context files represent redundant noise that degrades performance. Meta argues their situation is fundamentally different: a proprietary config-as-code system with tribal knowledge that exists nowhere in any model's training data.
+
+## Automated Self-Maintenance
+
+A critical production concern for any AI-driven system is ensuring information remains current as the underlying codebase evolves. Meta built automated self-refresh capabilities that run every few weeks to validate file paths, identify coverage gaps, re-run critic agents, and auto-fix stale references. This automation addresses what Meta identifies as a key principle: "Context that decays is worse than no context at all."
+
+The self-maintenance system represents an interesting recursive application of AI: the AI agents aren't just consumers of the context infrastructure, they're the engine that maintains it. This approach could potentially scale better than manual documentation maintenance, which often falls out of date as codebases evolve.
+
+Meta mentions they're exploring whether the automated refresh mechanism can detect not just stale context but emerging patterns and new tribal knowledge forming in recent code reviews and commits. This would represent a shift from reactive maintenance (fixing what's broken) to proactive knowledge discovery (identifying new patterns as they emerge).
+
+## Orchestration and Routing Layer
+
+On top of the context files, Meta built an orchestration layer that auto-routes engineers to the right tool based on natural language queries. The system determines from the query intent whether to scan operational dashboards and match against 85+ historical incident patterns, or to generate configuration code with multi-phase validation. This routing logic effectively provides a unified interface across different AI capabilities, abstracting away the complexity of choosing the appropriate tool.
+
+This orchestration represents a practical implementation of what might be called "meta-prompting"—using an LLM to determine which specialized system should handle a particular request. The routing layer must understand both the engineer's intent and the capabilities of different backend systems, making appropriate dispatching decisions.
+
+## Results and Metrics
+
+Meta reports several quantitative improvements from the system. AI context coverage increased from approximately 5% (covering just 5 files) to 100% (59 comprehensive context files). The number of codebase files with AI navigation support grew from approximately 50 to over 4,100. The system documented over 50 non-obvious patterns that had never been formally captured. Testing covered 55+ prompts with a 100% core pass rate.
+
+In preliminary tests on six tasks against the pipeline, agents with pre-computed context used roughly 40% fewer tool calls and tokens per task compared to agents without the context. Complex workflow guidance that previously required approximately two days of research and consultation with engineers now completes in approximately 30 minutes. These efficiency gains are substantial, though Meta appropriately characterizes them as "preliminary tests" rather than definitive benchmarks.
+
+It's worth noting that the 40% reduction in tool calls is measured on a relatively small sample (six tasks), and the comparison baseline (agents without context) may not represent an optimized alternative approach. The two-day to 30-minute improvement is compelling but applies specifically to "complex workflow guidance" rather than all development tasks. These caveats don't diminish the value of the approach, but suggest the results should be interpreted as promising early indicators rather than guaranteed outcomes at scale.
+
+## Critical Assessment and Tradeoffs
+
+Meta's approach involves significant upfront investment in building the multi-agent analysis pipeline and quality assurance processes. The system required orchestrating over 50 specialized agents across multiple phases, developing evaluation criteria for critic agents, and building automated maintenance infrastructure. This investment makes sense for Meta's scale but might not be justified for smaller codebases or teams.
+
+The "compass, not encyclopedia" design philosophy represents a deliberate tradeoff: conciseness over comprehensiveness. While this improves token efficiency and reduces noise, it necessarily means some information is omitted. The effectiveness depends on correctly identifying which knowledge is most critical—something the five-question framework and critic review process attempt to ensure, but which could still miss important edge cases.
+
+The reliance on large-context-window models is a practical consideration for deployment. While Meta notes the knowledge layer is model-agnostic, the initial knowledge extraction phase used large-context-window models to read extensive files and repositories. Teams using smaller or less capable models might not be able to replicate the extraction process, though they could potentially consume the resulting context files.
+
+Meta's claim that their context files avoid the pitfalls identified in academic research deserves scrutiny. They argue three design decisions differentiate their approach: files are concise (~1,000 tokens), opt-in (loaded only when relevant), and quality-gated (multi-round critic review). These are reasonable distinctions, but the effectiveness ultimately depends on empirical results in production use. The preliminary 40% reduction in tool calls is encouraging but represents limited evidence so far.
+
+## Applicability and Generalization
+
+Meta frames their approach as generalizable to any team with large, proprietary codebases. They provide a five-step framework for applying the approach elsewhere: identify tribal knowledge gaps where AI agents fail most, use the five-question framework for knowledge extraction, follow "compass, not encyclopedia" for concise context files, build quality gates using critic agents, and automate freshness validation.
+
+This framework is reasonable, though teams should consider whether the complexity is justified for their situation. The approach makes most sense for codebases with significant tribal knowledge, complex cross-module dependencies, and sufficient scale to justify the automation investment. Smaller projects or those with well-documented architectures might benefit more from simpler approaches like improved inline documentation or README files.
+
+The multi-agent orchestration approach could be simplified for teams with fewer resources. The core insight—systematically extracting and structuring tribal knowledge using AI, then validating it rigorously—doesn't necessarily require 50+ specialized agents. Teams might achieve reasonable results with a simpler pipeline of exploration, analysis, writing, and review phases using fewer agent types.
+
+## Production LLMOps Considerations
+
+From an LLMOps perspective, Meta's case study demonstrates several important practices for production AI systems. The emphasis on quality assurance through multi-round critic review addresses a common challenge with AI-generated content: ensuring it's actually correct and useful rather than plausible-sounding nonsense. The automated validation of file paths (achieving zero hallucinations) shows attention to verifiable accuracy rather than just subjective quality.
+
+The automated self-maintenance represents sophisticated thinking about system lifecycle management. Many AI systems are built as one-time solutions that gradually degrade as underlying data changes. Meta's approach of periodically re-validating and auto-fixing the context layer treats this as an operational requirement from the start, not an afterthought.
+
+The model-agnostic design of the knowledge layer provides flexibility in the rapidly evolving LLM landscape. While the extraction process used specific large-context-window models, the resulting context files can be consumed by various models. This separation of concerns—extraction infrastructure versus consumption interface—provides some insulation from model-specific dependencies.
+
+The integration of multiple specialized agent types in an orchestrated pipeline represents a production pattern that's likely to become more common. Rather than using a single general-purpose agent for all tasks, Meta deploys specialized agents with specific responsibilities (exploration, analysis, writing, critique, fixing, testing) and coordinates them through orchestration logic. This allows optimization of different agents for different tasks and provides clearer separation of concerns for debugging and improvement.
+
+## Future Directions
+
+Meta mentions expanding context coverage to additional pipelines across their data infrastructure and exploring tighter integration between context files and code generation workflows. The investigation into detecting emerging patterns and new tribal knowledge from code reviews and commits represents an interesting direction—shifting from static documentation to dynamic knowledge discovery.
+
+The broader implication is that AI systems might be better at maintaining certain types of documentation than humans are, particularly documentation that requires systematic analysis of large codebases. If the automated refresh mechanism can identify emerging patterns, it could provide early warning of architectural drift or highlight places where new tribal knowledge is accumulating and should be formally captured.
+
+The case study represents a sophisticated example of using AI to improve AI—deploying multi-agent systems to create knowledge infrastructure that makes other AI agents more effective. This recursive application of AI is likely to become increasingly common in production LLMOps as teams discover that manual infrastructure for AI systems doesn't scale effectively.

--- a/src/content/llmops-database/autonomous-multi-agent-system-for-complex-software-development.md
+++ b/src/content/llmops-database/autonomous-multi-agent-system-for-complex-software-development.md
@@ -1,0 +1,112 @@
+---
+title: "Autonomous Multi-Agent System for Complex Software Development"
+slug: "autonomous-multi-agent-system-for-complex-software-development"
+draft: false
+llmopsTags:
+  - "code-generation"
+  - "multi-agent-systems"
+  - "agent-based"
+  - "prompt-engineering"
+  - "evals"
+  - "human-in-the-loop"
+  - "cicd"
+  - "continuous-integration"
+  - "documentation"
+industryTags: "tech"
+company: "Factory"
+summary: "Factory presents \"Missions,\" an LLM-based autonomous development system designed to solve the fundamental limitation of single-agent contexts becoming diluted and unreliable during complex, multi-day software projects. The solution employs a multi-agent architecture with separation of concerns: an orchestrator for planning and coordination, workers for implementation, and independent validators for quality assurance. The system implements test-driven development at both unit and system levels, uses externalized shared state to avoid context overload, and employs model specialization for different roles. A real-world demonstration shows the system autonomously building a Slack clone over 16.5 hours with 185 agent runs, generating 38.8k lines of code with 89.25% test coverage, demonstrating that structured multi-agent orchestration with validation loops can produce reliable, production-quality software autonomously."
+link: "https://factory.ai/news/missions-architecture"
+year: 2026
+seo:
+  title: "Factory: Autonomous Multi-Agent System for Complex Software Development - ZenML LLMOps Database"
+  description: "Factory presents \"Missions,\" an LLM-based autonomous development system designed to solve the fundamental limitation of single-agent contexts becoming diluted and unreliable during complex, multi-day software projects. The solution employs a multi-agent architecture with separation of concerns: an orchestrator for planning and coordination, workers for implementation, and independent validators for quality assurance. The system implements test-driven development at both unit and system levels, uses externalized shared state to avoid context overload, and employs model specialization for different roles. A real-world demonstration shows the system autonomously building a Slack clone over 16.5 hours with 185 agent runs, generating 38.8k lines of code with 89.25% test coverage, demonstrating that structured multi-agent orchestration with validation loops can produce reliable, production-quality software autonomously."
+  canonical: "https://www.zenml.io/llmops-database/autonomous-multi-agent-system-for-complex-software-development"
+  ogTitle: "Factory: Autonomous Multi-Agent System for Complex Software Development - ZenML LLMOps Database"
+  ogDescription: "Factory presents \"Missions,\" an LLM-based autonomous development system designed to solve the fundamental limitation of single-agent contexts becoming diluted and unreliable during complex, multi-day software projects. The solution employs a multi-agent architecture with separation of concerns: an orchestrator for planning and coordination, workers for implementation, and independent validators for quality assurance. The system implements test-driven development at both unit and system levels, uses externalized shared state to avoid context overload, and employs model specialization for different roles. A real-world demonstration shows the system autonomously building a Slack clone over 16.5 hours with 185 agent runs, generating 38.8k lines of code with 89.25% test coverage, demonstrating that structured multi-agent orchestration with validation loops can produce reliable, production-quality software autonomously."
+notion:
+  pageId: "33ff8dff-2538-8071-98d7-fc44009a4f19"
+  databaseId: "1a9eaa1f57dd47d5af958caa57742b6b"
+  createdTime: "2026-04-11T16:43:00.000Z"
+  lastEditedTime: "2026-04-11T16:43:00.000Z"
+  publishedAt: "2026-04-14T08:49:48Z"
+---
+
+## Overview
+
+Factory's "Missions" system represents a sophisticated approach to deploying LLMs for autonomous, multi-day software development projects. The case study, published in April 2026, describes an architectural solution to a fundamental challenge in production LLM systems: how to maintain agent reliability and focus when tasks exceed the effective capacity of a single context window. Rather than attempting to cram increasingly complex information into a single agent session, Factory has designed a multi-agent orchestration system with explicit separation of concerns, validation gates, and shared state management.
+
+The core insight driving the architecture is empirical: agents are highly reactive to their context. Since agent trajectories are append-only, the model's reasoning at any point becomes a function of every past thought, observation, and action. Large language models seek coherence and integrate everything in their context into a unified worldview, which means they perform optimally only when every previous step in the trajectory urges them toward the next optimal step. When irrelevant or adversarial context accumulates, performance degrades measurably.
+
+## The Context Problem in Production LLM Systems
+
+Factory identifies two critical failure modes that emerge from poor context management in production agent systems. First, irrelevant context accumulates when tasks are unfocused or overly broad, causing the agent's context window to fill with information that isn't relevant to the current subtask. As scope broadens, less of the context actively pulls the agent toward optimal next steps, creating what they term "context dilution." Second, adversarial context accumulates when an agent that implemented something is later asked to evaluate its own work. The prior reasoning creates confirmation bias, making objective evaluation nearly impossible.
+
+These observations have significant implications for LLMOps practitioners. It's insufficient to simply decompose work into smaller chunks; each agent's goal must be narrowly focused and its trajectory must remain directionally consistent throughout execution. Every run must avoid accumulating context that is either not useful to the agent's current task or not aligned with the agent's incentive structure and the ideal outcome for that specific run.
+
+## Architectural Design Principles
+
+The Missions architecture embeds four key principles that address these context management challenges while enabling reliable autonomous operation at scale.
+
+**Separation of concerns and incentives** forms the foundation. Each role in the system has a single, well-defined goal, and the architecture ensures nothing in an agent's trajectory pulls it away from that goal. The orchestrator plans and decomposes approaches to the user's goal, steering execution to completion through all validation gates. Critically, it avoids accumulating overly granular implementation context by delegating all investigation and detailed implementation to subagents and workers. The orchestrator doesn't drive validation directly; instead, the system injects independent validators at milestones to surface gaps. Workers complete well-specified features with clear success criteria, iterating until they believe the work is correct, but they don't make the final judgment on correctness—an independent validator makes that determination. Validators evaluate completed work for correctness and completeness, surfacing bugs and gaps, but they don't implement fixes. Instead, they report issues back to the orchestrator, which creates targeted fix features that future workers implement.
+
+This separation addresses the adversarial context problem directly: by ensuring the agent evaluating work has never seen the implementation reasoning, Factory maintains objectivity in the validation process. It's a production-oriented solution to a fundamental challenge in agent reliability.
+
+**Test-driven development at two levels** operates at both micro and macro scales. At the worker level, each agent writes tests before code, ensuring tests reflect intended behavior rather than being retrofitted to match implementation details. At the mission level, the orchestrator defines correctness first by creating a validation contract—a set of behavioral assertions that define success—before defining any features. This ordering matters significantly from an LLMOps perspective. When creating the validation contract, the orchestrator draws from its understanding of requirements in isolation. If features were created first, the contract would be influenced by the planned implementation, creating subtle confirmation bias even at the architectural level.
+
+The validation assertions are later verified by fresh agents that exercise the system as a black box, using it the way a real user would rather than inspecting implementation code. This mirrors human software testing best practices but implements them through careful agent orchestration and context management.
+
+**Externalized state** ensures no single agent needs to hold a complete picture in its context at once. The full state is distributed across shared artifacts: the validation contract, the feature list, research notes, operational guidelines, and an evolving knowledge base. Each agent reads only what's relevant to its current job. Even the orchestrator delegates deep investigation to subagents to avoid consuming every detail itself. This is a pragmatic approach to working within context window limitations while maintaining system coherence—rather than fighting the constraints of current models, the architecture works with them.
+
+**Model specialization** recognizes that different models have different strengths in reasoning, discipline, creativity, thoroughness, speed, and cost, and that no single model excels at everything. Once roles are cleanly separated, model choice becomes local to each role: the orchestrator might use a model optimized for broad planning and judgment, workers might use models balancing reliable execution with cost efficiency, and validators might employ models known for thoroughness and skepticism. This represents mature LLMOps thinking—rather than treating model selection as a global decision, the architecture makes it a role-specific optimization problem.
+
+## System Operation and Execution Flow
+
+The actual execution of a Mission follows a structured workflow that implements these principles. A user describes what they want built, and the orchestrator investigates and asks clarifying questions until requirements are unambiguous. Then it writes the validation contract—a finite checklist of testable behavioral assertions that define completion and correctness for the entire mission. Each assertion specifies which tool will verify it and what evidence constitutes proof. For example, a validation assertion might specify that a user with valid credentials submits a login form and is redirected to the dashboard, verified using an agent-browser tool with screenshot and network response evidence.
+
+From there, the orchestrator decomposes work into features, where each feature is a bounded piece of implementation that explicitly claims which assertions it will fulfill. Features are grouped into milestones, each encompassing a logical unit of functionality. The orchestrator also creates shared state files—boundaries and procedures for its workers that enforce optimal structure and behavior, along with a library that accumulates knowledge over the mission's duration.
+
+A programmatic runner takes the feature list and spawns a worker for each feature in order. Each worker starts with a fresh context, receives its feature spec, writes tests first, then implements. This fresh-context-per-feature approach is central to avoiding context dilution—no worker is burdened with the implementation details of previous features unless explicitly provided through shared state.
+
+Once all features within a milestone are complete, the runner triggers validation using fresh agents operating in two modes. Scrutiny validators review each worker's implementation and trajectory for quality and correctness, encoding relevant knowledge updates into shared state for future workers. User-testing validators exercise the system as a black box, verifying behavior against the validation contract assertions without access to implementation details.
+
+After validation, the orchestrator reviews what workers and validators flagged and creates fix features targeted at actionable gaps. These fixes are executed before the milestone re-validates, creating a correction loop that continues until milestone validation passes. If implementation or validation is blocked, the orchestrator halts the mission and hands control back to the user, maintaining human-in-the-loop oversight for critical decisions.
+
+## Real-World Production Results
+
+Factory provides detailed metrics from a production mission that built a Slack clone with workspace authentication, channels and threads, real-time messaging with reactions and mentions, file uploads, search, and presence and notifications. While these metrics are from Factory's own system and should be interpreted with appropriate skepticism about potential cherry-picking, they provide valuable insight into the operational characteristics of production autonomous agent systems.
+
+The mission completed in 16.5 hours of total runtime, distributed as 2.3% orchestration (0.38 hours), 60.5% implementation (9.98 hours), and 37.2% validation (6.14 hours). The substantial time allocation to validation—more than a third of total runtime—reflects the architectural commitment to reliability over pure speed. The mission progressed through six milestones following a consistent implementation-validation cadence.
+
+The system executed 185 total agent runs: one orchestrator run spawning 12 subagents, 63 worker runs, and 27 validator runs spawning 82 subagents. The high number of validator subagents suggests that validation involves substantial investigation and testing activity, not just simple checks. The system consumed 778.5 million tokens total, with 30.3M input tokens, 744.9M cache read tokens, and 3.4M output tokens. The cache read numbers indicate Factory is making extensive use of prompt caching to manage costs—without caching, this mission would have been substantially more expensive to run.
+
+Token distribution by role shows 29.2M tokens for orchestration, 485.5M for implementation, and 263.8M for validation, roughly tracking the time distribution but with validation using proportionally more tokens relative to time, likely due to the need for thorough investigation and testing.
+
+The system generated 38.8k lines of code with 52.5% being tests (20.4k test lines vs 18.5k source lines), achieving 89.25% statement coverage. The test-heavy output reflects the architectural commitment to test-driven development, though it's worth noting that statement coverage is only one dimension of test quality and doesn't guarantee the tests are actually effective at catching bugs.
+
+The reliability metrics show convergence behavior: across six milestones and four validation rounds, zero milestones passed initially, one passed in round two, two in round three, and all six passed in round four. Validators surfaced 81 total issues (65 blocking, 11 non-blocking, 5 suggestions), and the orchestrator generated 21 fix features representing 34.4% of implementation work. This correction loop demonstrates the system's ability to iteratively improve toward correctness, though it also reveals that initial implementations were far from perfect—requiring substantial rework through multiple validation cycles.
+
+Trajectory lengths remained bounded throughout execution, with median run lengths of 51 assistant turns for implementation (90th percentile at 123 turns) and 30 turns for validation (90th percentile at 37 turns). These bounded trajectories suggest the architecture successfully prevents runaway agent loops and maintains focus within individual runs.
+
+## LLMOps Considerations and Critical Assessment
+
+From an LLMOps perspective, Factory's Missions system demonstrates several mature practices for production LLM deployment, though the case study is ultimately a product announcement and should be evaluated critically.
+
+**Strengths in the architectural approach** include the explicit handling of context management as a first-class concern, recognizing that context quality determines agent reliability in production systems. The separation of concerns between implementation and validation mirrors established software engineering practices adapted thoughtfully for LLM agents. The multi-level testing approach (unit tests by workers, system tests by validators) creates defense in depth against errors. Externalized state and shared knowledge bases allow for learning and consistency across agent runs without context pollution. Model specialization by role enables cost-performance optimization at a granular level. The system's transparency around metrics (tokens, runs, trajectories) suggests operational maturity in monitoring and understanding production LLM behavior.
+
+**Potential concerns and limitations** include that the case study presents results from a single, potentially cherry-picked example rather than aggregate statistics across many missions, which limits our ability to assess typical vs. best-case performance. The 16.5-hour runtime for a Slack clone is significant, and while the output quality metrics look reasonable, there's no comparison to human developer time or discussion of when autonomous development is cost-effective versus traditional approaches. The 34.4% fix-feature ratio suggests substantial rework is normal, raising questions about efficiency and total cost. The system requires 185 agent runs and 778.5M tokens for one application, and the economics depend heavily on prompt caching (744.9M cached tokens)—actual costs could be substantially higher without effective caching strategies.
+
+The validation approach relies on agents evaluating agent-generated code and behavior, which may miss entire classes of issues that human reviewers would catch. There's no discussion of failure modes, how often missions need to be halted for human intervention, or what types of problems the system cannot handle autonomously. The statement coverage metric of 89.25% is presented positively but without discussion of whether these tests are actually effective at catching bugs or just mechanically achieve coverage. The architecture assumes well-specified requirements upfront, but real software development often involves evolving understanding of requirements, and it's unclear how the system handles requirements that shift during execution.
+
+**Production LLM operations insights** that emerge from this case study include the importance of architectural patterns that prevent context dilution through fresh-context execution and role separation. The value of validation loops and multi-round correction for achieving reliability in autonomous agent systems is clearly demonstrated, even at the cost of substantial time and token investment. The metrics show that prompt caching is essential for making long-running, multi-agent systems economically viable—the 744.9M cached token reads would be prohibitively expensive as fresh reads. Bounded trajectory lengths through focused goals and scoped roles help prevent runaway execution and unpredictable costs.
+
+The substantial allocation of resources to validation (37.2% of time, 33.9% of tokens) suggests that achieving reliability in autonomous systems requires treating testing and validation as equal partners to implementation, not afterthoughts. The system demonstrates that model-based evaluation of model outputs can work at scale when properly structured with separation of concerns, though the ultimate effectiveness remains an open question.
+
+## Implications for LLM Production Systems
+
+Factory's Missions system represents a significant data point in the evolution of production LLM applications toward longer-running, more autonomous operation. The architectural principles—context management through separation of concerns, externalized state, test-driven development at multiple levels, and validation loops—provide a framework that other teams building production agent systems can learn from, even if they're not using Factory's specific product.
+
+The case study illustrates that current LLM capabilities can support genuinely autonomous, multi-hour software development tasks when wrapped in appropriate orchestration architecture, though with non-trivial resource requirements and validation overhead. The system's reliance on multiple models, extensive prompt caching, and substantial validation loops highlights that production autonomous agent systems are complex infrastructure projects requiring careful engineering, not just clever prompting.
+
+The transparency around metrics like token usage, agent runs, and trajectory lengths is valuable for the LLMOps community's developing understanding of what production autonomous agent systems actually look like in operation. However, practitioners should approach these results with appropriate skepticism given that Factory is selling this as a product and the case study presents a single, potentially optimistic example rather than aggregate performance data across diverse projects and failure cases.
+
+As LLMs continue to improve in reasoning, planning, execution, and computer use capabilities, Factory argues that each improvement will compound through their architecture. This is plausible—better planners will produce tighter specs, better workers will make fewer mistakes, and better validators will judge correctness more reliably. Similarly, as models become faster and cheaper, tighter validation loops and more ambitious missions become economically viable. However, the fundamental question of when autonomous development provides better outcomes than human development at acceptable cost remains open and likely depends heavily on project characteristics, team capabilities, and specific use cases.

--- a/src/content/llmops-database/building-a-production-rag-system-for-technical-document-search-with-local-llms.md
+++ b/src/content/llmops-database/building-a-production-rag-system-for-technical-document-search-with-local-llms.md
@@ -1,0 +1,140 @@
+---
+title: "Building a Production RAG System for Technical Document Search with Local LLMs"
+slug: "building-a-production-rag-system-for-technical-document-search-with-local-llms"
+draft: false
+llmopsTags:
+  - "document-processing"
+  - "question-answering"
+  - "chatbot"
+  - "rag"
+  - "embeddings"
+  - "semantic-search"
+  - "vector-search"
+  - "chunking"
+  - "error-handling"
+  - "latency-optimization"
+  - "cost-optimization"
+  - "chromadb"
+  - "llama-index"
+  - "docker"
+  - "sqlite"
+  - "fastapi"
+  - "monitoring"
+  - "databases"
+  - "open-source"
+  - "pytorch"
+  - "microsoft-azure"
+  - "meta"
+  - "nvidia"
+industryTags: "energy"
+company: "Core Marine"
+summary: "An engineer at Core Marine, an offshore engineering company, was tasked with building an internal chat tool that could answer questions about nearly a decade of company projects using natural language queries. The challenge involved indexing 1TB of highly technical, unstructured documents including OrcaFlex simulation files, reports, and regulations, while maintaining fast response times and data confidentiality through local LLM deployment. The solution employed a RAG architecture using Ollama for local LLM inference (llama3.2:3b), LlamaIndex as the orchestration framework, ChromaDB as a vector database, and nomic-embed-text for embeddings. After overcoming significant challenges with memory management, file filtering, GPU constraints, and storage limitations, the system successfully indexed 451GB of documents (738,470 vectors) and deployed a Flask API with Streamlit frontend, serving documents directly from Azure Blob Storage while keeping the vector index local."
+link: "https://en.andros.dev/blog/aa31d744/from-zero-to-a-rag-system-successes-and-failures/"
+year: 2026
+seo:
+  title: "Core Marine: Building a Production RAG System for Technical Document Search with Local LLMs - ZenML LLMOps Database"
+  description: "An engineer at Core Marine, an offshore engineering company, was tasked with building an internal chat tool that could answer questions about nearly a decade of company projects using natural language queries. The challenge involved indexing 1TB of highly technical, unstructured documents including OrcaFlex simulation files, reports, and regulations, while maintaining fast response times and data confidentiality through local LLM deployment. The solution employed a RAG architecture using Ollama for local LLM inference (llama3.2:3b), LlamaIndex as the orchestration framework, ChromaDB as a vector database, and nomic-embed-text for embeddings. After overcoming significant challenges with memory management, file filtering, GPU constraints, and storage limitations, the system successfully indexed 451GB of documents (738,470 vectors) and deployed a Flask API with Streamlit frontend, serving documents directly from Azure Blob Storage while keeping the vector index local."
+  canonical: "https://www.zenml.io/llmops-database/building-a-production-rag-system-for-technical-document-search-with-local-llms"
+  ogTitle: "Core Marine: Building a Production RAG System for Technical Document Search with Local LLMs - ZenML LLMOps Database"
+  ogDescription: "An engineer at Core Marine, an offshore engineering company, was tasked with building an internal chat tool that could answer questions about nearly a decade of company projects using natural language queries. The challenge involved indexing 1TB of highly technical, unstructured documents including OrcaFlex simulation files, reports, and regulations, while maintaining fast response times and data confidentiality through local LLM deployment. The solution employed a RAG architecture using Ollama for local LLM inference (llama3.2:3b), LlamaIndex as the orchestration framework, ChromaDB as a vector database, and nomic-embed-text for embeddings. After overcoming significant challenges with memory management, file filtering, GPU constraints, and storage limitations, the system successfully indexed 451GB of documents (738,470 vectors) and deployed a Flask API with Streamlit frontend, serving documents directly from Azure Blob Storage while keeping the vector index local."
+notion:
+  pageId: "341f8dff-2538-8076-81be-de5223de0ae7"
+  databaseId: "1a9eaa1f57dd47d5af958caa57742b6b"
+  createdTime: "2026-04-13T07:05:00.000Z"
+  lastEditedTime: "2026-04-13T07:05:00.000Z"
+  publishedAt: "2026-04-14T08:50:00Z"
+---
+
+## Overview
+
+This case study documents the journey of building a production RAG (Retrieval-Augmented Generation) system at Core Marine, a company operating in the offshore engineering industry. The engineer, Andros Fenollosa, was given the task of creating an internal tool that would allow company engineers to ask questions in natural language about nearly a decade of company projects and receive answers with references to source documents. The emphasis was on fast response times and the ability to extract information from highly technical documents, particularly OrcaFlex files used for simulating floating body dynamics, cables, and other offshore infrastructure. The author explicitly states this was their first RAG implementation and they had no prior knowledge of how such systems worked, making this a particularly valuable real-world learning case study.
+
+The initial data source consisted of 1TB of mixed technical documents stored in Azure, including project files, technical documentation, reports, analyses, regulations, CSVs, and various other formats with minimal organization. A critical constraint was that all LLM processing had to be local without relying on external APIs due to confidentiality requirements. The project took significantly longer than initially expected and involved numerous technical challenges that required iterative problem-solving.
+
+## Technology Stack Selection
+
+The author approached technology selection pragmatically, choosing tools based on maturity, ease of use, and confidentiality requirements. For the local language model, **Ollama** emerged as the most mature option for running LLaMA models locally without external API dependencies. The final deployment used **llama3.2:3b** as the inference model. For embeddings, after testing several options, **nomic-embed-text** was selected for its good performance and quality with technical documents.
+
+A critical architectural decision was selecting **LlamaIndex** as the RAG orchestration framework. LlamaIndex handles the complex pipeline of document indexing, embedding generation, vector database storage, and query execution. The author notes this was essential because without proper orchestration, even a fast language model cannot effectively retrieve relevant information from large document collections. The analogy used is apt: a RAG engine functions like a book's index, allowing direct navigation to relevant content rather than reading everything sequentially.
+
+Python was chosen as the development language primarily due to developer productivity and comfort, though the author notes both Ollama and LlamaIndex have excellent Python SDKs. The initial prototype involved simple scripts to test vectorization and queries, which worked well with minimal code, leading to an overly optimistic timeline estimate that proved incorrect once real-world data was introduced.
+
+## Data Ingestion and File Filtering Challenges
+
+The first major production challenge emerged when processing the actual document corpus. The initial attempt to index documents resulted in RAM overflow and system freezes within minutes. Debugging revealed that LlamaIndex was attempting to process massive files that contributed no value to the RAG system: videos, simulations, backup files, and other binary formats. The system tried to load multi-gigabyte files entirely into memory as if they were text, causing catastrophic resource exhaustion.
+
+The solution was implementing a comprehensive filtering pipeline that excluded files by extension and naming patterns. The filtering system categorized exclusions into multiple groups: video formats (mp4, avi, mov, etc.), images (jpg, png, gif, etc.), executables (exe, dll, jar, etc.), compressed archives (zip, rar, 7z, etc.), simulation files (sim, dat), temporary files (tmp, cache, log, etc.), backups (bak, old, bkp, etc.), and email formats (msg, pst, eml). Additionally, files that were expensive to process without adding value—such as CSVs and JSONs—were excluded. Documents in formats like PDF, DOCX, XLSX, and PPTX were converted to plain text for efficient processing.
+
+This filtering resulted in a 54% reduction in files requiring indexing, which not only prevented memory exhaustion but also improved overall system efficiency. The author emphasizes this was a critical lesson: understanding your data and preprocessing it appropriately is essential for production RAG systems.
+
+## Vector Database and Indexing Architecture
+
+The initial indexing approach used LlamaIndex's default JSON-based storage format, which works well for small document sets but proved completely unmanageable at scale. Every service restart required reprocessing all documents from scratch, potentially taking days. The author attempted to add checkpoint systems to save progress, but data corruption, errors, and slow performance created an insurmountable bottleneck.
+
+The breakthrough came from migrating to **ChromaDB**, an open-source vector database (Apache-2.0 license) specifically designed for storing and querying vector embeddings. ChromaDB provides an abstraction layer over traditional databases—the author configured it with SQLite as the backing store—and offers specialized functionality for similarity searches and clustering. This architectural change was described as "radical and instant" in its impact.
+
+The new architecture transformed indexing from a monolithic memory-bound process into a batch pipeline that processed 150 files at a time, generated embeddings, and stored them directly in ChromaDB. This enabled indexing the 451GB corpus across multiple sessions with checkpoints and no data loss on interruptions. The SQLite-backed storage also made backup and restore operations trivial—simply copying the database file. The final indexed database contained 738,470 vectors and occupied 54GB of storage.
+
+However, a new bottleneck emerged: processing speed. Initial benchmarks revealed that the author's laptop with an integrated graphics card would require several months to complete indexing, processing approximately 500MB of documents in 4-5 hours on CPU alone.
+
+## GPU Infrastructure and Cost Management
+
+To address the computational bottleneck, the company rented a virtual machine equipped with an **NVIDIA RTX 4000 SFF Ada** GPU with 20GB of VRAM. The author notes these rentals "are not exactly cheap" and that working under this constraint added pressure to the project. The system was containerized and optimized to leverage GPU acceleration through the NVIDIA Container Toolkit.
+
+The indexing process ran for 2-3 weeks on the GPU-equipped VM before completing successfully. Once indexing finished, the 54GB ChromaDB SQLite file was copied to the local production environment and the expensive VM was shut down. The total cost for the Hetzner GPU rental was €184, which the author describes as "not cheap" but necessary to make the project feasible. This represents a practical example of the infrastructure cost considerations in LLMOps: sometimes expensive resources are required temporarily during the indexing/training phase but can be shut down once the artifacts are created.
+
+## API and User Interface Design
+
+For production deployment, the author built a **Flask** API to provide HTTP access to the RAG system, which orchestrates queries between LlamaIndex, ChromaDB, and Ollama. The API was deployed using **Gunicorn** for production-grade serving. For the frontend, **Streamlit** was selected due to the author's familiarity with it for internal tools and its native Q&A chat widget that mimics modern AI chat interfaces. The entire visual interface was implemented in a couple of hours, with subsequent time spent on polish: company branding, loading spinners, session persistence, and other UX details.
+
+A critical requirement was that responses must include source references—citations to the original documents used to generate each answer. The system was configured with response templates that ensure every answer includes document references with download links. This citation capability is essential for trustworthiness in enterprise RAG systems, allowing users to verify information against source documents.
+
+## Storage Architecture and Document Serving
+
+A significant constraint emerged during deployment: the production virtual machine had limited resources, particularly only 100GB of disk space, making it impossible to store the original 451GB of documents locally. However, the vector database alone doesn't eliminate the need for original documents—users must be able to access source materials referenced in responses.
+
+The elegant solution was architectural separation: the vector index (54GB ChromaDB database) and LLM (~10GB) are stored locally on the production VM, while original documents remain in **Azure Blob Storage**. For each document cited in a response, the system generates a download link with a **SAS (Shared Access Signature) token** that allows users to download directly from Azure without requiring documents to be stored on the application server. This demonstrates a practical pattern in LLMOps: separating hot data (frequently accessed embeddings and models) from cold data (original documents accessed on-demand).
+
+## Production Architecture and Service Orchestration
+
+The final production architecture consists of multiple integrated layers orchestrated through **Docker Compose**:
+
+- **LLM Layer**: Ollama running llama3.2:3b for local response generation
+- **Embeddings**: nomic-embed-text for document vectorization
+- **Vector Database**: ChromaDB with HNSW (Hierarchical Navigable Small World) indexing backed by SQLite
+- **RAG Framework**: LlamaIndex orchestrating the retrieval-augmented generation pipeline
+- **API Layer**: Flask with Gunicorn providing HTTP REST service
+- **Frontend**: Streamlit providing the conversational chat interface
+- **Container Orchestration**: Docker Compose managing all services
+- **GPU Acceleration**: NVIDIA Container Toolkit enabling hardware acceleration
+- **Document Storage**: Azure Blob Storage for cloud-based document persistence
+
+The data flow works as follows: users interact with the Streamlit web interface, which sends HTTP requests to the Flask API. The backend calls LlamaIndex, which queries ChromaDB for relevant document vectors based on the user's question embedded with nomic-embed-text. Retrieved context is passed to Ollama for response generation. The response includes citations with Azure Blob Storage SAS token links for document downloads.
+
+## Operational Lessons and Production Best Practices
+
+The author shares several hard-won lessons from production deployment that represent valuable LLMOps practices:
+
+**Memory Management**: Loading all documents into memory for batch processing is dangerous and leads to system crashes. The solution is explicit batch processing (150 files per iteration in this case) with explicit garbage collector calls between batches. Each batch is processed, embedded, stored in ChromaDB, and then memory is freed before continuing to the next batch.
+
+**Error Handling and Tolerance**: Even after comprehensive filtering, some problematic files passed through—corrupt PDFs, Word documents with broken macros, spreadsheets with unexpected formats. The strategy adopted was error tolerance: if a file fails during parsing, it's logged and the system moves to the next file. A single problematic file never stops an entire batch. Failed files can be manually reviewed and potentially assigned to different batches or excluded.
+
+**Checkpoint Systems**: When individual batches can take hours to process, system reliability requires robust checkpointing. The implementation saves the last completed batch, total processed nodes, and timestamps. On restart after power outages or other interruptions, indexing resumes exactly where it left off rather than starting from zero.
+
+**Monitoring and Observability**: For long-running RAG indexing processes, comprehensive monitoring is essential. The author implemented multiple monitoring scripts for different operational states: `index-progress`, `index-watch`, `index-speed`, `index-checkpoint`, and `index-failed`. When RAG systems are processing for hours or days, operators need real-time visibility into what's happening and the ability to diagnose issues.
+
+## Critical Assessment and Limitations
+
+The author provides a refreshingly honest assessment of the system's limitations. The original aspiration was to integrate an OrcaFlex simulation instance that would allow the LLM to actually run projects or perform simulations on demand, but this proved beyond the available time and resources. This represents a common pattern in production LLM systems: the initial deployment focuses on achievable core functionality (document retrieval and Q&A) rather than more ambitious but higher-risk features (simulation integration).
+
+The author emphasizes that "it's not a perfect system, but it's sufficient" and reports being "very happy with the final result" because the system is "fast, reliable, and above all useful" to colleagues. This pragmatic framing is important for LLMOps practitioners: production systems are judged on utility and reliability, not perfection.
+
+The most important advice offered is about data quality: "spend time building the best possible data. If the source is not relevant enough, the LLM won't be able to generate good answers." This echoes a fundamental principle in LLMOps—garbage in, garbage out applies even more critically to RAG systems where retrieval quality directly determines generation quality.
+
+## Production Deployment Considerations
+
+Two community comments on the blog post raise important questions about production quality that the original post doesn't fully address. One commenter asks about accuracy given the variety of text formats in the base dataset and how the system handles chunking where paragraphs or lists get broken across document boundaries, noting this could result in "half baked bread" during similarity search. Another asks for more detail on the checkpoint system implementation and the Flask + Streamlit integration pattern.
+
+These questions highlight that while the case study documents the successful deployment of a working RAG system, there are remaining questions about retrieval quality metrics, chunking strategies, and detailed implementation patterns that would be valuable for practitioners. The absence of quantitative evaluation metrics (retrieval precision/recall, answer accuracy, user satisfaction scores) represents a gap common in many real-world case studies where teams focus on getting systems working rather than comprehensive evaluation.
+
+The emphasis on local deployment for confidentiality, the use of open-source components (LlamaIndex, ChromaDB, Ollama), and the pragmatic architecture that separates storage concerns represents a thoughtful approach to enterprise LLMOps constraints. The total infrastructure cost (€184 for GPU rental) provides a useful data point for budgeting similar projects, though ongoing operational costs aren't discussed.

--- a/src/content/llmops-database/extreme-harness-engineering-building-production-systems-with-zero-human-written-code.md
+++ b/src/content/llmops-database/extreme-harness-engineering-building-production-systems-with-zero-human-written-code.md
@@ -1,0 +1,165 @@
+---
+title: "Extreme Harness Engineering: Building Production Systems with Zero Human-Written Code"
+slug: "extreme-harness-engineering-building-production-systems-with-zero-human-written-code"
+draft: false
+llmopsTags:
+  - "code-generation"
+  - "poc"
+  - "structured-output"
+  - "prompt-engineering"
+  - "multi-agent-systems"
+  - "agent-based"
+  - "human-in-the-loop"
+  - "latency-optimization"
+  - "cost-optimization"
+  - "error-handling"
+  - "evals"
+  - "docker"
+  - "monitoring"
+  - "cicd"
+  - "orchestration"
+  - "continuous-integration"
+  - "continuous-deployment"
+  - "open-source"
+  - "documentation"
+  - "guardrails"
+  - "reliability"
+  - "scalability"
+  - "fastapi"
+  - "postgresql"
+  - "elasticsearch"
+  - "langchain"
+  - "openai"
+  - "anthropic"
+  - "meta"
+  - "google-gcp"
+industryTags: "tech"
+company: "OpenAI"
+summary: "OpenAI's Frontier Product Exploration team conducted a five-month experiment building an internal Electron application with zero lines of human-written code, generating over one million lines of code across thousands of pull requests. The team developed \"harness engineering\" principles and Symphony, an Elixir-based orchestration system, to manage multiple coding agents at scale. By removing humans from the code authorship loop and focusing on building infrastructure, observability, and context for agents to operate autonomously, the team achieved 5-10 PRs per engineer per day with agents handling the full PR lifecycle including review, merge conflict resolution, and deployment, ultimately demonstrating that software can be built and maintained entirely by AI agents when proper systems and guardrails are in place."
+link: "https://www.latent.space/p/harness-eng"
+year: 2026
+seo:
+  title: "OpenAI: Extreme Harness Engineering: Building Production Systems with Zero Human-Written Code - ZenML LLMOps Database"
+  description: "OpenAI's Frontier Product Exploration team conducted a five-month experiment building an internal Electron application with zero lines of human-written code, generating over one million lines of code across thousands of pull requests. The team developed \"harness engineering\" principles and Symphony, an Elixir-based orchestration system, to manage multiple coding agents at scale. By removing humans from the code authorship loop and focusing on building infrastructure, observability, and context for agents to operate autonomously, the team achieved 5-10 PRs per engineer per day with agents handling the full PR lifecycle including review, merge conflict resolution, and deployment, ultimately demonstrating that software can be built and maintained entirely by AI agents when proper systems and guardrails are in place."
+  canonical: "https://www.zenml.io/llmops-database/extreme-harness-engineering-building-production-systems-with-zero-human-written-code"
+  ogTitle: "OpenAI: Extreme Harness Engineering: Building Production Systems with Zero Human-Written Code - ZenML LLMOps Database"
+  ogDescription: "OpenAI's Frontier Product Exploration team conducted a five-month experiment building an internal Electron application with zero lines of human-written code, generating over one million lines of code across thousands of pull requests. The team developed \"harness engineering\" principles and Symphony, an Elixir-based orchestration system, to manage multiple coding agents at scale. By removing humans from the code authorship loop and focusing on building infrastructure, observability, and context for agents to operate autonomously, the team achieved 5-10 PRs per engineer per day with agents handling the full PR lifecycle including review, merge conflict resolution, and deployment, ultimately demonstrating that software can be built and maintained entirely by AI agents when proper systems and guardrails are in place."
+notion:
+  pageId: "341f8dff-2538-80be-9fcb-f33488c83fca"
+  databaseId: "1a9eaa1f57dd47d5af958caa57742b6b"
+  createdTime: "2026-04-13T07:02:00.000Z"
+  lastEditedTime: "2026-04-13T07:02:00.000Z"
+  publishedAt: "2026-04-14T08:59:10Z"
+---
+
+## Overview
+
+This case study documents an ambitious experiment by OpenAI's Frontier Product Exploration team, led by Ryan Lopopolo, to build production software entirely with AI coding agents. Over five months starting in late 2025, the team built an internal Electron-based application with a strict constraint: zero lines of human-written code. The codebase grew to over one million lines of code across more than 1,500 pull requests, all authored, reviewed, and merged by AI agents. This work introduced the concept of "harness engineering" - the discipline of building infrastructure and context that enables coding agents to operate autonomously at scale.
+
+The experiment wasn't just about demonstrating that agents could write code, but rather about fundamentally rethinking the software development lifecycle when humans are no longer the primary code authors. Ryan's team discovered that the real bottleneck wasn't token cost or model capability, but rather human attention and the need to build systems that could operate without constant human supervision. The result was Symphony, an Elixir-based multi-agent orchestration platform that manages the full lifecycle of software development tasks.
+
+## Core Philosophy and Constraints
+
+The experiment began with a deliberate constraint: Ryan refused to write any code himself, forcing the team to build everything through agents. This wasn't just a thought experiment - they were building a real product for internal use at OpenAI. The philosophy was simple: if OpenAI wants to deploy agents that can do economically valuable work in enterprises, those agents need to be capable of doing everything a human engineer does, end to end.
+
+Starting with early versions of Codex CLI and the Codex Mini model, the first month and a half was "10 times slower" than human development. However, by paying that upfront cost and building the right abstractions, tools, and infrastructure, the team eventually became far more productive than any individual human engineer could be. The key insight was treating agent failures not as prompt engineering problems, but as missing capabilities, context, or structure that needed to be systematically addressed.
+
+## Evolution Through Model Generations
+
+The team progressed through multiple Codex model generations (GPT-5.1, 5.2, 5.3, 5.4), and each required adaptation of their approach. A particularly interesting case was the introduction of background shells in Codex 5.3. Previous versions would block on long-running scripts, but 5.3 became "less patient" and would spawn commands in the background while continuing other work. This forced the team to completely retool their build system to ensure builds completed in under one minute.
+
+The one-minute build constraint became a critical invariant. The team migrated through multiple build systems - from bespoke Makefiles to Bazel to Turbo to nx - all in pursuit of keeping the inner development loop fast enough for agents to stay productive. Unlike human-led projects where build times slowly degrade until a team dedicates weeks to optimization, the team used cheap tokens and massive parallelism to constantly maintain these invariants through continuous "gardening" of the codebase.
+
+## Symphony: Multi-Agent Orchestration
+
+By late December 2025, the team was producing 3.5 PRs per engineer per day. When GPT-5.2 launched in early January 2026, that jumped to 5-10 PRs per day with no other changes. The human bottleneck became obvious - engineers were spending all their time context-switching between tmux panes to babysit different agent sessions.
+
+This led to the creation of Symphony, an Elixir-based orchestration platform that removes humans from the terminal entirely. Elixir was chosen (by the model itself, interestingly) because its process supervision model and GenServer primitives naturally map to the problem of orchestrating large numbers of concurrent coding tasks. Symphony manages the full lifecycle: spawning Codex agents in isolated worktrees, driving them through task completion, coordinating PR reviews, handling merge conflicts, managing rework when PRs aren't mergeable, and ultimately getting code merged to main.
+
+The system architecture has six layers: policy (encoding rules and requirements), configuration (environment and tool setup), coordination (task assignment and agent lifecycle), execution (actual coding work), integration (CI/CD and merging), and observability (metrics, logs, traces). A critical design choice was making the entire stack "CLI-first" - everything from the app itself to the local development environment to observability tools is controllable via command-line interfaces, which makes it maximally token-efficient and agent-legible.
+
+## Observability and Context Architecture
+
+One of the most sophisticated aspects of the system is its observability stack. The team runs a full local observability platform including Vector for log aggregation, VictoriaMetrics for metrics, Grafana for dashboards, and distributed tracing. Critically, the agents themselves author the Grafana dashboard JSON definitions, configure the alerts, and respond to pages when things go wrong. This creates a closed loop where an agent that gets paged for a missing timeout can both fix the immediate issue and durably update the reliability documentation to require timeouts on all future network calls.
+
+The team invested heavily in making everything "agent-legible." This means structuring information as text that can be easily consumed in context windows. The repository contains several key markdown files: a spec.md that defines the overall product vision, an agent.md with a table of contents guiding agent behavior, core-beliefs.md encoding team values and practices, and a tech-tracker.md that serves as a markdown-based task list before the team adopted proper ticketing systems.
+
+Skills became a central abstraction for encoding engineering knowledge. These are reusable prompts and scripts that teach agents how to perform common tasks. The team deliberately kept the number of skills small (around six) and focused on making them comprehensive rather than creating many narrow skills. When agents made mistakes, the first response was to update an existing skill to cover that case, making the fix durable for all future work.
+
+## Autonomous Code Review and Merging
+
+Perhaps the most radical aspect of the system is autonomous merging with zero human code review before merge. Human review happens post-merge as a sampling mechanism to identify systemic issues. The team built code review agents that run automatically on PR synchronization. These agents are instructed to bias toward merging, to not surface anything greater than P2 priority, and to provide feedback that the authoring agent can choose to accept, defer, or push back against.
+
+The authoring agents are given flexibility in how they respond to review feedback, preventing thrashing where review agents and authoring agents end up in unproductive loops. The system also includes quality score tracking - a markdown table that serves as a hook for Codex to periodically review all business logic against documented guardrails and propose follow-up work for itself.
+
+The merge flow uses the "$land" skill, which coaches Codex to push the PR, wait for human and agent reviewers, wait for CI to be green, fix any flaky tests, merge upstream if conflicts arise, handle the merge queue, and deal with any flakes until the code is in main. The entire process runs autonomously, with humans only needing to keep their laptops open.
+
+## Build System and Development Environment
+
+The development environment is fully self-contained and agent-managed. Rather than setting up an environment and then spawning agents into it, the team inverts this: Codex is the entry point, and it has skills and scripts to boot the entire local development stack if needed. This includes the Electron app itself, backend services, and the full observability stack.
+
+The team uses worktrees extensively to enable massive parallelism - multiple agents can work on different features simultaneously in isolated worktrees. While this creates merge conflicts, the models have proven "really great at resolving merge conflicts," and since code is disposable, the overhead is acceptable. The build system went through multiple iterations specifically to serve agent needs, not human preferences.
+
+An interesting optimization was making CLI outputs extremely token-efficient. For example, they patched prettier to run in silent mode because agents don't care that every file was already formatted - they only need to know if formatting succeeded or failed. Similarly, their PNPM distributed test runner was wrapped to suppress passing test output and only show failures, dramatically reducing token consumption.
+
+## Ghost Libraries and Spec-Driven Distribution
+
+The team developed an innovative approach to distributing software they call "ghost libraries." Rather than sharing source code, they create high-fidelity specifications that coding agents can use to reproduce the system from scratch. The workflow is remarkable: spawn a Codex instance with the proprietary repo as reference, ask it to write a spec, spawn a second disconnected Codex to implement the spec, spawn a third to review the implementation against the original, update the spec to reduce divergence, and loop until the spec can reproduce the system with high fidelity.
+
+This approach has profound implications. If software can be distributed as specifications rather than code, it becomes much cheaper to share knowledge, easier to adapt systems to different environments, and natural to maintain multiple implementations. It also means that internalized dependencies become practical - rather than managing complex dependency graphs, teams can inline dependencies and have agents maintain them, making it easier to customize and secure the code.
+
+## Human Role and Team Dynamics
+
+In this model, humans shift from code authors to systems architects. Ryan describes the role as similar to being a group tech lead for a 500-person organization - it's not appropriate to be in the weeds on every PR. Instead, humans focus on building infrastructure, observability, and context that enables agents to work autonomously. They spend time identifying where agents struggle, where humans are spending attention, and how to build systems to eliminate those bottlenecks.
+
+The team maintains very rigid architecture - the codebase contains around 500 NPM packages, which would be excessive for a seven-person team but makes sense when each human is effectively managing 10-50 agents. This decomposition creates clear boundaries that prevent agents (and humans) from trampling on each other's work.
+
+Daily standups are 45 minutes long because the team needs significant synchronous time to share knowledge about the current state of the system. With so much happening autonomously, it's easy to lose track of what the codebase actually looks like. Ryan recounts being surprised to discover that someone had replaced the MCPCC Playwright integration with a custom local daemon exposing a minimal CLI - a change that happened entirely through agent work without his knowledge.
+
+## Skills and Knowledge Distillation
+
+The team developed sophisticated approaches to learning from agent trajectories. They collect all Codex session logs for the entire team into blob storage and run agent loops over them daily to identify patterns and opportunities for improvement. The insights get fed back into the repository as updated skills, documentation, or tests, creating a virtuous cycle where everybody benefits from everybody else's experience.
+
+Similarly, PR comments and failed builds are treated as signals that the agent was missing context. The team has processes to "slurp up" this feedback and integrate it back into the repository. When an agent gets paged for a production issue, it can update documentation to ensure similar issues are prevented in the future. This creates a self-improving system where the collective knowledge of the team accumulates in agent-accessible form.
+
+The team also encoded non-functional requirements into docs, tests, review agents, and skills. Everything from timeout requirements on network calls to the company's meme culture and Slack communication style is documented in a form that can be prompt-injected into agent context. One particularly amusing example: they have skills for generating "deep fried memes" and maintaining company culture in Slack, which GPT-5.4 proved quite capable at.
+
+## Production Deployment and Enterprise Context
+
+While the codebase is managed entirely by agents, there's still a human in the loop for cutting release branches and approving smoke tests before promoting to distribution. This is a native application rather than a continuously deployed service, which provides natural checkpoints for human oversight.
+
+The team also built an internal data agent using Frontier technology to make OpenAI's internal data ontology accessible. This required encoding semantic layer information - definitions of what revenue means, what constitutes an active user, and other business-critical metrics that even humans often disagree on. The agent needs to understand not just the technical structure of data warehouses but the business context of how the company operates.
+
+Interestingly, the team includes context about the product vision, customer segments, pilot customers, and 12-month goals in their core-beliefs.md. This business context informs how agents build software, just as it would for human engineers. The team even documents who's on the team and what their roles are, creating a comprehensive context that enables agents to make informed decisions.
+
+## Current Limitations and Future Directions
+
+Despite the remarkable success, Ryan identifies clear limitations in current models. They struggle with pure white space zero-to-one product development, where there's no existing codebase to reference and the vision exists only in someone's head. The gnarliest refactorings - those requiring deep rethinking of interface boundaries - also still require significant human involvement.
+
+However, Ryan is explicitly "not betting against the model" - he expects these capabilities to improve with each release. The strategy is to build infrastructure and processes that are robust to model improvements, allowing humans to continuously move higher up the stack as models handle increasingly complex tasks.
+
+The Frontier platform represents the productization of these learnings for enterprise customers. It provides highly observable, safe, controlled agent deployment with integration into existing IAM stacks, security tooling, and workspace tools. The platform includes the Agents SDK as a "works by default" harness that incorporates all the best practices discovered through this experiment, from the shell tool to Codex harness to file attachments and containers.
+
+## Token Economics and Scale
+
+The team runs at extreme scale: over one billion tokens per day, roughly $2-3k in daily token spend based on market rates and caching assumptions. Ryan is "admirably evangelical" about this, calling it borderline "negligent" if enterprises aren't using this level of token volume. The philosophy is that tokens are fundamentally cheap and parallelizable, while human attention is fundamentally scarce and serial.
+
+This creates a different optimization function. Rather than minimizing token usage, the team optimizes for minimizing human attention. They'll happily spend tokens on continuous build optimization, comprehensive observability, redundant agent runs, and extensive context injection if it means humans can focus on higher-level problems.
+
+## Technical Stack and Tool Choices
+
+The application is built with Electron, using a sophisticated architecture that separates main and render processes with MVC-style decomposition. The backend is hosted in the cloud, but local development includes the full stack. The team uses Mia extensively for dependency management, allowing them to easily pull down Go-written VictoriaMetrics binaries and other observability components.
+
+Tool choices are explicitly agent-driven. When the team needed an orchestration layer, they gave the model context and let it choose Elixir for its process supervision capabilities. This decision makes sense from the model's perspective even if the humans on the team don't have Elixir expertise - the code is disposable and the model will maintain it.
+
+The GitHub CLI (gh) is extensively used and praised for being "fantastic" and "super industry standard." The team rarely interacts with GitHub's web UI, instead using commands like "gh pr view --web" to quickly verify something before merging. This CLI-first approach extends to every aspect of the system.
+
+## Broader Implications
+
+This work represents a fundamental rethinking of software development. Traditional practices like careful PR review, human-legible code organization, and collaborative coding are being replaced with agent-legible architecture, autonomous merging, and systems thinking. The role of software engineers is shifting from crafting code to crafting the context and infrastructure that enables agents to craft code.
+
+The experiment also demonstrates that the "Dark Factory" concept - fully automated manufacturing with no humans in the loop - is achievable for software development today with current models. While there are still limitations, the trajectory is clear: as models improve, the range of tasks that can be fully automated will expand, allowing humans to focus on progressively higher-level challenges.
+
+The work has significant implications for enterprise software development. If a small team can achieve this level of automation and productivity with current tools, large enterprises that adopt similar practices could see massive productivity gains. The Frontier platform aims to make this accessible by providing the infrastructure, observability, and governance layers needed to deploy agents safely at scale.
+
+Perhaps most importantly, this case study demonstrates that realizing the full potential of coding agents requires rethinking the entire software development lifecycle, not just adopting better prompting techniques. It's about building systems where agents can operate autonomously, making mistakes that get automatically caught and corrected, learning from experience, and continuously improving without constant human oversight. This is what "harness engineering" means in practice - and it represents a new discipline that will be critical as AI agents become capable of increasingly complex and valuable work.

--- a/src/content/llmops-database/large-scale-ocr-processing-of-academic-papers-using-ai-coding-agents-and-serverless-gpu-infrastructure.md
+++ b/src/content/llmops-database/large-scale-ocr-processing-of-academic-papers-using-ai-coding-agents-and-serverless-gpu-infrastructure.md
@@ -1,0 +1,142 @@
+---
+title: "Large-Scale OCR Processing of Academic Papers Using AI Coding Agents and Serverless GPU Infrastructure"
+slug: "large-scale-ocr-processing-of-academic-papers-using-ai-coding-agents-and-serverless-gpu-infrastructure"
+draft: false
+llmopsTags:
+  - "document-processing"
+  - "chatbot"
+  - "question-answering"
+  - "prompt-engineering"
+  - "cost-optimization"
+  - "latency-optimization"
+  - "model-optimization"
+  - "evals"
+  - "vllm"
+  - "serverless"
+  - "pytorch"
+  - "langchain"
+  - "open-source"
+  - "documentation"
+  - "scaling"
+  - "hugging-face"
+  - "openai"
+  - "nvidia"
+  - "google-gcp"
+industryTags: "tech"
+company: "Huggingface"
+summary: "Hugging Face needed to convert approximately 27,000 academic papers to Markdown format to enable their \"chat with paper\" feature powered by HuggingChat, but these papers lacked HTML versions on arXiv. The team used OpenAI's Codex coding agent to orchestrate the entire workflow, which involved selecting the best open-source OCR model (Chandra-OCR 2) from leaderboards, deploying it on Hugging Face Jobs serverless GPU infrastructure using vLLM, and processing all papers across 16 parallel L40S GPU instances. The solution successfully processed 30,000 papers in approximately 29-30 hours at an estimated cost of $850, significantly cheaper than using proprietary APIs, and enabled chat functionality for all papers on the platform."
+link: "https://huggingface.co/blog/nielsr/ocr-papers-jobs"
+year: 2026
+seo:
+  title: "Huggingface: Large-Scale OCR Processing of Academic Papers Using AI Coding Agents and Serverless GPU Infrastructure - ZenML LLMOps Database"
+  description: "Hugging Face needed to convert approximately 27,000 academic papers to Markdown format to enable their \"chat with paper\" feature powered by HuggingChat, but these papers lacked HTML versions on arXiv. The team used OpenAI's Codex coding agent to orchestrate the entire workflow, which involved selecting the best open-source OCR model (Chandra-OCR 2) from leaderboards, deploying it on Hugging Face Jobs serverless GPU infrastructure using vLLM, and processing all papers across 16 parallel L40S GPU instances. The solution successfully processed 30,000 papers in approximately 29-30 hours at an estimated cost of $850, significantly cheaper than using proprietary APIs, and enabled chat functionality for all papers on the platform."
+  canonical: "https://www.zenml.io/llmops-database/large-scale-ocr-processing-of-academic-papers-using-ai-coding-agents-and-serverless-gpu-infrastructure"
+  ogTitle: "Huggingface: Large-Scale OCR Processing of Academic Papers Using AI Coding Agents and Serverless GPU Infrastructure - ZenML LLMOps Database"
+  ogDescription: "Hugging Face needed to convert approximately 27,000 academic papers to Markdown format to enable their \"chat with paper\" feature powered by HuggingChat, but these papers lacked HTML versions on arXiv. The team used OpenAI's Codex coding agent to orchestrate the entire workflow, which involved selecting the best open-source OCR model (Chandra-OCR 2) from leaderboards, deploying it on Hugging Face Jobs serverless GPU infrastructure using vLLM, and processing all papers across 16 parallel L40S GPU instances. The solution successfully processed 30,000 papers in approximately 29-30 hours at an estimated cost of $850, significantly cheaper than using proprietary APIs, and enabled chat functionality for all papers on the platform."
+notion:
+  pageId: "342f8dff-2538-80ca-b385-c8ca59187285"
+  databaseId: "1a9eaa1f57dd47d5af958caa57742b6b"
+  createdTime: "2026-04-14T08:45:00.000Z"
+  lastEditedTime: "2026-04-14T08:45:00.000Z"
+  publishedAt: "2026-04-14T08:49:59Z"
+---
+
+## Overview
+
+This case study from Hugging Face demonstrates a sophisticated LLMOps workflow that combines AI coding agents, open-source model selection, serverless GPU infrastructure, and storage optimization to solve a large-scale document processing challenge. The company maintains a platform that indexes arXiv papers, allowing researchers to claim papers, link resources, and engage with content. They introduced a "chat with paper" feature powered by HuggingChat that enables users to interact with research papers conversationally. However, this feature relied on HTML versions of papers from arXiv, which were unavailable for approximately 27,000 indexed papers, creating a significant gap in functionality.
+
+The solution architecture is particularly notable for its use of an AI coding agent (OpenAI's Codex) to orchestrate the entire pipeline rather than manually writing infrastructure code. This represents an emerging pattern in LLMOps where AI assists not just in the application layer but also in the operational deployment and management of AI workloads themselves. The project successfully processed all 27,000+ papers using open-source models on serverless infrastructure, demonstrating both technical feasibility and cost efficiency compared to proprietary alternatives.
+
+## Model Selection and Evaluation
+
+The team needed to select an appropriate open-source OCR model capable of converting PDF documents into Markdown format with interleaved HTML for images and tables. Rather than relying on anecdotal evidence or manual testing, they leveraged Hugging Face's native leaderboard feature called "Evaluation results." This feature transforms Hugging Face datasets into standardized benchmarks where models can submit their performance metrics via pull requests.
+
+For OCR tasks, they identified OlmOCRBench by AllenAI as the authoritative benchmark for evaluating OCR models' ability to convert documents into structured Markdown. By consulting this leaderboard, they selected Chandra-OCR 2 by Datalab, which was the top-performing model at the time. The model is released under an OpenRAIL license, making it suitable for commercial use. This demonstrates a mature approach to model selection based on standardized evaluation rather than trial-and-error or vendor claims.
+
+The use of evaluation leaderboards represents an important LLMOps practice: making model selection decisions based on reproducible benchmarks rather than subjective assessments. This approach provides transparency and defensibility for production model choices while reducing the time and resources needed for internal evaluation.
+
+## AI-Assisted Development with Coding Agents
+
+A distinctive aspect of this case study is the extensive use of OpenAI's Codex coding agent (accessed through the Codex Desktop app) to implement the entire processing pipeline. Rather than manually writing scripts to deploy the Chandra-OCR-2 model on serverless infrastructure, the team prompted Codex with relevant documentation and let it generate the necessary code.
+
+The workflow involved pointing Codex to multiple information sources including the Chandra-OCR-2 model card (to understand how to run it with vLLM), the Hugging Face CLI documentation (to understand how to use serverless GPU infrastructure), and the list of 27,000 arXiv IDs requiring processing. The coding agent then autonomously implemented scripts to orchestrate the entire job submission and monitoring workflow.
+
+This represents an emerging pattern in LLMOps where large language models assist in deploying and managing other AI workloads. The case study explicitly notes "as it's 2026, nowadays we can simply point a coding agent such as Claude Code, Cursor or Codex to a set of URLs and it will figure it out by itself." This suggests a shift in development practices where coding agents handle infrastructure orchestration that would traditionally require significant manual engineering effort.
+
+The team iteratively refined their approach through conversational prompting with Codex. They conducted cost and performance experiments on different GPU types, adjusted storage mechanisms, and monitored job progress—all through natural language interactions with the coding agent rather than manual scripting.
+
+## Infrastructure and Deployment Strategy
+
+The deployment leveraged Hugging Face Jobs, a serverless compute platform supporting both CPUs and GPUs ranging from Nvidia T4s to 8x Nvidia H200s with pay-as-you-go pricing charged by the second. This serverless approach eliminates the need to provision and manage persistent infrastructure, which is particularly suitable for batch processing workloads with variable demand.
+
+To determine the optimal GPU configuration, the team (via Codex) conducted experiments on a subset of 120 papers using different GPU types. They compared Nvidia A10G-large and Nvidia L40S GPUs by launching parallel jobs and measuring throughput. The L40S processed approximately 60 papers per hour (with a maximum of 30 pages per paper) compared to 32 papers per hour on the A10G. While the A10G-large was cheaper per hour, the slower processing speed meant longer total runtime and ultimately higher costs.
+
+Based on these experiments, they selected the L40S and determined that running 16 parallel jobs would complete the entire workload in approximately 29-30 hours at an estimated cost of $850. This compares favorably to using Chandra's proprietary API, which would have cost $1,841.07 in "fast/balanced" mode or $2,761.60 in "high-accuracy" mode. The comparison with 16x A10G-large instances (estimated at $1,350) demonstrates the importance of considering total cost of ownership rather than just hourly rates.
+
+The inference deployment used vLLM, a high-performance inference framework optimized for large language models and vision-language models. vLLM provides features like continuous batching, PagedAttention for efficient memory management, and optimized CUDA kernels that significantly improve throughput compared to naive implementations. Using vLLM with the Transformers-compatible Chandra-OCR-2 model allowed the team to maximize GPU utilization and processing speed.
+
+## Storage Architecture and Optimization
+
+Initially, the pipeline was designed to write results to a Hugging Face dataset. However, the team recognized that this approach was suboptimal for their use case. Since new papers are added daily, storing results in a git-versioned dataset would create an enormous number of commits and poor performance for mutable data.
+
+Instead, they pivoted to using Hugging Face Buckets, which are powered by Xet for fast, cheap, and mutable storage without git versioning. This is more appropriate for frequently updated data where version history is less important than performance and cost efficiency.
+
+The team further optimized the workflow by leveraging hf-mount, a newly launched tool that mounts Hugging Face Buckets (and other repository types) as local filesystems. This abstraction eliminated the need to implement custom download/upload logic in the processing scripts. The OCR jobs could simply write to what appeared to be a local directory, with hf-mount handling the synchronization to remote storage transparently.
+
+This approach significantly simplified the code that Codex needed to generate and reduced potential points of failure related to network operations, retry logic, and error handling. Each of the 16 parallel jobs wrote to its own bucket, and after completion, these were merged into a single bucket for integration into the Paper Pages feature.
+
+## Orchestration and Monitoring
+
+The orchestration workflow managed 16 parallel jobs running simultaneously on separate L40S GPUs. Each job processed a subset of the 27,000 papers, with some jobs completing faster than others depending on the page counts of their assigned papers. The team monitored progress by repeatedly asking Codex to "check the progress," and the coding agent would report how many of the 16 jobs had completed.
+
+Remarkably, all 16 jobs succeeded on the first attempt without requiring restarts or debugging, which the case study attributes to the robustness of the generated code and the reliability of the underlying infrastructure. After approximately one day (29-30 hours), all jobs completed successfully.
+
+The final integration step involved merging the 16 separate buckets into a single consolidated bucket, which was then integrated by team member Mishig into the Paper Pages feature. This enabled the "chat with paper" functionality for all indexed papers, not just those with HTML versions on arXiv.
+
+## Production Integration and User-Facing Features
+
+The OCR processing pipeline serves as infrastructure for Hugging Face's Paper Pages feature, which allows researchers to promote their work, claim papers, link related resources (models, datasets, Spaces, GitHub repositories, project pages), and tag papers with organizational affiliations. The platform supports Reddit-style upvoting and commenting, creating a social layer around academic research.
+
+The "chat with paper" functionality powered by HuggingChat operates by converting paper content into Markdown and using it as context for an LLM. For papers with HTML versions on arXiv, the system converts the HTML to Markdown. For the 27,000 papers without HTML versions, the newly OCR'd Markdown serves the same purpose. This demonstrates a classic RAG (Retrieval-Augmented Generation) pattern where document content is ingested, processed, and provided as context to enable conversational interaction.
+
+The case study notes that one commenter raised concerns about output quality after the OCR integration, asking "How are you planning to check the quality of outputs in this 'Chat with paper' feature after OCR integration? I tried it, not good results." This highlights an important consideration in production LLMOps: the quality of the OCR output directly impacts the quality of the downstream chat functionality. The team's reliance on the OlmOCRBench leaderboard for model selection was intended to mitigate quality issues, but real-world performance may vary depending on the specific characteristics of academic papers compared to the benchmark dataset.
+
+## Cost Analysis and Economic Considerations
+
+The cost comparison provides valuable insights into the economics of different deployment approaches for large-scale AI workloads. Processing 27,000 papers cost approximately $850 using self-managed infrastructure (16x L40S GPUs on Hugging Face Jobs for ~30 hours), compared to $1,841.07 using Chandra's "fast/balanced" API mode or $2,761.60 for "high-accuracy" mode.
+
+This represents a cost reduction of approximately 54-69% compared to using the proprietary API. The savings come from several factors: direct access to GPU compute at wholesale rates, use of open-source models without per-request pricing, and optimization of GPU selection based on throughput rather than just hourly cost.
+
+However, the comparison should be considered carefully. The case study doesn't address the engineering time required for implementation, though the use of Codex presumably reduced this significantly. Additionally, API-based solutions typically include built-in reliability, monitoring, and support, whereas self-managed infrastructure requires more operational overhead. The case study's success on the first attempt may not be typical, and production deployments generally need error handling, retry logic, and monitoring that aren't explicitly discussed.
+
+The serverless pay-as-you-go pricing model is particularly well-suited to this batch processing workload. The team only paid for the approximately 30 hours of actual compute time rather than provisioning infrastructure that would sit idle between processing runs. This represents a significant advantage over maintaining dedicated GPU servers.
+
+## Challenges and Limitations
+
+While the case study presents a successful implementation, several considerations merit attention. First, as noted by a commenter, there are concerns about OCR quality that could affect the downstream chat experience. The team selected the top-performing model from OlmOCRBench, but benchmark performance doesn't always translate perfectly to specific use cases like academic papers with complex mathematical notation, tables, and figures.
+
+Second, the case study mentions processing "at most 30 pages for each paper," suggesting some papers were truncated. This may be a cost-optimization measure, but it means the chat functionality may not have access to the complete content of longer papers, potentially limiting its usefulness for comprehensive papers.
+
+Third, while the use of Codex for orchestration is impressive, it introduces dependencies on proprietary AI services for infrastructure management. If Codex's API becomes unavailable or significantly more expensive, or if the quality of generated code degrades with model updates, this could impact operational capabilities. The case study doesn't discuss version pinning, validation of generated code, or fallback strategies.
+
+Fourth, there's limited discussion of quality assurance and validation. The case study doesn't mention sampling outputs to verify OCR accuracy, comparing results against ground truth for a subset of papers, or establishing quality metrics beyond the benchmark scores. In production LLMOps, validation and monitoring are critical, especially when processing thousands of documents that will directly impact user experience.
+
+## LLMOps Maturity and Best Practices
+
+This case study demonstrates several mature LLMOps practices. The use of standardized benchmarks and leaderboards for model selection shows a data-driven approach to decision-making. The experimentation with different GPU types and parallel job configurations demonstrates performance optimization based on empirical measurements rather than assumptions.
+
+The storage architecture evolution from datasets to mounted buckets shows responsiveness to operational requirements and willingness to optimize based on actual usage patterns. The successful execution of 16 parallel jobs without failures suggests robust error handling and infrastructure reliability, though the case study doesn't detail the specific mechanisms ensuring this reliability.
+
+However, some traditional LLMOps concerns receive limited attention. There's no discussion of model versioning or reproducibility—if Chandra-OCR-2 is updated, how would this affect consistency of the paper corpus? There's limited discussion of monitoring and observability during the processing runs beyond asking Codex for progress updates. Quality metrics, error rates, and validation procedures aren't explicitly covered.
+
+The reliance on AI coding agents for infrastructure orchestration is both a strength and a potential concern. While it dramatically reduces implementation time and lowers barriers to deployment, it may also reduce visibility into the actual implementation details and make debugging more challenging when issues arise. The case study suggests this is becoming standard practice in 2026, but organizations should consider the tradeoffs carefully.
+
+## Broader Implications
+
+This case study illustrates several important trends in LLMOps and AI engineering. First, the combination of open-source models, serverless infrastructure, and AI-assisted development enables relatively small teams to execute large-scale AI deployments that would have required significant engineering resources in earlier years.
+
+Second, the economics of self-managed GPU infrastructure versus proprietary APIs are shifting in favor of direct compute access for large-scale batch workloads, particularly when suitable open-source models are available. Organizations processing substantial volumes should conduct similar cost analyses rather than defaulting to API-based solutions.
+
+Third, the emergence of AI coding agents as infrastructure orchestration tools represents a significant shift in how AI workloads are deployed and managed. The ability to describe requirements in natural language and have code generated automatically reduces the specialized knowledge required for deployment while potentially increasing the pace of iteration.
+
+Finally, the integration of multiple Hugging Face platform capabilities—leaderboards for model selection, Jobs for serverless compute, Buckets for storage, and hf-mount for filesystem abstraction—demonstrates the value of cohesive platform ecosystems that reduce integration overhead and enable teams to focus on application logic rather than infrastructure plumbing.

--- a/src/content/llmops-database/self-improving-agent-through-llm-based-session-analysis.md
+++ b/src/content/llmops-database/self-improving-agent-through-llm-based-session-analysis.md
@@ -1,0 +1,154 @@
+---
+title: "Self-Improving Agent Through LLM-Based Session Analysis"
+slug: "self-improving-agent-through-llm-based-session-analysis"
+draft: false
+llmopsTags:
+  - "code-generation"
+  - "code-interpretation"
+  - "data-analysis"
+  - "prompt-engineering"
+  - "embeddings"
+  - "agent-based"
+  - "human-in-the-loop"
+  - "error-handling"
+  - "semantic-search"
+  - "few-shot"
+  - "evals"
+  - "monitoring"
+  - "databases"
+  - "api-gateway"
+  - "cicd"
+  - "documentation"
+  - "openai"
+industryTags: "tech"
+company: "Factory"
+summary: "Factory developed Signals, an LLM-based system that analyzes AI agent sessions at scale to identify user friction and delight without exposing conversation content. The system uses GPT-5.2 to process thousands of daily sessions through OpenAI's batch API, extracting structured facets, detecting friction patterns, and correlating findings with system logs and releases. When friction patterns cross predefined thresholds, the system automatically files tickets that Factory's Droid agent picks up, implements fixes for, and submits pull requests—creating a recursive self-improvement loop where the agent detects and fixes its own failures. Early results show 73% of issues are auto-resolved with an average fix time under 4 hours, though human approval is still required before merging changes."
+link: "https://factory.ai/news/factory-signals"
+year: 2026
+seo:
+  title: "Factory: Self-Improving Agent Through LLM-Based Session Analysis - ZenML LLMOps Database"
+  description: "Factory developed Signals, an LLM-based system that analyzes AI agent sessions at scale to identify user friction and delight without exposing conversation content. The system uses GPT-5.2 to process thousands of daily sessions through OpenAI's batch API, extracting structured facets, detecting friction patterns, and correlating findings with system logs and releases. When friction patterns cross predefined thresholds, the system automatically files tickets that Factory's Droid agent picks up, implements fixes for, and submits pull requests—creating a recursive self-improvement loop where the agent detects and fixes its own failures. Early results show 73% of issues are auto-resolved with an average fix time under 4 hours, though human approval is still required before merging changes."
+  canonical: "https://www.zenml.io/llmops-database/self-improving-agent-through-llm-based-session-analysis"
+  ogTitle: "Factory: Self-Improving Agent Through LLM-Based Session Analysis - ZenML LLMOps Database"
+  ogDescription: "Factory developed Signals, an LLM-based system that analyzes AI agent sessions at scale to identify user friction and delight without exposing conversation content. The system uses GPT-5.2 to process thousands of daily sessions through OpenAI's batch API, extracting structured facets, detecting friction patterns, and correlating findings with system logs and releases. When friction patterns cross predefined thresholds, the system automatically files tickets that Factory's Droid agent picks up, implements fixes for, and submits pull requests—creating a recursive self-improvement loop where the agent detects and fixes its own failures. Early results show 73% of issues are auto-resolved with an average fix time under 4 hours, though human approval is still required before merging changes."
+notion:
+  pageId: "33ff8dff-2538-80af-80cf-fb6c8f724969"
+  databaseId: "1a9eaa1f57dd47d5af958caa57742b6b"
+  createdTime: "2026-04-11T16:44:00.000Z"
+  lastEditedTime: "2026-04-11T16:44:00.000Z"
+  publishedAt: "2026-04-14T08:50:30Z"
+---
+
+## Overview
+
+Factory built Signals, a production LLM system designed to analyze their AI coding agent (Droid) sessions at scale to identify user friction and delight moments without human reviewers reading individual conversations. The system represents an ambitious approach to recursive self-improvement—where an AI agent analyzes its own behavior, identifies problems, and implements fixes autonomously. This case study is particularly notable because it demonstrates LLMs being used not just as the primary product feature, but as a critical monitoring and improvement layer in the production system itself.
+
+The problem Factory faced is common in AI product development: traditional metrics like session duration, tool calls executed, and completion rates fail to capture the actual user experience. A session might show successful completion in the metrics but hide eighteen minutes of user frustration fighting with the tool. Human review would catch these issues but doesn't scale to thousands of daily sessions and raises privacy concerns. Factory's solution was to build an LLM-powered analysis pipeline that thinks like a human reviewer but operates at machine scale while preserving privacy through abstraction.
+
+## Technical Architecture and Implementation
+
+The Signals system processes sessions using a multi-stage pipeline built around OpenAI's batch API. The architecture is designed for cost efficiency and scale rather than real-time processing. Sessions from the past 24 hours are fetched from BigQuery, filtered to those with at least 30 agentic steps to ensure meaningful interactions, and sent to OpenAI's batch API for analysis using GPT-5.2. The system analyzes thousands of sessions daily, with volume dynamically adjusted based on a token budget. The 24-hour processing window is deliberate—they're looking for aggregate patterns rather than real-time alerts, and batching provides significant API cost savings compared to streaming analysis.
+
+Results flow into two destinations: BigQuery for historical analysis and Slack for daily team reports. The BigQuery storage enables temporal queries to correlate friction patterns with releases and feature changes, while the Slack integration provides daily pulse reports on user experience. This dual-destination approach balances long-term analytical needs with immediate team awareness.
+
+## Facet Extraction and Schema Evolution
+
+A key innovation in Signals is the facet extraction system. Every session gets decomposed into structured metadata that Factory calls "facets"—programming languages involved, primary intent, tool call confirmation counts, session outcomes (success vs abandonment), and referenced frameworks. These facets enable aggregate analysis across thousands of sessions without anyone reading underlying conversations.
+
+What makes this particularly interesting from an LLMOps perspective is that the facet schema itself evolves autonomously through semantic clustering. As Signals processes batches of sessions, it generates embeddings for each session's abstracted summary and clusters similar sessions together. The LLM then analyzes these clusters to identify new facet categories worth tracking. When a cluster emerges that doesn't map cleanly to existing facets, Signals proposes adding a new dimension. Factory provides the example of "branch switches" as a facet that didn't exist in early versions but emerged through clustering—the system identified a group of sessions sharing similar patterns that didn't fit existing categories, and when the LLM examined what they had in common, it surfaced that git branch changes correlated with session complexity.
+
+This represents a sophisticated approach to schema evolution in production LLM systems. Rather than manually updating categorization schemas based on ad-hoc observations, Factory has built a system that discovers new analytical dimensions through unsupervised learning. However, the text doesn't specify how they validate these proposed facets, what thresholds determine when a cluster is significant enough to warrant a new facet, or how they prevent schema bloat over time.
+
+## Friction Detection and Classification
+
+The friction analyzer scans for seven primary pattern types: error events (model errors, tool failures, timeouts), repeated rephrasing (three or more consecutive restatements), escalation tone (phrases like "broken", "why isn't", "frustrating"), platform confusion (questions about Factory features), abandoned tool flows (tool calls rejected or cancelled), backtracking ("undo", "revert", deleting code), and context churn (repeatedly adding/removing the same file).
+
+Each friction moment receives a severity rating (high, medium, or low) and abstracted citations that describe what happened without exposing user quotes, code, or PII. A citation might read "user expressed frustration after third failed tool call" rather than quoting the user's actual words. This abstraction is central to Factory's privacy-preserving approach.
+
+Like the facet system, friction categories evolve through embedding-based clustering. The system generates embeddings for friction descriptions, clusters them to find recurring patterns that don't fit existing categories, and proposes new friction types when clusters reach significance. Factory cites "context churn" as a category that emerged from clustering—the system surfaced a group of friction moments sharing semantic similarity but not matching existing types, and the LLM identified the common thread of users repeatedly modifying context windows in ways that correlated with eventual abandonment.
+
+The distribution data Factory shares shows that friction severity varies significantly by type. For example, error events skew toward high severity (35% high, 45% medium), while platform confusion is predominantly low severity (55% medium, 30% low). However, the text doesn't explain how severity ratings are determined—whether they're LLM-generated judgments, rule-based classifications, or derived from downstream outcomes like abandonment rates.
+
+## Delight Identification
+
+Signals doesn't only identify problems; it also identifies moments where the product genuinely impressed users—positive exclamations, first-attempt successes on complex tasks, explicit mentions of time saved, and rapid approval flows followed by appreciation. Factory argues these delight signals matter for understanding what to do more of, not just what to fix.
+
+The delight categorization system also evolves through clustering. Factory notes that the system recently surfaced "learning moments" as a new delight type after discovering that sessions where Droid explained its reasoning generated disproportionately positive signals compared to sessions that just executed without explanation. This discovery led to product insights about when and how to provide explanations.
+
+From an LLMOps perspective, this dual focus on friction and delight is noteworthy. Many monitoring systems focus exclusively on errors and failures. By systematically identifying positive patterns, Factory can reinforce behaviors that work well and potentially expand them to other contexts. However, the text doesn't detail how delight signals are weighted against friction signals when evaluating overall session quality or making product decisions.
+
+## Correlation with System Behavior
+
+Signals becomes more powerful when correlated with internal logging and release data. Factory pipes error logs from their observability system into Signals' analysis. When a session shows friction, Signals can cross-reference with backend errors that occurred during the same time window. This surfaces patterns like "users experience repeated rephrasing friction when the context assembly service throws timeout errors" without manual investigation of individual sessions.
+
+The system also correlates with release notes automatically. When a new CLI version ships, Signals tracks whether friction patterns change in subsequent sessions. Factory caught regressions this way—a release that changed how file context was assembled correlated with a spike in context churn friction the following day, visible immediately in aggregate patterns rather than requiring weeks of manual review.
+
+They can also track improvements quantitatively. When they shipped a change to how Droid handles ambiguous requests, the "repeated rephrasing" friction rate dropped 30% within 48 hours, surfaced by Signals without anyone reading before-and-after sessions to verify the fix.
+
+This correlation capability is critical for production LLM systems. By connecting user-facing friction patterns with backend system behavior and code changes, Factory has built a closed-loop feedback system that can attribute problems to specific system components and verify that fixes actually improve user experience. The challenge, not addressed in the text, is managing false correlations—with thousands of sessions and numerous system events, spurious correlations are inevitable.
+
+## Recursive Self-Improvement Loop
+
+The most ambitious aspect of Signals is the closed-loop automation. When friction patterns cross predefined thresholds, the system files Linear tickets automatically. Droid (Factory's AI coding agent) picks up those tickets, assigns them to itself, implements fixes, and submits pull requests. A human still approves the PR before merge, but the path from "users are frustrated by X" to "here's a fix for X" happens without manual triaging, assignment, or even pattern recognition.
+
+Factory reports that 73% of issues are auto-resolved with an average time to fix under 4 hours, requiring only one human approval step. Recent examples include tickets for improving tool timeout handling after Signals detected it was responsible for over half of high-severity friction, and fixing output truncation that was delivering incomplete code to users.
+
+From an LLMOps perspective, this represents a sophisticated form of automated incident response and remediation. However, several important details are missing from the case study. What constitutes a "threshold" for automatic ticket filing? How do they prevent the system from filing duplicate tickets for the same underlying issue? What percentage of auto-generated fixes actually resolve the friction patterns that triggered them? What happens when Droid implements a fix that introduces new problems? The claim of 73% auto-resolution is impressive if true, but without details on how "resolution" is measured or what the 27% failure mode looks like, it's difficult to assess the actual maturity of this system.
+
+The text acknowledges that "it's not fully automated yet" because humans still approve PRs before merge, but doesn't discuss other important guardrails. In a production system serving real users, the consequences of an incorrect automated fix could be severe. How do they test these auto-generated fixes before deployment? Is there canary deployment or gradual rollout? What monitoring catches problems introduced by automated fixes?
+
+## Privacy-Preserving Analytics
+
+Factory emphasizes that Signals resolves the traditional tradeoff between reading user sessions to understand problems and staying blind to preserve privacy. Their approach uses multiple layers of abstraction: the LLM extracts patterns while omitting specific user content, individual results flow into aggregate statistics that only become meaningful at scale, and patterns only surface when they appear across enough distinct sessions to prevent identifying individual users.
+
+This privacy-preserving approach is important for production LLM systems, especially those handling proprietary code or sensitive information. However, the technical details of how privacy is enforced are sparse. Are there technical controls preventing the LLM from including verbatim user content in abstractions, or is it purely prompt-based instruction? How do they validate that abstractions don't leak identifying information? What constitutes "enough distinct sessions" to prevent user identification?
+
+The claim that "the model never surfaces raw conversation content to human analysts" is strong but relies on trust in the abstraction process. If the LLM is the gatekeeper between raw conversations and human-visible summaries, then the privacy guarantees are only as good as the LLM's instruction-following reliability. Production LLM systems dealing with sensitive data typically need additional technical controls beyond prompt engineering.
+
+## Insights and Patterns Discovered
+
+After running Signals for several months, Factory identified several patterns that weren't visible through traditional metrics:
+
+Context churn emerged as the leading indicator of eventual frustration. When users repeatedly add and remove the same file from context, something fundamental is wrong—either the file isn't being read correctly or the agent isn't using it as expected. This pattern often appears minutes before more obvious friction signals like escalation in tone. This insight has predictive value for real-time intervention.
+
+Rephrasing cascades predict abandonment with surprising accuracy. If a user rephrases three times, there's roughly 40% chance they'll rephrase again. If they hit five rephrases, session completion rates drop significantly. This led Factory to implement proactive clarification when Droid detects potential ambiguity, rather than waiting for the user to rephrase—a concrete product improvement driven by Signals analysis.
+
+Error recovery matters more than error prevention. Sessions that hit errors but recovered gracefully actually scored higher on delight than sessions with no errors at all. Users seem to appreciate resilience over perfection. A system that fails and recovers builds more trust than one that works flawlessly but feels fragile. This counterintuitive finding challenges the common assumption that error-free operation is the primary goal.
+
+On delight, the most common positive signal is efficiency. The abstracted phrase "would have taken me hours" appears across hundreds of delight citations. Users don't expect the agent to be faster than manual work, but when it is, they notice and appreciate it.
+
+These insights demonstrate the value of systematic LLM-based analysis at scale. However, it's worth noting that some of these patterns—like rephrasing cascades predicting abandonment—might be discoverable through traditional analytics on structured data without requiring LLM analysis. The context churn and error recovery insights seem more dependent on the semantic understanding that LLMs provide.
+
+## Critical Assessment
+
+The Signals case study represents sophisticated LLMOps work, but several aspects warrant critical examination:
+
+**Unvalidated Claims**: The 73% auto-resolution rate and sub-4-hour fix time are impressive if accurate, but the text provides no details on measurement methodology, what counts as "resolution," or whether these fixes actually reduce the friction patterns that triggered them. This is a common issue in vendor-produced case studies—dramatic metrics without supporting evidence or methodology.
+
+**Missing Operational Details**: For a system operating in production at scale, critical operational details are absent. How much does this system cost to run daily? What's the failure rate of the batch processing pipeline? How do they handle LLM API outages or rate limits? What's the latency from a user experiencing friction to that pattern appearing in Signals analysis (likely 24+ hours given the batch architecture)? These operational realities significantly impact the practical value of the system.
+
+**Circular Logic Risk**: The system uses LLMs to evaluate LLM agent behavior. This raises questions about whether it can detect failure modes that are blind spots for the same model family. If GPT-5.2 analyzing Droid sessions misses certain types of problems because of its own biases or limitations, those gaps will persist in the self-improvement loop. The text doesn't address this fundamental limitation.
+
+**Human-in-the-Loop Unclear**: While Factory mentions human approval of PRs, the role of humans in validating friction detection, facet proposals, and ticket generation is unclear. If the system is filing tickets automatically and Droid is implementing fixes automatically, what prevents runaway automation or systematic misdiagnosis of problems? The guardrails aren't described.
+
+**Privacy Claims Need Scrutiny**: The privacy-preserving claims rely heavily on LLM abstraction working reliably. In practice, LLMs can and do leak training data or fail to follow instructions about excluding specific content. For a system handling proprietary code, the privacy guarantees need more technical depth than "we prompt the LLM to abstract."
+
+**Generalization Questions**: This system is built specifically for analyzing sessions with Factory's Droid agent. How much of the architecture and approach would generalize to other LLM applications? The facet extraction and friction detection seem domain-specific, which limits the broader applicability of the techniques described.
+
+## Future Directions
+
+Factory outlines ambitious plans for evolution. They're moving toward real-time analysis, surfacing friction indicators during active sessions so the agent can course-correct before frustration builds. This would represent a significant architectural shift from batch processing to streaming analysis with much higher operational complexity and cost.
+
+Beyond reactive fixes, they're building toward proactive evolution where Signals identifies what's missing, not just what's broken. When clusters reveal users repeatedly asking for capabilities that don't exist, that becomes signal for what to build next. The evolution mechanism continues to find new patterns—they mention it recently proposed tracking "specification drift" for sessions where the user's stated goal shifted mid-conversation.
+
+The stated end goal is "an agent that learns from every interaction, improves continuously, and evolves its own capabilities over time." This represents the holy grail of AI systems—true autonomous improvement. However, the path from the current system (which still requires human PR approval) to fully autonomous evolution involves solving numerous unsolved problems in AI safety, testing, and validation.
+
+## LLMOps Takeaways
+
+Despite the critical questions raised above, Signals demonstrates several valuable LLMOps patterns:
+
+Using LLMs as evaluators of other LLM systems is increasingly common and valuable, but needs careful validation and awareness of circular reasoning risks. The approach of generating embeddings for sessions and clustering to discover new patterns shows how to combine traditional ML techniques with LLM analysis. The batch processing architecture optimized for cost rather than latency is appropriate for aggregate pattern detection and shows pragmatic engineering trade-offs. Correlating LLM-based user experience signals with system logs and releases creates a powerful feedback loop for production AI systems. Building schema evolution into the system from the start, rather than hardcoding categories, increases adaptability over time but requires mechanisms to validate and prune the schema.
+
+The recursive self-improvement loop, while impressive in concept, requires extensive guardrails and human oversight that the case study doesn't fully detail. For organizations considering similar approaches, the operational maturity needed to safely deploy automated remediation should not be underestimated. The privacy-preserving abstraction approach is valuable but needs technical enforcement beyond prompt engineering for sensitive applications.
+
+Overall, Signals represents sophisticated LLMOps work that pushes boundaries in autonomous system improvement, though the case study would benefit from more technical depth on validation, guardrails, and operational realities beyond the impressive top-line metrics.

--- a/src/lib/llmops.ts
+++ b/src/lib/llmops.ts
@@ -28,6 +28,35 @@ export function sortByYearDesc(entries: LLMOpsEntry[]): LLMOpsEntry[] {
   });
 }
 
+export type LLMOpsProvenance = {
+  webflow?: { lastPublished?: string; lastUpdated?: string; createdOn?: string };
+  notion?: { publishedAt?: string; lastEditedTime?: string; createdTime?: string };
+};
+
+/**
+ * Derive the date an entry was *added* to the LLMOps DB.
+ *
+ * Prefers creation timestamps so edits never re-float an entry.
+ * Distinct from the floating chain in rss.xml.ts: a feed wants
+ * "recently touched", a reference library wants "recently added".
+ */
+export function deriveAddedDate(data: LLMOpsProvenance): Date | null {
+  const candidates = [
+    data.notion?.createdTime,
+    data.webflow?.createdOn,
+    data.notion?.publishedAt,
+    data.webflow?.lastPublished,
+    data.notion?.lastEditedTime,
+    data.webflow?.lastUpdated,
+  ];
+  for (const raw of candidates) {
+    if (!raw) continue;
+    const d = new Date(raw);
+    if (!isNaN(d.getTime())) return d;
+  }
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // Related entries (by shared tags, industry, company)
 // ---------------------------------------------------------------------------

--- a/src/pages/llmops-database/rss.xml.ts
+++ b/src/pages/llmops-database/rss.xml.ts
@@ -8,6 +8,7 @@
 import type { APIRoute } from "astro";
 import { getCollection } from "astro:content";
 import { SITE_URL } from "../../lib/constants";
+import type { LLMOpsProvenance } from "../../lib/llmops";
 
 function escapeXml(s: string): string {
   return s
@@ -17,11 +18,6 @@ function escapeXml(s: string): string {
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&apos;");
 }
-
-type LLMOpsProvenance = {
-  webflow?: { lastPublished?: string; lastUpdated?: string; createdOn?: string };
-  notion?: { publishedAt?: string; lastEditedTime?: string; createdTime?: string };
-};
 
 /** Derive a Date from the website-native/Webflow provenance fallback chain. */
 function derivePubDate(data: LLMOpsProvenance): Date | null {

--- a/src/pages/llmops-index.json.ts
+++ b/src/pages/llmops-index.json.ts
@@ -8,6 +8,7 @@
  */
 import type { APIRoute } from "astro";
 import { getCollection } from "astro:content";
+import { deriveAddedDate } from "../lib/llmops";
 
 // Ensure this is pre-rendered at build time
 export const prerender = true;
@@ -23,6 +24,7 @@ export const GET: APIRoute = async () => {
     llmopsTags: entry.data.llmopsTags,
     industryTags: entry.data.industryTags || null,
     year: entry.data.year || null,
+    addedAt: deriveAddedDate(entry.data)?.getTime() ?? null,
     link: entry.data.link || null,
   }));
 


### PR DESCRIPTION
## Summary

Two related changes bundled together:

**1. Seven new LLMOps database entries (2026-04-14)**

Native-publish entries from the Notion pipeline (`notion:` provenance block, not legacy `webflow:`).

| Company | Topic |
|---|---|
| OpenAI | Extreme harness engineering — 1M+ LOC with zero human-written code |
| Meta | AI agents documenting tribal knowledge in data pipelines |
| Factory | Autonomous multi-agent system (Missions) for complex software |
| Factory | Self-improving agent via LLM-based session analysis (Signals) |
| Hugging Face | Large-scale OCR of 27k academic papers on serverless GPUs |
| Core Marine | Production RAG for 1TB of technical engineering documents |
| Lerim | Using Claude to optimize AI agent memory extraction |

**2. Fix 'Newest first' sort to mean *date added*, not *source year***

Previously the LLMOps Research Hub sorted `"newest"` by the source material's publication year with an A-Z title tie-break — producing a flat block of all 2026 entries alphabetized, then 2025, etc. Not useful for finding recently-added content.

Now sorts by a derived `addedAt` timestamp from the entry's provenance (webflow/notion block) using a **stable chain** (`createdTime` / `createdOn` first → fallback to `publishedAt` / `lastPublished` → fallback to edit timestamps). Edits won't re-float old entries.

### Implementation

- `src/lib/llmops.ts` — exports `deriveAddedDate(data)` and shared `LLMOpsProvenance` type
- `src/pages/llmops-index.json.ts` — emits `addedAt` as **epoch ms** (not ISO string) so the sort comparator is pure numeric comparison, zero `Date.parse` calls at runtime
- `src/components/islands/LLMOpsFilter.tsx` — `"newest"` case sorts by `addedAt` desc, slug tie-break
- `src/pages/llmops-database/rss.xml.ts` — imports the shared `LLMOpsProvenance` type (deduplication). RSS keeps its own `derivePubDate` because a feed wants *floating* semantics; this is intentional.

### Why epoch ms instead of ISO string in the JSON index

With ~1,515 entries, every sort re-run triggers ≈ O(N log N) ≈ 16k comparator calls. Emitting a `number` at build time means the comparator is just `tb - ta`, not `Date.parse(a.addedAt)` per comparison.

### Design decision: stable ("recently added") vs floating ("recently touched")

Picked stable. Reference libraries want predictable ordering — a small edit to an old entry shouldn't bump it to the top. The RSS feed continues to use the floating chain because *feed* semantics are different ("what changed?").

## Verification

- `pnpm validate:llmops` → 0 errors (2 pre-existing warnings on unrelated slug formats)
- `pnpm check` → 0 new errors (1 pre-existing `mdast` type error unrelated to this PR)
- `pnpm build` → exit 0
- Sanity-checked generated `/llmops-index.json`: all 1,514 entries have numeric `addedAt`, zero nulls
- Sorted-desc top 10 correctly places the 7 new entries at positions 1–7

## Test plan

- [ ] Cloudflare Pages preview build succeeds
- [ ] On preview URL, `/llmops-database` with default "Newest first" shows the 7 new entries at the top
- [ ] Switching sort to A-Z and back to "Newest first" still produces the date-added ordering
- [ ] URL state (`?sort=newest`) still persists/round-trips