### PR TITLE
Fix nested `<a>` tags breaking card grids on tag/industry pages

### DIFF
--- a/src/pages/industry-tags/[slug].astro
+++ b/src/pages/industry-tags/[slug].astro
@@ -143,9 +143,9 @@ const commonMLOpsTags = (await getMLOpsTagCounts(mlopsEntries)).slice(0, 8);
               {entry.data.summary && (
                 <p class="mt-2 line-clamp-3 text-sm text-gray-600">{entry.data.summary}</p>
               )}
-              <div class="relative mt-auto flex flex-wrap gap-1.5 pt-4">
+              <div class="mt-auto flex flex-wrap gap-1.5 pt-4">
                 {entry.data.llmopsTags.slice(0, 4).map((tagSlug: string) => (
-                  <Badge variant="blue" href={`/llmops-tags/${tagSlug}`}>{llmopsTagMap[tagSlug] || tagSlug}</Badge>
+                  <Badge variant="blue" href={`/llmops-tags/${tagSlug}`} class="relative">{llmopsTagMap[tagSlug] || tagSlug}</Badge>
                 ))}
                 {entry.data.llmopsTags.length > 4 && (
                   <Badge variant="gray">+{entry.data.llmopsTags.length - 4}</Badge>
@@ -187,9 +187,9 @@ const commonMLOpsTags = (await getMLOpsTagCounts(mlopsEntries)).slice(0, 8);
                 </>
               </div>
               <p class="mt-2 line-clamp-3 text-sm text-gray-600">{entry.data.summary}</p>
-              <div class="relative mt-auto flex flex-wrap gap-1.5 pt-4">
+              <div class="mt-auto flex flex-wrap gap-1.5 pt-4">
                 {entry.data.mlopsTags.slice(0, 4).map((tagSlug: string) => (
-                  <Badge variant="success" href={`/mlops-tags/${tagSlug}`}>{mlopsTagMap[tagSlug] || tagSlug}</Badge>
+                  <Badge variant="success" href={`/mlops-tags/${tagSlug}`} class="relative">{mlopsTagMap[tagSlug] || tagSlug}</Badge>
                 ))}
                 {entry.data.mlopsTags.length > 4 && (
                   <Badge variant="gray">+{entry.data.mlopsTags.length - 4}</Badge>

--- a/src/pages/industry-tags/[slug].astro
+++ b/src/pages/industry-tags/[slug].astro
@@ -126,12 +126,16 @@ const commonMLOpsTags = (await getMLOpsTagCounts(mlopsEntries)).slice(0, 8);
         <h2 class="mb-6 text-2xl font-bold tracking-tight text-gray-900">LLMOps entries</h2>
         <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           {llmopsEntries.map((entry) => (
-            <a
-              href={`/llmops-database/${entry.data.slug}`}
-              class="group flex flex-col rounded-lg border border-gray-200 bg-white p-5 transition-shadow hover:shadow-md"
+            <div
+              class="group relative flex flex-col rounded-lg border border-gray-200 bg-white p-5 transition-shadow hover:shadow-md"
             >
               <h3 class="text-lg font-semibold text-gray-900 group-hover:text-primary-600">
-                {entry.data.title}
+                <a
+                  href={`/llmops-database/${entry.data.slug}`}
+                  class="before:absolute before:inset-0 before:content-['']"
+                >
+                  {entry.data.title}
+                </a>
               </h3>
               {entry.data.company && (
                 <p class="mt-1 text-sm text-gray-500">{entry.data.company}</p>
@@ -139,7 +143,7 @@ const commonMLOpsTags = (await getMLOpsTagCounts(mlopsEntries)).slice(0, 8);
               {entry.data.summary && (
                 <p class="mt-2 line-clamp-3 text-sm text-gray-600">{entry.data.summary}</p>
               )}
-              <div class="mt-auto flex flex-wrap gap-1.5 pt-4">
+              <div class="relative mt-auto flex flex-wrap gap-1.5 pt-4">
                 {entry.data.llmopsTags.slice(0, 4).map((tagSlug: string) => (
                   <Badge variant="blue" href={`/llmops-tags/${tagSlug}`}>{llmopsTagMap[tagSlug] || tagSlug}</Badge>
                 ))}
@@ -147,7 +151,7 @@ const commonMLOpsTags = (await getMLOpsTagCounts(mlopsEntries)).slice(0, 8);
                   <Badge variant="gray">+{entry.data.llmopsTags.length - 4}</Badge>
                 )}
               </div>
-            </a>
+            </div>
           ))}
         </div>
       </section>
@@ -158,12 +162,16 @@ const commonMLOpsTags = (await getMLOpsTagCounts(mlopsEntries)).slice(0, 8);
         <h2 class="mb-6 text-2xl font-bold tracking-tight text-gray-900">MLOps entries</h2>
         <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           {mlopsEntries.map((entry) => (
-            <a
-              href={`/mlops-database/${entry.data.slug}`}
-              class="group flex flex-col rounded-lg border border-gray-200 bg-white p-5 transition-shadow hover:shadow-md"
+            <div
+              class="group relative flex flex-col rounded-lg border border-gray-200 bg-white p-5 transition-shadow hover:shadow-md"
             >
               <h3 class="text-lg font-semibold text-gray-900 group-hover:text-primary-600">
-                {entry.data.title}
+                <a
+                  href={`/mlops-database/${entry.data.slug}`}
+                  class="before:absolute before:inset-0 before:content-['']"
+                >
+                  {entry.data.title}
+                </a>
               </h3>
               <div class="mt-1 flex flex-wrap items-center gap-2 text-sm text-gray-500">
                 <span>{entry.data.company}</span>
@@ -179,7 +187,7 @@ const commonMLOpsTags = (await getMLOpsTagCounts(mlopsEntries)).slice(0, 8);
                 </>
               </div>
               <p class="mt-2 line-clamp-3 text-sm text-gray-600">{entry.data.summary}</p>
-              <div class="mt-auto flex flex-wrap gap-1.5 pt-4">
+              <div class="relative mt-auto flex flex-wrap gap-1.5 pt-4">
                 {entry.data.mlopsTags.slice(0, 4).map((tagSlug: string) => (
                   <Badge variant="success" href={`/mlops-tags/${tagSlug}`}>{mlopsTagMap[tagSlug] || tagSlug}</Badge>
                 ))}
@@ -187,7 +195,7 @@ const commonMLOpsTags = (await getMLOpsTagCounts(mlopsEntries)).slice(0, 8);
                   <Badge variant="gray">+{entry.data.mlopsTags.length - 4}</Badge>
                 )}
               </div>
-            </a>
+            </div>
           ))}
         </div>
       </section>

--- a/src/pages/llmops-tags/[slug].astro
+++ b/src/pages/llmops-tags/[slug].astro
@@ -91,9 +91,9 @@ const commonIndustries = (await getIndustryTagCounts(allEntries)).slice(0, 8);
           {entry.data.summary && (
             <p class="mt-2 line-clamp-3 text-sm text-gray-600">{entry.data.summary}</p>
           )}
-          <div class="relative mt-auto flex flex-wrap gap-1.5 pt-4">
+          <div class="mt-auto flex flex-wrap gap-1.5 pt-4">
             {entry.data.llmopsTags.slice(0, 4).map((tagSlug: string) => (
-              <Badge variant="blue" href={`/llmops-tags/${tagSlug}`}>{tagMap[tagSlug] || tagSlug}</Badge>
+              <Badge variant="blue" href={`/llmops-tags/${tagSlug}`} class="relative">{tagMap[tagSlug] || tagSlug}</Badge>
             ))}
             {entry.data.llmopsTags.length > 4 && (
               <Badge variant="gray">+{entry.data.llmopsTags.length - 4}</Badge>

--- a/src/pages/llmops-tags/[slug].astro
+++ b/src/pages/llmops-tags/[slug].astro
@@ -74,12 +74,16 @@ const commonIndustries = (await getIndustryTagCounts(allEntries)).slice(0, 8);
     {/* Entry grid */}
     <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
       {allEntries.map((entry) => (
-        <a
-          href={`/llmops-database/${entry.data.slug}`}
-          class="group flex flex-col rounded-lg border border-gray-200 bg-white p-5 transition-shadow hover:shadow-md"
+        <div
+          class="group relative flex flex-col rounded-lg border border-gray-200 bg-white p-5 transition-shadow hover:shadow-md"
         >
           <h2 class="text-lg font-semibold text-gray-900 group-hover:text-primary-600">
-            {entry.data.title}
+            <a
+              href={`/llmops-database/${entry.data.slug}`}
+              class="before:absolute before:inset-0 before:content-['']"
+            >
+              {entry.data.title}
+            </a>
           </h2>
           {entry.data.company && (
             <p class="mt-1 text-sm text-gray-500">{entry.data.company}</p>
@@ -87,7 +91,7 @@ const commonIndustries = (await getIndustryTagCounts(allEntries)).slice(0, 8);
           {entry.data.summary && (
             <p class="mt-2 line-clamp-3 text-sm text-gray-600">{entry.data.summary}</p>
           )}
-          <div class="mt-auto flex flex-wrap gap-1.5 pt-4">
+          <div class="relative mt-auto flex flex-wrap gap-1.5 pt-4">
             {entry.data.llmopsTags.slice(0, 4).map((tagSlug: string) => (
               <Badge variant="blue" href={`/llmops-tags/${tagSlug}`}>{tagMap[tagSlug] || tagSlug}</Badge>
             ))}
@@ -95,7 +99,7 @@ const commonIndustries = (await getIndustryTagCounts(allEntries)).slice(0, 8);
               <Badge variant="gray">+{entry.data.llmopsTags.length - 4}</Badge>
             )}
           </div>
-        </a>
+        </div>
       ))}
     </div>
 

--- a/src/pages/mlops-tags/[slug].astro
+++ b/src/pages/mlops-tags/[slug].astro
@@ -104,9 +104,9 @@ const commonIndustries = (await getMLOpsIndustryTagCounts(allEntries)).slice(
             </>
           </div>
           <p class="mt-2 line-clamp-3 text-sm text-gray-600">{entry.data.summary}</p>
-          <div class="relative mt-auto flex flex-wrap gap-1.5 pt-4">
+          <div class="mt-auto flex flex-wrap gap-1.5 pt-4">
             {entry.data.mlopsTags.slice(0, 4).map((tagSlug: string) => (
-              <Badge variant="success" href={`/mlops-tags/${tagSlug}`}>{tagMap[tagSlug] || tagSlug}</Badge>
+              <Badge variant="success" href={`/mlops-tags/${tagSlug}`} class="relative">{tagMap[tagSlug] || tagSlug}</Badge>
             ))}
             {entry.data.mlopsTags.length > 4 && (
               <Badge variant="gray">+{entry.data.mlopsTags.length - 4}</Badge>

--- a/src/pages/mlops-tags/[slug].astro
+++ b/src/pages/mlops-tags/[slug].astro
@@ -79,12 +79,16 @@ const commonIndustries = (await getMLOpsIndustryTagCounts(allEntries)).slice(
 
     <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
       {allEntries.map((entry) => (
-        <a
-          href={`/mlops-database/${entry.data.slug}`}
-          class="group flex flex-col rounded-lg border border-gray-200 bg-white p-5 transition-shadow hover:shadow-md"
+        <div
+          class="group relative flex flex-col rounded-lg border border-gray-200 bg-white p-5 transition-shadow hover:shadow-md"
         >
           <h2 class="text-lg font-semibold text-gray-900 group-hover:text-primary-600">
-            {entry.data.title}
+            <a
+              href={`/mlops-database/${entry.data.slug}`}
+              class="before:absolute before:inset-0 before:content-['']"
+            >
+              {entry.data.title}
+            </a>
           </h2>
           <div class="mt-1 flex flex-wrap items-center gap-2 text-sm text-gray-500">
             <span>{entry.data.company}</span>
@@ -100,7 +104,7 @@ const commonIndustries = (await getMLOpsIndustryTagCounts(allEntries)).slice(
             </>
           </div>
           <p class="mt-2 line-clamp-3 text-sm text-gray-600">{entry.data.summary}</p>
-          <div class="mt-auto flex flex-wrap gap-1.5 pt-4">
+          <div class="relative mt-auto flex flex-wrap gap-1.5 pt-4">
             {entry.data.mlopsTags.slice(0, 4).map((tagSlug: string) => (
               <Badge variant="success" href={`/mlops-tags/${tagSlug}`}>{tagMap[tagSlug] || tagSlug}</Badge>
             ))}
@@ -108,7 +112,7 @@ const commonIndustries = (await getMLOpsIndustryTagCounts(allEntries)).slice(
               <Badge variant="gray">+{entry.data.mlopsTags.length - 4}</Badge>
             )}
           </div>
-        </a>
+        </div>
       ))}
     </div>
 


### PR DESCRIPTION
## Summary

Cards on `/llmops-tags/<slug>`, `/mlops-tags/<slug>`, and `/industry-tags/<slug>` were rendering in a checkerboard pattern — every real card was followed by an empty-looking cell containing only its tag chips.

**Root cause:** the card wrapper was `<a href="/llmops-database/...">` and inside it the tag-chip Badges were *also* `<a>` elements. Nested anchors are invalid HTML5 — browsers silently auto-close the outer `<a>` the moment they parse the inner one, which evicts the tag-chip container out of its card and into the next grid cell.

## What changed

Switched to the **stretched-link** pattern in three template files:

| File | Grids fixed |
|---|---|
| `src/pages/llmops-tags/[slug].astro` | 1 |
| `src/pages/mlops-tags/[slug].astro` | 1 |
| `src/pages/industry-tags/[slug].astro` | 2 (LLMOps section + MLOps section) |

Per card:
1. Outer `<a>` → `<div>` with `relative` added to the class list
2. Title text wrapped in a new `<a>` whose `::before` covers the whole card via `before:absolute before:inset-0 before:content-['']`
3. **Linked tag-chip Badges get `class="relative"`** so they sit above the stretched pseudo and remain independently clickable. The non-link `+N` `<span>` chip and footer whitespace stay static, so they fall back through to the stretched link below — preserving full-card click parity with the original behavior.

> Note: the second commit (6c9d40c) refines the first — the initial fix put `relative` on the whole footer container, which lifted the inert `+N` chip and footer gaps above the stretched link and broke whole-card click for those areas. Codex Connector flagged this; the second commit moves `relative` onto the linked chips themselves, matching Bootstrap's canonical stretched-link guidance.

Result: same UX as the original intent (whole card clickable, chips independently navigable), valid HTML5, no checkerboard.

## Verification

- `pnpm build` passes — no new errors, build time unchanged (~33s)
- Live browser check via local dev server, using `document.elementFromPoint` on a card with >4 tags:

| Click target | Resolves to |
|---|---|
| Card body (title / company / summary) | Entry detail page (via stretched `::before`) ✓ |
| Linked tag chip | That chip's tag page ✓ |
| `+N` `<span>` chip | Entry detail page ✓ |
| Footer whitespace | Entry detail page ✓ |

## Other pages with the same outer-`<a>` pattern (verified safe)

- `src/pages/llmops-database/[slug].astro` "More Like This" — uses `<span>` for tags, not `<a>`, so no nesting bug
- `src/pages/mlops-database/[slug].astro` "More Like This" — same, uses `<span>` for tags
- `src/pages/blog/[slug].astro` — Badge with href is at top level, not inside an outer `<a>`

## Possible follow-ups (out of scope here)

- **`BlogCard.astro` may have the same nested-`<a>` pattern.** Quick scan suggests the card-wrapping `<a>` contains an inner title `<a>`. Worth a separate audit.
- **Shared `EntryCard.astro` component.** Six near-identical card blocks live across five files (this PR's four plus the two "More Like This" sections). Could collapse into one component with a stable prop shape — separate refactor PR.
- **`@utility stretched-link` in `global.css`.** Would let us replace `before:absolute before:inset-0 before:content-['']` with a single named utility. Wash for four occurrences; revisit if the pattern grows.

## Test plan

- [x] Preview deploy renders `/llmops-tags/prompt-engineering` as a clean 3-column grid (no checkerboard, no orphaned tag rows)
- [x] Same check on `/mlops-tags/<any-slug>` and `/industry-tags/tech`
- [x] Click any card body (title, company, summary) — navigates to the corresponding `/llmops-database/<slug>` (or `/mlops-database/<slug>`)
- [x] Click any linked tag chip — navigates to that tag page, *not* the entry detail
- [x] On a card with >4 tags: click the `+N` chip — navigates to the entry detail page
- [x] Click empty space inside the tag-chip footer (gaps / right-side whitespace) — navigates to the entry detail page
- [ ] Inspect element on a card: outer is `<div>`, single `<a>` inside `<h2>`/`<h3>` for the title, separate `<a>`s for chips — no nested anchors