### PR TITLE
content(team): add Lennart Szy as Founder's Associate

### DIFF
--- a/src/content/team/lennart-szy.md
+++ b/src/content/team/lennart-szy.md
@@ -1,0 +1,13 @@
+---
+title: "Lennart Szy"
+slug: "lennart-szy"
+draft: false
+position: "Founder's Associate"
+photo:
+  url: "https://assets.zenml.io/content/team/c14bab2d/lennart.avif"
+email: "lennart@zenml.io"
+linkedin: "https://www.linkedin.com/in/lennart-szy/"
+order: 3.5
+---
+
+<ul><li>Plans trips around local food, then pretends the sightseeing was intentional</li><li>Slowly becoming fluent in Spanish, automations, and Munich ski logistics</li><li>Head of Networking</li></ul>


### PR DESCRIPTION
## Summary
- New team member: Lennart Szy, Founder's Associate
- Slotted right after Viola on the team grid (`order: 3.5`)
- Photo uploaded to R2 at `content/team/c14bab2d/lennart.avif`
- Adds email (`lennart@zenml.io`) and LinkedIn link

## Test plan
- [x] Verify team card renders on `/company` with photo, name, position, and bio bullets
- [x] Confirm Lennart appears immediately after Viola Nuener in the grid order
- [ ] Photo loads from `assets.zenml.io` (HTTP 200)
- [x] Email + LinkedIn icons link correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)