### PR TITLE
Add `memory` and `harness-engineering` LLMOps tags

### DIFF
--- a/src/content/llmops-database/ai-agent-optimization-using-claude-to-systematically-improve-memory-extraction-quality.md
+++ b/src/content/llmops-database/ai-agent-optimization-using-claude-to-systematically-improve-memory-extraction-quality.md
@@ -16,6 +16,7 @@ llmopsTags:
   - "open-source"
   - "fastapi"
   - "anthropic"
+  - "memory"
 industryTags: "tech"
 company: "Lerim"
 summary: "Lerim, an open-source memory system for coding agents, faced challenges with memory extraction quality and accuracy. The solution involved using Claude Code (Opus 4.6) in an AutoResearch pattern to systematically optimize Lerim's prompts, DSPy signatures, tool descriptions, and schema definitions through automated experiments with comprehensive evaluation harnesses. Over two optimization rounds comprising 24 experiments, the system achieved a 41% improvement in composite quality score, with the single biggest win coming from a one-line code change (switching from dspy.Predict to dspy.ChainOfThought). The experiments revealed that schema-level changes outperformed prompt engineering, that positive guidance beats restrictive rules, and that component-level optimizations cascade into end-to-end improvements across the entire system."

--- a/src/content/llmops-database/ai-powered-developer-productivity-with-minions-and-machine-to-machine-payments.md
+++ b/src/content/llmops-database/ai-powered-developer-productivity-with-minions-and-machine-to-machine-payments.md
@@ -25,6 +25,7 @@ llmopsTags:
   - "cache"
   - "monitoring"
   - "anthropic"
+  - "harness-engineering"
 industryTags: "tech"
 company: "Stripe"
 summary: "Stripe has deployed an internal AI agent system called \"Minions\" that autonomously handles software development tasks, landing approximately 1,300 pull requests per week with no human assistance beyond code review. Engineers can initiate development work from Slack by simply adding an emoji reaction, which provisions cloud-based development environments and uses AI agents built on the Goose harness to implement features, update documentation, and make code changes. The system leverages Stripe's existing developer productivity infrastructure including hosted development environments, comprehensive CI/CD pipelines, and internal tooling accessible through MCP servers. Additionally, Stripe is pioneering machine-to-machine payment capabilities that allow AI agents to act as economic actors, autonomously purchasing services from third-party APIs to complete tasks, demonstrated through an agent that planned a birthday party by paying for browser automation, venue search, and mail services."

--- a/src/content/llmops-database/autonomous-ai-agent-for-end-to-end-ml-experimentation-in-ads-ranking.md
+++ b/src/content/llmops-database/autonomous-ai-agent-for-end-to-end-ml-experimentation-in-ads-ranking.md
@@ -21,6 +21,7 @@ llmopsTags:
   - "guardrails"
   - "reliability"
   - "meta"
+  - "memory"
 industryTags: "tech"
 company: "Meta"
 summary: "Meta developed the Ranking Engineer Agent (REA), an autonomous AI agent designed to manage the complete machine learning lifecycle for ads ranking models across billions of users on Facebook, Instagram, Messenger, and WhatsApp. Traditional ML experimentation at Meta was bottlenecked by manual, sequential workflows where engineers spent days to weeks per iteration crafting hypotheses, launching training jobs, debugging failures, and analyzing results. REA addresses this by autonomously executing the full experimentation cycle through a hibernate-and-wake mechanism for multi-day workflows, a dual-source hypothesis engine combining historical insights with ML research, and a three-phase planning framework operating within predefined compute budgets. In its initial production deployment, REA doubled average model accuracy improvements compared to baseline approaches across six models and achieved 5x engineering productivity gains, enabling three engineers to deliver improvement proposals for eight models—work that historically required two engineers per model."

--- a/src/content/llmops-database/autonomous-multi-phase-software-architecture-execution-with-llm-agents.md
+++ b/src/content/llmops-database/autonomous-multi-phase-software-architecture-execution-with-llm-agents.md
@@ -31,6 +31,7 @@ llmopsTags:
   - "anthropic"
   - "openai"
   - "google-gcp"
+  - "memory"
 industryTags: "healthcare"
 company: "Cara"
 summary: "Cara, a healthcare software platform company, used Claude Code (Opus 4.6) to autonomously execute 66 software tickets across 2 repositories, write 536 tests, and deliver a composable 5-layer architecture for their healthcare app platform in under 4 hours. The problem was a flat list of 25 scaffolds with no composition model, making it impossible to automatically assemble applications from component parts. The solution involved implementing a structured execution framework called RePPITS (Research, Propose, Plan, Implement, Test, Secure) with persistent memory, parallel subagents, phase gates, and comprehensive security audits. This required approximately 20-25 hours of preparation including codebase structuring, instruction file refinement, and epic planning. The autonomous execution produced approximately 20,000 lines of code organized into 53 scaffolds across 5 architectural layers (Foundation, Runtime, Capability, Adapter, Specialty), with 2 critical bugs and 10 other issues caught and fixed through automated security audits, resulting in zero deferred issues and only one minor production incident that was resolved in under 5 minutes."

--- a/src/content/llmops-database/autonomous-security-agents-for-continuous-vulnerability-detection-and-remediation.md
+++ b/src/content/llmops-database/autonomous-security-agents-for-continuous-vulnerability-detection-and-remediation.md
@@ -20,6 +20,7 @@ llmopsTags:
   - "continuous-deployment"
   - "documentation"
   - "google-gcp"
+  - "memory"
 industryTags: "tech"
 company: "Cursor"
 summary: "Cursor faced a challenge where their PR velocity increased 5x over nine months, making traditional static analysis and code ownership insufficient for security at scale. They implemented Cursor Automations to build a fleet of autonomous security agents that continuously identify and repair vulnerabilities in their codebase. The solution includes four main automation templates: Agentic Security Review (which has run on thousands of PRs and prevented hundreds of issues in two months), Vuln Hunter (for scanning existing code), Anybump (which automates dependency patching), and Invariant Sentinel (for daily compliance monitoring). These agents operate through a custom security MCP tool deployed as a serverless Lambda function, providing persistent data storage, deduplication of LLM-generated findings, and consistent output formatting."

--- a/src/content/llmops-database/building-a-generalized-internal-agent-with-sandboxed-execution-and-credential-brokering.md
+++ b/src/content/llmops-database/building-a-generalized-internal-agent-with-sandboxed-execution-and-credential-brokering.md
@@ -34,6 +34,7 @@ llmopsTags:
   - "openai"
   - "hugging-face"
   - "circleci"
+  - "harness-engineering"
 industryTags: "tech"
 company: "Browserbase"
 summary: "Browserbase built an internal generalized agent called \"bb\" to automate knowledge work across engineering, operations, sales, support, and executive functions. The problem was that many internal tasks—from investigating production sessions to logging feature requests—required manual effort and coordination across multiple systems, many of which lacked clean APIs. The solution involved creating a single agent loop that runs in isolated cloud sandboxes with credential brokering, a skills-based system for domain-specific workflows, and integration via Slack for natural interaction. The results included 100% feature request pipeline coverage with zero human effort, 99% of support tickets receiving first response in under 24 hours, session investigation time dropping from 30-60 minutes to a single Slack message, and engineers shifting from writing PRs to reviewing agent-generated ones."

--- a/src/content/llmops-database/building-a-multi-agent-gtm-system-for-sales-automation.md
+++ b/src/content/llmops-database/building-a-multi-agent-gtm-system-for-sales-automation.md
@@ -27,6 +27,8 @@ llmopsTags:
   - "meta"
   - "anthropic"
   - "openai"
+  - "memory"
+  - "harness-engineering"
 industryTags: "tech"
 company: "Langchain"
 summary: "LangChain built an end-to-end GTM (Go-To-Market) agent to automate outbound sales research and email drafting, addressing the problem of sales reps spending excessive time toggling between multiple systems and manually researching leads. The agent triggers on new Salesforce leads, performs multi-source research, checks contact history, and generates personalized email drafts with reasoning for rep approval via Slack. The solution increased lead-to-qualified-opportunity conversion by 250%, saved each sales rep 40 hours per month (1,320 hours team-wide), increased follow-up rates by 97% for lower-intent leads and 18% for higher-intent leads, and achieved 50% daily and 86% weekly active usage across the GTM team."

--- a/src/content/llmops-database/building-a-software-factory-with-ai-agents-at-scale.md
+++ b/src/content/llmops-database/building-a-software-factory-with-ai-agents-at-scale.md
@@ -42,6 +42,7 @@ llmopsTags:
   - "anthropic"
   - "openai"
   - "meta"
+  - "memory"
 industryTags: "tech"
 company: "Cursor"
 summary: "Cursor, a developer tool company, shares their journey of building what they call a \"software factory\" where AI agents handle increasingly autonomous software development tasks. The presentation outlines how they progressed through levels of autonomy from basic autocomplete to spawning hundreds of agents working asynchronously across their codebase. Their solution involves establishing guardrails through rules that emerge dynamically, creating verifiable systems with automated testing, and building skills and integrations that enable agents to work independently. Results include engineers managing fleets of agents rather than writing code directly, with some features being developed entirely by agents from feature flagging through testing to deployment, though significant work remains in observability, orchestration, and preventing agents from going off-track."

--- a/src/content/llmops-database/building-an-ai-powered-software-factory-with-autonomous-code-generation-and-review.md
+++ b/src/content/llmops-database/building-an-ai-powered-software-factory-with-autonomous-code-generation-and-review.md
@@ -27,6 +27,7 @@ llmopsTags:
   - "continuous-integration"
   - "continuous-deployment"
   - "anthropic"
+  - "harness-engineering"
 industryTags: "tech"
 company: "Twin Sun"
 summary: "Twin Sun, a Nashville-based software development agency, built an autonomous software development factory called Scarif that uses Claude Code agents to handle the majority of the software development lifecycle. The system addresses the challenge of scaling development capacity while maintaining code quality and consistency across multiple concurrent client projects. By introducing AI agents incrementally into their existing disciplined development workflow—starting with PR review and gradually expanding to code generation, testing, and deployment—they achieved a 70% autonomous approval rate on pull requests while maintaining their high standards for code quality and design patterns."

--- a/src/content/llmops-database/building-an-autonomous-ai-analytics-agent-for-enterprise-data-analysis.md
+++ b/src/content/llmops-database/building-an-autonomous-ai-analytics-agent-for-enterprise-data-analysis.md
@@ -17,6 +17,7 @@ llmopsTags:
   - "fastapi"
   - "documentation"
   - "meta"
+  - "memory"
 industryTags: "tech"
 company: "Meta"
 summary: "Meta built Analytics Agent to address the repetitive nature of data analysis work, where 88% of queries by data scientists rely on tables they've queried in the preceding 90 days. Starting from a weekend prototype that could execute SQL autonomously, the agent evolved through rapid iteration from a single devserver to a production system used by 77% of Meta's data scientists and engineers within six months. The solution combines personalized context (through query history analysis), an iterative reasoning loop that allows the agent to write and execute code autonomously, transparent output showing all SQL queries, and a layered knowledge system (Cookbooks, Recipes, Ingredients) that encodes team-specific analytical best practices. The agent scales data scientists by handling routine analyses while maintaining transparency and verification capabilities."

--- a/src/content/llmops-database/building-and-deploying-an-organization-wide-ai-agent-with-production-security-challenges.md
+++ b/src/content/llmops-database/building-and-deploying-an-organization-wide-ai-agent-with-production-security-challenges.md
@@ -31,6 +31,7 @@ llmopsTags:
   - "documentation"
   - "anthropic"
   - "google-gcp"
+  - "memory"
 industryTags: "tech"
 company: "Daily.dev"
 summary: "Daily.dev built \"Smith,\" an internal AI agent deployed in their Slack workspace that provides autonomous access to databases, GitHub repositories, browser automation, and scheduled tasks across the organization. Initially developed in four days using AI coding assistants (Codex and Claude Code), the team spent three subsequent weeks addressing critical production issues including credential leakage, event-loop hangs, memory overflow from long conversations, and security vulnerabilities in a shared runtime environment. The agent now runs in production with 60 tools, 25 self-authored skills, progressive tool disclosure, containerized execution, and defense-in-depth security layers, though several challenges remain unresolved including mysterious crashes from power users and the inherent difficulty of verifying autonomous agent behavior in production systems."

--- a/src/content/llmops-database/building-and-shipping-codex-an-ai-powered-coding-agent-platform.md
+++ b/src/content/llmops-database/building-and-shipping-codex-an-ai-powered-coding-agent-platform.md
@@ -18,6 +18,7 @@ llmopsTags:
   - "monitoring"
   - "openai"
   - "meta"
+  - "harness-engineering"
 industryTags: "tech"
 company: "OpenAI"
 summary: "OpenAI's Codex team demonstrates how they built and operate a production AI coding agent platform that enables developers to delegate complex software development tasks to LLMs. The team leverages their own product extensively in development, with designers writing more code than engineers did six months prior, and product managers submitting PRs directly. The solution includes multiple model tiers (GPT-5.4 for complex tasks, Codex Spark for rapid iteration at 1,200 tokens/second), a multi-agent architecture that allows parallel task execution, and an open-source harness that powers CLI, IDE extensions, and a standalone app. Results include 20-30x user growth in months, adoption across OpenAI internally as a primary development tool, and a development workflow where specs are minimal (around 10 bullets) with emphasis on rapid prototyping and community-driven iteration."

--- a/src/content/llmops-database/building-custom-agents-at-scale-notions-multi-year-journey-to-production-ready-agentic-workflows.md
+++ b/src/content/llmops-database/building-custom-agents-at-scale-notions-multi-year-journey-to-production-ready-agentic-workflows.md
@@ -56,6 +56,8 @@ llmopsTags:
   - "meta"
   - "microsoft-azure"
   - "amazon-aws"
+  - "memory"
+  - "harness-engineering"
 industryTags: "tech"
 company: "Notion"
 summary: "Notion, a knowledge work platform serving enterprise customers, spent multiple years (2022-2026) iterating through four to five complete rebuilds of their agent infrastructure before shipping Custom Agents to production. The core problem was enabling users to automate complex workflows across their workspaces while maintaining enterprise-grade reliability, security, and cost efficiency. Their solution involved building a sophisticated agent harness with progressive tool disclosure, SQL-like database abstractions, markdown-based interfaces optimized for LLM consumption, and a comprehensive evaluation framework. The result was a production system handling over 100 tools, serving majority-agent traffic for search, and enabling workflows like automated bug triaging, email processing, and meeting notes capture that fundamentally changed how their company and customers operate."

--- a/src/content/llmops-database/building-durable-and-reliable-ai-agents-at-scale-with-dapr-workflows.md
+++ b/src/content/llmops-database/building-durable-and-reliable-ai-agents-at-scale-with-dapr-workflows.md
@@ -40,6 +40,7 @@ llmopsTags:
   - "google-gcp"
   - "meta"
   - "anthropic"
+  - "memory"
 industryTags: "tech"
 company: "HumanLayer"
 summary: "This case study presents Dapr, a CNCF graduated project, and its application to production AI agent systems through the Dapr Agents framework. The core problem addressed is the unreliability of current agent frameworks when running at scale in production environments, particularly the challenge of state loss during failures that forces expensive re-execution of long-running agentic workflows. Dapr Agents provides a durable agent framework with built-in workflow orchestration, automatic failure detection and recovery, exactly-once execution guarantees, and support for over 30 different state stores. The solution was demonstrated through live examples showing agents automatically resuming from their exact point of failure without manual intervention, multi-agent collaboration using pub/sub mechanisms, and complete observability through OpenTelemetry integration. Contributed by Nvidia to the Dapr project and reaching 1.0 stability in 2026, the framework addresses critical production gaps in existing agent frameworks like LangChain and LangGraph."

--- a/src/content/llmops-database/building-general-purpose-ai-agents-with-agent-harnesses-and-tool-runtimes.md
+++ b/src/content/llmops-database/building-general-purpose-ai-agents-with-agent-harnesses-and-tool-runtimes.md
@@ -32,6 +32,7 @@ llmopsTags:
   - "openai"
   - "microsoft-azure"
   - "google-gcp"
+  - "harness-engineering"
 industryTags: "tech"
 company: "Langchain / Arcade"
 summary: "LangChain and Arcade collaborated to demonstrate how general-purpose AI agents can be built for enterprise deployment by combining two critical components: an agent harness (like LangChain's Deep Agents) that provides the scaffolding for LLM-powered agents to interact with file systems and execute code, and a secure tool runtime (like Arcade) that handles authentication, authorization, and integration with over 8,000 third-party services. The solution addresses the gap between single-user coding agents running locally and multi-user enterprise agents that require proper security controls, delegated authorization, and the ability to perform actions as specific users across multiple services. The approach enables organizations to deploy agents that can handle complex workflows like flight booking, email management, and LinkedIn recruiting while maintaining enterprise-grade security and compliance requirements."

--- a/src/content/llmops-database/building-pi-a-minimal-extensible-coding-agent-framework.md
+++ b/src/content/llmops-database/building-pi-a-minimal-extensible-coding-agent-framework.md
@@ -25,6 +25,7 @@ llmopsTags:
   - "google-gcp"
   - "amazon-aws"
   - "microsoft-azure"
+  - "harness-engineering"
 industryTags: "tech"
 company: "Pi"
 summary: "The presenter, Mario, describes the development of Pi, a minimal and extensible coding agent framework designed to address limitations in existing tools like Claude Code, Cursor, and OpenCode. Frustrated by feature bloat, poor context management, lack of model choice, and insufficient observability in commercial coding agents, Mario built Pi as a stripped-down core that provides only four basic tools (read, write, edit, bash) with extensive customization capabilities through TypeScript extensions. Pi achieved competitive performance on the TerminalBench coding benchmark, ranking second only to Terminus while maintaining a system prompt of just a few tokens. The framework emphasizes developer control, hot-reloading extensions, and adaptability to individual workflows rather than forcing users to conform to opinionated agent designs."

--- a/src/content/llmops-database/building-production-ai-agents-for-internal-data-analytics-and-full-stack-application-generation.md
+++ b/src/content/llmops-database/building-production-ai-agents-for-internal-data-analytics-and-full-stack-application-generation.md
@@ -36,6 +36,7 @@ llmopsTags:
   - "openai"
   - "google-gcp"
   - "cloudflare"
+  - "harness-engineering"
 industryTags: "tech"
 company: "Vercel"
 summary: "Vercel developed two significant production AI applications: DZ, an internal text-to-SQL data agent that enables employees to query Snowflake using natural language in Slack, and V0, a public-facing AI tool for generating full-stack web applications. The company initially built DZ as a traditional tool-based agent but completely rebuilt it as a coding-style agent with simplified architecture (just two tools: bash and SQL execution), dramatically improving performance by leveraging models' native coding capabilities. V0 evolved from a 2023 prototype targeting frontend engineers into a comprehensive full-stack development tool as models improved, finding strong product-market fit with tech-adjacent users and enabling significant internal productivity gains. Both products demonstrate Vercel's philosophy that building custom agents is straightforward and preferable to buying off-the-shelf solutions, with the company successfully deploying these AI systems at scale while maintaining reliability and supporting their core infrastructure business."

--- a/src/content/llmops-database/building-production-data-agents-with-long-running-context-and-iterative-workflows.md
+++ b/src/content/llmops-database/building-production-data-agents-with-long-running-context-and-iterative-workflows.md
@@ -28,6 +28,8 @@ llmopsTags:
   - "databases"
   - "anthropic"
   - "openai"
+  - "memory"
+  - "harness-engineering"
 industryTags: "tech"
 company: "Hex"
 summary: "Hex, a data analytics platform, evolved from single-shot text-to-SQL features to building sophisticated multi-agent systems that operate across entire data notebooks and conversational threads. The company faced challenges with model context limitations, tool proliferation, and evaluation of iterative data work that doesn't lend itself to simple pass/fail metrics. Their solution involved building custom orchestration infrastructure on Temporal, implementing dynamic context retrieval systems, creating specialized agents (notebook agent, threads agent, semantic modeling agent, context agent) that are now converging into unified capabilities, and developing novel evaluation approaches including a 90-day simulation benchmark. Results include widespread internal adoption where users described the experience as transformative, differentiation through context accumulation over time creating a flywheel effect, and the ability to handle complex multi-step data analysis tasks that require 20+ minutes of agent work with sophisticated error detection and iterative refinement."

--- a/src/content/llmops-database/building-production-ready-ai-agents-through-harness-engineering-and-continual-learning.md
+++ b/src/content/llmops-database/building-production-ready-ai-agents-through-harness-engineering-and-continual-learning.md
@@ -34,6 +34,7 @@ llmopsTags:
   - "google-gcp"
   - "amazon-aws"
   - "hugging-face"
+  - "harness-engineering"
 industryTags: "tech"
 company: "Langchain"
 summary: "Langchain's approach to production AI agents focuses on \"harness engineering\" - the practice of wrapping LLMs with context engineering, prompting, tools, verification systems, and orchestration logic to solve specific tasks. The team has developed open-source infrastructure including Deep Agents and comprehensive evaluation frameworks to help developers build task-specific agents that improve over time through continual learning loops. By treating agents as \"model plus harness,\" they've achieved significant improvements on benchmarks like SWE-bench (moving from top 30 to top 5 on Terminal Bench 2.0 through harness optimization alone) while emphasizing that production success requires custom harnesses tailored to specific customer use cases rather than relying solely on frontier model capabilities."

--- a/src/content/llmops-database/building-reliable-production-ai-agents-with-durable-execution-infrastructure.md
+++ b/src/content/llmops-database/building-reliable-production-ai-agents-with-durable-execution-infrastructure.md
@@ -43,6 +43,7 @@ llmopsTags:
   - "microsoft-azure"
   - "google-gcp"
   - "amazon-aws"
+  - "memory"
 industryTags: "tech"
 company: "Temporal"
 summary: "This case study explores how Temporal provides durable execution infrastructure for building reliable, long-running AI agents in production environments. The problem addressed is that traditional approaches to building production systems—whether through manual retry logic, event-driven architectures, or checkpoint-based solutions—require significant engineering effort to handle failures common in cloud environments and agentic workflows. Temporal solves this through a deterministic execution model that separates business logic from reliability concerns, allowing developers to write regular code in their preferred language while automatically handling crashes, retries, and state management. The solution has been adopted by companies like OpenAI (Codex on the web), Replit, and Lovable, with integrations across major AI frameworks including OpenAI Agents SDK, Pydantic AI, Vercel AI SDK, BrainTrust, and LangFuse, enabling developers to build production-grade agentic systems with significantly reduced complexity."

--- a/src/content/llmops-database/building-stateful-learning-agents-for-production-sre.md
+++ b/src/content/llmops-database/building-stateful-learning-agents-for-production-sre.md
@@ -10,6 +10,7 @@ llmopsTags:
   - "human-in-the-loop"
   - "error-handling"
   - "monitoring"
+  - "memory"
 industryTags: "tech"
 company: "Cleric"
 summary: "Cleric, an AI-powered Site Reliability Engineering platform, addresses the fundamental limitation of stateless AI agents by building a learning agent that accumulates knowledge over time. The problem Cleric tackles is that most AI agents operate without memory or context from past interactions, limiting their effectiveness in complex production environments. Their solution centers on three core principles: making it easy for users to correct the agent through persistent memories and self-harvested skills, rewarding corrections with visibly better performance that persists and compounds across sessions, and continuously absorbing context from infrastructure, observability tools, and incident channels without requiring explicit user direction. Deployed to dozens of customers, Cleric has demonstrated that stateful agents that complete the full learning loop—acting, learning, and adapting—build user trust and deliver higher utility than stateless alternatives."

--- a/src/content/llmops-database/cloud-based-agent-orchestration-platform-for-multi-agent-coding-workflows.md
+++ b/src/content/llmops-database/cloud-based-agent-orchestration-platform-for-multi-agent-coding-workflows.md
@@ -22,6 +22,7 @@ llmopsTags:
   - "security"
   - "anthropic"
   - "google-gcp"
+  - "harness-engineering"
 industryTags: "tech"
 company: "Warp"
 summary: "Warp, a terminal software company, developed a cloud-based agent orchestration platform called Oz to address the limitations of running multiple AI coding agents on local laptops. The problem emerged as developers increasingly shifted from writing code by hand to writing by prompt, creating laptop capacity constraints, lack of visibility into agent work across teams, and inability to run agents when laptops are offline. Warp's solution provides cloud-hosted agent execution with automatic tracking, team visibility, programmable APIs, and support for multiple agent harnesses, enabling developers to parallelize coding tasks across multiple cloud agents, create scheduled automations, and embed agent capabilities into internal applications. The platform demonstrates successful use cases including parallel feature implementation, automated issue triage, and team-wide agent coordination."

--- a/src/content/llmops-database/cognitive-memory-agent-building-stateful-ai-agents-with-multi-layer-memory-architecture.md
+++ b/src/content/llmops-database/cognitive-memory-agent-building-stateful-ai-agents-with-multi-layer-memory-architecture.md
@@ -37,6 +37,7 @@ llmopsTags:
   - "databases"
   - "orchestration"
   - "hugging-face"
+  - "memory"
 industryTags: "tech"
 company: "LinkedIn"
 summary: "LinkedIn developed the Cognitive Memory Agent (CMA), a horizontal memory platform designed to enable stateful and context-aware AI agents at scale, initially deployed within their Hiring Assistant product. The problem addressed was that delivering truly agentic experiences required more than capable models—agents needed domain intelligence, organizational context, and the ability to improve over time through personalized memory. CMA solves this by intelligently storing and retrieving contextually relevant information across multiple memory layers (conversational, episodic, semantic, and procedural), enabling agents to maintain continuity beyond context windows, learn from interactions, and provide deeply personalized experiences. The solution has been successfully integrated into Hiring Assistant, where it helps recruiters by suggesting roles based on past projects, auto-populating hiring requirements, and providing insights from historical activities, thereby reducing user friction and increasing productivity."

--- a/src/content/llmops-database/evolution-from-context-engineering-to-harness-engineering-philosophical-and-practical-approaches-to-building-production-llm-systems.md
+++ b/src/content/llmops-database/evolution-from-context-engineering-to-harness-engineering-philosophical-and-practical-approaches-to-building-production-llm-systems.md
@@ -25,6 +25,8 @@ llmopsTags:
   - "anthropic"
   - "openai"
   - "meta"
+  - "memory"
+  - "harness-engineering"
 industryTags: "tech"
 company: "Boundary / LangChain / HumanLayer"
 summary: "This case study presents a comprehensive discussion between engineers from LangChain and creators of the Ralph/Wim Loop system about the evolution of production LLM systems from basic agent loops to sophisticated harness engineering. The discussion addresses the fundamental shift from context engineering (where developers manually craft prompts and tool calls) to harness engineering (where models are reinforcement-learned to work optimally with specific tool sets and execution environments). The participants explore the tradeoffs between building custom harnesses versus using existing frameworks, the importance of evaluation-driven development, and the ongoing tension between automated code generation and deep systems understanding. They conclude that while newer abstraction layers provide faster time-to-value, understanding the underlying primitives remains essential for production engineering excellence."

--- a/src/content/llmops-database/extreme-harness-engineering-building-production-software-with-zero-human-written-code.md
+++ b/src/content/llmops-database/extreme-harness-engineering-building-production-software-with-zero-human-written-code.md
@@ -28,6 +28,7 @@ llmopsTags:
   - "elasticsearch"
   - "guardrails"
   - "openai"
+  - "harness-engineering"
 industryTags: "tech"
 company: "OpenAI"
 summary: "OpenAI's Frontier Product Exploration team conducted a five-month experiment building an internal beta product with zero manually written code, generating over 1 million lines of code across thousands of PRs while processing approximately 1 billion tokens per day. The team developed \"Symphony,\" an Elixir-based orchestration system that manages multiple Codex agents autonomously, removing humans from the code review and merge loop entirely. By shifting focus from prompt engineering to \"harness engineering\"—building systems, observability, and context that enable agents to work independently—the team achieved 5-10 PRs per engineer per day and established a new paradigm where software is optimized for agent legibility rather than human readability."

--- a/src/content/llmops-database/extreme-harness-engineering-building-production-systems-with-zero-human-written-code.md
+++ b/src/content/llmops-database/extreme-harness-engineering-building-production-systems-with-zero-human-written-code.md
@@ -33,6 +33,7 @@ llmopsTags:
   - "anthropic"
   - "meta"
   - "google-gcp"
+  - "harness-engineering"
 industryTags: "tech"
 company: "OpenAI"
 summary: "OpenAI's Frontier Product Exploration team conducted a five-month experiment building an internal Electron application with zero lines of human-written code, generating over one million lines of code across thousands of pull requests. The team developed \"harness engineering\" principles and Symphony, an Elixir-based orchestration system, to manage multiple coding agents at scale. By removing humans from the code authorship loop and focusing on building infrastructure, observability, and context for agents to operate autonomously, the team achieved 5-10 PRs per engineer per day with agents handling the full PR lifecycle including review, merge conflict resolution, and deployment, ultimately demonstrating that software can be built and maintained entirely by AI agents when proper systems and guardrails are in place."

--- a/src/content/llmops-database/harness-engineering-building-software-where-humans-steer-and-agents-execute.md
+++ b/src/content/llmops-database/harness-engineering-building-software-where-humans-steer-and-agents-execute.md
@@ -31,6 +31,7 @@ llmopsTags:
   - "reliability"
   - "scalability"
   - "openai"
+  - "harness-engineering"
 industryTags: "tech"
 company: "OpenAI"
 summary: "Ryan Leopo, a member of technical staff at OpenAI, describes his team's approach to building software exclusively with AI coding agents over a nine-month period, where human engineers were banned from directly editing code. The problem was how to productively deploy abundant AI coding capacity while shifting engineering roles toward systems thinking, delegation, and defining what constitutes good code. Their solution involved creating a comprehensive harness engineering approach with skills, documentation, automated review agents, linting, and testing frameworks that provide just-in-time context to agents, enabling them to write, test, and deploy production code autonomously. The results included dramatically increased velocity with 3-5 PRs per engineer per day, reduced merge conflicts, automated code reviews, and the ability to complete large-scale migrations and maintain high code quality standards while human engineers focused on higher-leverage activities like architecture, delegation, and defining system requirements."

--- a/src/content/llmops-database/hyper-personalized-merchandising-through-hybrid-llm-and-deep-learning-systems.md
+++ b/src/content/llmops-database/hyper-personalized-merchandising-through-hybrid-llm-and-deep-learning-systems.md
@@ -50,6 +50,7 @@ llmopsTags:
   - "anthropic"
   - "meta"
   - "google-gcp"
+  - "memory"
 industryTags: "e-commerce"
 company: "Doordash"
 summary: "DoorDash faced the challenge of personalizing experiences across a massive, diverse catalog spanning restaurants, grocery, retail, and other local commerce categories for millions of users with rapidly shifting intents. Traditional collaborative filtering and deep learning approaches could not adapt quickly enough to short-lived, high-context moments like Black Friday or individual life events. DoorDash developed a hybrid architecture that leverages LLMs for product understanding, consumer profile generation in natural language, and content blueprint creation, while maintaining traditional deep learning models for efficient last-mile ranking and retrieval. This approach enables the platform to serve dynamic, moment-aware personalization that adapts to real-time user intent while managing latency and cost constraints. The system uses GEPA optimization within DSPy for compound AI system tuning, combines offline LLM processing with online signal blending, and evaluates performance through quantitative metrics, LLM-as-judge, and human feedback."

--- a/src/content/llmops-database/multi-agent-ai-architecture-for-site-reliability-engineering-in-cloud-native-infrastructure.md
+++ b/src/content/llmops-database/multi-agent-ai-architecture-for-site-reliability-engineering-in-cloud-native-infrastructure.md
@@ -41,6 +41,7 @@ llmopsTags:
   - "nvidia"
   - "microsoft-azure"
   - "google-gcp"
+  - "memory"
 industryTags: "tech"
 company: "Komodor"
 summary: "Komodor introduced Klaudia AI, a multi-agent architecture designed to address the complexity of modern cloud-native infrastructure incident management. The problem stems from contemporary systems running hundreds of microservices across multi-cloud environments where symptoms appear in one place while root causes exist elsewhere, making single-agent AI tools ineffective. Klaudia's solution employs a three-layer architecture with over 50 domain-specific expert agents (covering Kubernetes, GPU/NVIDIA, AWS, ArgoCD, Istio, and more) coordinated by workflow orchestrators, all underpinned by a knowledge graph that maps entity relationships across the stack. The system demonstrated significant results including 80% reduction in MTTR for Kubernetes issues at Cisco Outshift, 55% faster pipeline failure diagnosis with the Airflow agent, and the ability to ship new domain agents in 2-4 weeks through its extensible platform architecture."

--- a/src/content/llmops-database/multi-agent-research-and-intelligence-platform-for-pharmaceutical-data-integration.md
+++ b/src/content/llmops-database/multi-agent-research-and-intelligence-platform-for-pharmaceutical-data-integration.md
@@ -33,6 +33,8 @@ llmopsTags:
   - "scalability"
   - "anthropic"
   - "microsoft-azure"
+  - "memory"
+  - "harness-engineering"
 industryTags: "healthcare"
 company: "Madrigal"
 summary: "Madrigal Pharmaceuticals built an enterprise multi-agent platform to integrate, search, and synthesize information from diverse pharmaceutical datasets scattered across structured systems, unstructured documents, and external sources. Using LangChain's DeepAgents framework and LangSmith for observability, evaluation, and deployment, they created a modular skills-based architecture where specialized agents work in parallel under an orchestrator, with all data normalized through consistent tool interfaces. The system reduced development time for new use cases from weeks to hours, achieved production deployment in weeks rather than months, and enabled domain experts to contribute directly to agent skill development while maintaining pharmaceutical-grade accuracy and governance."

--- a/src/content/llmops-database/multi-agent-system-for-interview-analysis-and-report-generation-at-scale.md
+++ b/src/content/llmops-database/multi-agent-system-for-interview-analysis-and-report-generation-at-scale.md
@@ -35,6 +35,8 @@ llmopsTags:
   - "devops"
   - "anthropic"
   - "openai"
+  - "memory"
+  - "harness-engineering"
 industryTags: "tech"
 company: "ListenLabs"
 summary: "ListenLabs, a platform for analyzing user research at scale, built a sophisticated multi-agent system that processes hundreds to thousands of user interviews, surveys, and focus group feedback. The company evolved from basic retrieval-augmented generation to a complex architecture featuring three primary agents: a study creation agent (Composer) that collaboratively builds discussion guides with users through an artifact-based interface, an interview agent that conducts voice-based multimodal conversations with participants, and a research agent that analyzes large volumes of qualitative data to generate insights, charts, video clips, and PowerPoint presentations. Their system demonstrates advanced LLMOps practices including parallelized sub-agent execution for processing hundreds of interviews simultaneously, custom evaluation agents for quality control, contextual prompt engineering, code execution in sandboxes, and sophisticated trace analysis for continuous improvement. The platform handles the complete lifecycle from study design through data collection to automated analysis and reporting."

--- a/src/content/llmops-database/observational-memory-human-inspired-context-compression-for-agent-systems.md
+++ b/src/content/llmops-database/observational-memory-human-inspired-context-compression-for-agent-systems.md
@@ -22,6 +22,7 @@ llmopsTags:
   - "google-gcp"
   - "anthropic"
   - "meta"
+  - "memory"
 industryTags: "tech"
 company: "Mastra"
 summary: "Mastra developed an observational memory system for LLM agents that compresses conversations 5-40x while maintaining temporal awareness and contextual relevance. The system uses two background agents (observer and reflector) to extract meaningful information from conversations while intelligently discarding noise, modeling how human memory retains what matters and lets details fade. The solution achieved 94.87% on the LongMemEval benchmark with GPT-5-mini and 84.23% with GPT-4o, outperforming existing approaches. Deployed in production across hiring and healthcare applications within the Mastra TypeScript agent framework, the system leverages prompt caching for cost efficiency and runs background compression to avoid blocking user interactions."

--- a/src/content/llmops-database/open-source-agent-orchestration-platform-for-multi-agent-business-automation.md
+++ b/src/content/llmops-database/open-source-agent-orchestration-platform-for-multi-agent-business-automation.md
@@ -26,6 +26,7 @@ llmopsTags:
   - "openai"
   - "google-gcp"
   - "hugging-face"
+  - "memory"
 industryTags: "tech"
 company: "Paperclip"
 summary: "Paperclip is an open-source agent orchestration platform designed to manage AI agents in production environments for business automation. The platform addresses the challenge of coordinating multiple AI agents across different organizational functions by providing a centralized control plane with organizational hierarchies, task management, quality assurance workflows, and vendor-neutral agent integration. The creator demonstrates using Paperclip to manage its own development, including creating marketing videos through agent collaboration, managing code reviews, and coordinating work across engineering and marketing teams. The platform achieved rapid adoption with 50,000 GitHub stars within approximately two months of release, though it remains in early stages with planned features for multi-user support, cloud deployment, and improved organizational learning."

--- a/src/content/llmops-database/replacing-complex-feature-implementation-with-prompt-based-skills-git-worktrees-in-production.md
+++ b/src/content/llmops-database/replacing-complex-feature-implementation-with-prompt-based-skills-git-worktrees-in-production.md
@@ -15,6 +15,7 @@ llmopsTags:
   - "open-source"
   - "anthropic"
   - "openai"
+  - "harness-engineering"
 industryTags: "tech"
 company: "Cursor"
 summary: "Cursor replaced a complex git worktrees feature consisting of approximately 15,000 lines of code with a markdown-based skill implementation of roughly 40 lines. The original feature enabled parallel agent work across isolated git checkouts with sophisticated management, judging, and cleanup systems. By leveraging two existing primitives—agent skills and sub-agents—the team reimplemented both the worktree and best-of-n features using primarily prompt engineering. While the new approach significantly reduced maintenance burden and enabled new capabilities like multi-repo support and mid-chat switching, it introduced challenges around model reliability in staying within designated worktrees, particularly for smaller models and longer sessions. The team is addressing these limitations through evaluation frameworks, reinforcement learning improvements, and continued prompt refinement."

--- a/src/content/llmops-database/terminal-native-ai-coding-agent-with-multi-model-architecture-and-adaptive-context-management.md
+++ b/src/content/llmops-database/terminal-native-ai-coding-agent-with-multi-model-architecture-and-adaptive-context-management.md
@@ -48,6 +48,7 @@ llmopsTags:
   - "google-gcp"
   - "microsoft-azure"
   - "hugging-face"
+  - "memory"
 industryTags: "tech"
 company: "Opendev"
 summary: "OpenDev is an open-source, command-line AI coding agent written in Rust that addresses the fundamental challenges of building production-ready autonomous software engineering systems. The agent tackles three critical problems: managing finite context windows over long sessions, preventing destructive operations while maintaining developer productivity, and extending capabilities without overwhelming token budgets. The solution employs a compound AI system architecture with per-workflow LLM binding, dual-agent separation of planning from execution, adaptive context compaction that progressively reduces older observations, lazy tool discovery via Model Context Protocol (MCP), and a defense-in-depth safety architecture. Results demonstrate approximately 54% reduction in peak context consumption, session lengths extending from 15-20 turns to 30-40 turns without emergency compaction, and a robust framework for terminal-first AI assistance that operates where developers manage source control, execute builds, and deploy environments."

--- a/src/content/llmops-database/training-agentic-models-with-reinforcement-learning-for-production-deployment.md
+++ b/src/content/llmops-database/training-agentic-models-with-reinforcement-learning-for-production-deployment.md
@@ -50,6 +50,7 @@ llmopsTags:
   - "google-gcp"
   - "nvidia"
   - "hugging-face"
+  - "harness-engineering"
 industryTags: "tech"
 company: "Kimi / Cursor / Chroma"
 summary: "This case study examines three production LLM systems—Kimi K2.5, Cursor Composer 2, and Chroma Context-1—that use reinforcement learning to train agentic models for real-world tasks. All three teams face similar challenges: managing context windows during long agentic sessions, bridging the gap between training environments and production deployments, and designing reward functions that avoid degenerate behaviors. Kimi K2.5 introduces Agent Swarm for parallel task decomposition, achieving 78.4% accuracy on BrowseComp with 4.5× latency reduction. Cursor Composer 2 implements real-time RL from production traffic with a five-hour deployment cycle, training on tasks with median 181-line changes. Chroma Context-1 develops self-editing search capabilities in a 20B parameter model that matches frontier-scale performance at 10× speed. Common solutions include training inside production harnesses, using outcome-based rewards augmented with generative reward models, running asynchronous large-scale rollouts, and building domain-specific evaluation benchmarks."

--- a/src/content/llmops-tags/harness-engineering.md
+++ b/src/content/llmops-tags/harness-engineering.md
@@ -1,0 +1,4 @@
+---
+name: "harness_engineering"
+slug: "harness-engineering"
+---

--- a/src/content/llmops-tags/memory.md
+++ b/src/content/llmops-tags/memory.md
@@ -1,0 +1,4 @@
+---
+name: "memory"
+slug: "memory"
+---


### PR DESCRIPTION
## Summary

Introduces two new LLMOps database tags — `memory` and `harness-engineering` — and applies them to 36 Notion-native entries (all post-Nov 2025) that substantively discuss agent memory architectures or agent harness engineering.

## Why

Two technology areas have become prominent in recent LLMOps content but had no corresponding tags:
- **Agent memory**: long/short-term, episodic/semantic/procedural memory, conversational memory stores, cross-session persistence (LinkedIn CMA, Mastra observational memory, Cognitive Memory Agent, Mem0-style systems)
- **Harness engineering**: how teams compose agent runtime environments — Claude Code, Codex, Goose, Deep Agents, Pi, custom harnesses (the Anthropic/OpenAI/Cursor/Langchain conversation about agent + harness architecture)

Without these tags, readers couldn't easily find the substantial cluster of case studies on either topic.

## How

Two-step approach matching how this codebase handles tags:
1. **Register tags** — add `memory.md` and `harness-engineering.md` under `src/content/llmops-tags/`. The `slugReferenceArray` schema in `src/content.config.ts` validates `llmopsTags` against this filesystem registry, so the files must exist before any entry can reference them.
2. **Apply tags via two-pass selection**:
   - Pass 1: keyword filter on Notion-native entries — flag any with ≥2 mentions of "memory" or "harness".
   - Pass 2: read each candidate's surrounding passages and disambiguate. "memory" splits into agent-memory (keep) vs RAM/GPU/cache (reject); "harness" splits into agent-harness/harness-engineering (keep) vs "evaluation harness" testing infra (reject).

Tags applied via surgical line insertion (not YAML round-trip) to keep diffs to exactly one added line per file.

## Selection results

| Tag | Candidates (≥2 mentions) | Kept | Rejected |
|---|---|---|---|
| `memory` | 35 | 22 | 13 (RAM / GPU / cache only) |
| `harness-engineering` | 23 | 20 | 3 (evaluation-harness only) |

6 entries get both tags. Total: 42 tag insertions across 36 files.

## Verification

- `pnpm validate:llmops` ✓ (2 pre-existing slug-format warnings on unrelated files)
- `pnpm check` ✓ (1 pre-existing `mdast` TS error in `src/lib/remark-default-lang.ts`, unrelated)
- `pnpm build` ✓ — Pagefind indexed 1801 pages

The new tags will surface automatically in the `LLMOpsFilter` faceted sidebar, entry-card chips, and `?tags=memory` URL parameters — no template/UI changes needed because facet counts are computed at runtime from `item.llmopsTags`.

## Test plan

- [x] Visit `/llmops-database` on the preview deploy, confirm `memory` and `harness-engineering` appear in the technology facet sidebar with correct counts (22 and 20)
- [x] Click `memory` filter, verify only the 22 tagged entries appear
- [x] Click `harness-engineering` filter, verify only the 20 tagged entries appear
- [x] Spot-check a both-tagged entry like `multi-agent-research-and-intelligence-platform-for-pharmaceutical-data-integration` shows both chips
- [x] Confirm `/llmops-database/?tags=memory&tags=harness-engineering&tagMode=and` returns the 6 intersection entries