### PR TITLE
Fix quality gates and optimize release-note images

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.14",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^22.19.11",
     "cheerio": "^1.2.0",
     "domhandler": "^5.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.3.14
         version: 2.3.14
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/node':
         specifier: ^22.19.11
         version: 22.19.11

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -4,11 +4,11 @@
  * Structure: brand/social | primary columns | VS columns | extended columns | legal
  */
 import {
-  FOOTER_PRIMARY,
-  FOOTER_VS,
   FOOTER_EXTENDED,
-  FOOTER_SOCIAL,
   FOOTER_LEGAL,
+  FOOTER_PRIMARY,
+  FOOTER_SOCIAL,
+  FOOTER_VS,
   type SocialPlatform,
 } from "../lib/footer";
 

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -15,7 +15,12 @@ interface Props {
   ariaLabel?: string;
 }
 
-const { currentPage, totalPages, getHref, ariaLabel = "Pagination" } = Astro.props;
+const {
+  currentPage,
+  totalPages,
+  getHref,
+  ariaLabel = "Pagination",
+} = Astro.props;
 
 if (totalPages <= 1) return;
 

--- a/src/components/blog/BlogCard.astro
+++ b/src/components/blog/BlogCard.astro
@@ -41,7 +41,11 @@ const {
 } = Astro.props;
 
 const formattedDate = publishedDate
-  ? new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", year: "numeric" }).format(publishedDate)
+  ? new Intl.DateTimeFormat("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    }).format(publishedDate)
   : undefined;
 ---
 

--- a/src/components/blog/BlogHero.astro
+++ b/src/components/blog/BlogHero.astro
@@ -36,7 +36,11 @@ const {
 } = Astro.props;
 
 const formattedDate = publishedDate
-  ? new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", year: "numeric" }).format(publishedDate)
+  ? new Intl.DateTimeFormat("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    }).format(publishedDate)
   : undefined;
 ---
 

--- a/src/components/blog/CategoryBar.astro
+++ b/src/components/blog/CategoryBar.astro
@@ -19,7 +19,12 @@ interface Props {
   breadcrumbTitle?: string;
 }
 
-const { categories = [], activeCategory, backLink = false, breadcrumbTitle } = Astro.props;
+const {
+  categories = [],
+  activeCategory,
+  backLink = false,
+  breadcrumbTitle,
+} = Astro.props;
 
 const topCategories = categories.slice(0, 8);
 ---

--- a/src/components/islands/BlogSearch.tsx
+++ b/src/components/islands/BlogSearch.tsx
@@ -5,7 +5,7 @@
  * JSON endpoint on first interaction (focus or typing). Supports Cmd+K /
  * Ctrl+K focus, arrow key navigation, Escape to clear.
  */
-import { useState, useRef, useEffect, useCallback } from "preact/hooks";
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 
 interface PostEntry {
   title: string;
@@ -51,14 +51,18 @@ export default function BlogSearch({ searchIndexUrl }: Props) {
     }
   }, [searchIndexUrl]);
 
-  const results = query.trim().length >= 2
-    ? posts
-        .filter((p) => {
-          const q = query.toLowerCase();
-          return p.title.toLowerCase().includes(q) || p.excerpt.toLowerCase().includes(q);
-        })
-        .slice(0, 6)
-    : [];
+  const results =
+    query.trim().length >= 2
+      ? posts
+          .filter((p) => {
+            const q = query.toLowerCase();
+            return (
+              p.title.toLowerCase().includes(q) ||
+              p.excerpt.toLowerCase().includes(q)
+            );
+          })
+          .slice(0, 6)
+      : [];
 
   const showDropdown = isOpen && query.trim().length >= 2;
 
@@ -77,7 +81,10 @@ export default function BlogSearch({ searchIndexUrl }: Props) {
   // Close on outside click
   useEffect(() => {
     const handler = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
         setIsOpen(false);
       }
     };
@@ -101,7 +108,11 @@ export default function BlogSearch({ searchIndexUrl }: Props) {
       } else if (e.key === "ArrowUp") {
         e.preventDefault();
         setActiveIndex((i) => (i > 0 ? i - 1 : results.length - 1));
-      } else if (e.key === "Enter" && activeIndex >= 0 && results[activeIndex]) {
+      } else if (
+        e.key === "Enter" &&
+        activeIndex >= 0 &&
+        results[activeIndex]
+      ) {
         e.preventDefault();
         window.location.href = `/blog/${results[activeIndex].slug}`;
       }
@@ -111,9 +122,10 @@ export default function BlogSearch({ searchIndexUrl }: Props) {
 
   const formatDate = (dateStr: string) => {
     try {
-      return new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric" }).format(
-        new Date(dateStr),
-      );
+      return new Intl.DateTimeFormat("en-US", {
+        month: "short",
+        day: "numeric",
+      }).format(new Date(dateStr));
     } catch {
       return "";
     }
@@ -125,6 +137,7 @@ export default function BlogSearch({ searchIndexUrl }: Props) {
         {/* Search icon */}
         <svg
           class="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+          aria-hidden="true"
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
@@ -172,9 +185,13 @@ export default function BlogSearch({ searchIndexUrl }: Props) {
           class="absolute right-0 top-full z-50 mt-1.5 w-80 overflow-hidden rounded-md border border-gray-200 bg-white shadow-lg"
         >
           {isLoading ? (
-            <div class="px-4 py-6 text-center text-sm text-gray-500">Loading…</div>
+            <div class="px-4 py-6 text-center text-sm text-gray-500">
+              Loading…
+            </div>
           ) : loadError ? (
-            <div class="px-4 py-6 text-center text-sm text-gray-500">Search unavailable</div>
+            <div class="px-4 py-6 text-center text-sm text-gray-500">
+              Search unavailable
+            </div>
           ) : results.length > 0 ? (
             results.map((post, i) => (
               <a
@@ -187,7 +204,9 @@ export default function BlogSearch({ searchIndexUrl }: Props) {
                 }`}
                 onMouseEnter={() => setActiveIndex(i)}
               >
-                <div class="line-clamp-1 text-sm font-medium text-gray-900">{post.title}</div>
+                <div class="line-clamp-1 text-sm font-medium text-gray-900">
+                  {post.title}
+                </div>
                 <div class="mt-0.5 flex items-center gap-2 text-xs text-gray-500">
                   {post.category && <span>{post.category}</span>}
                   {post.category && post.date && (
@@ -200,7 +219,9 @@ export default function BlogSearch({ searchIndexUrl }: Props) {
               </a>
             ))
           ) : (
-            <div class="px-4 py-6 text-center text-sm text-gray-500">No posts found</div>
+            <div class="px-4 py-6 text-center text-sm text-gray-500">
+              No posts found
+            </div>
           )}
         </div>
       )}

--- a/src/components/islands/ContactForm.tsx
+++ b/src/components/islands/ContactForm.tsx
@@ -7,10 +7,10 @@
  * Supports optional Cloudflare Turnstile bot protection — pass `turnstileSiteKey`
  * to enable the invisible challenge widget.
  */
-import { useState, useCallback, useEffect, useRef } from "preact/hooks";
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import type { PlaceholderField } from "../../lib/formTypes";
+import { type FormType, validateForm } from "../../lib/formValidation";
 import type { CtaLink } from "../../lib/marketingPageTypes";
-import { validateForm, type FormType } from "../../lib/formValidation";
 
 interface Props {
   formType: FormType;
@@ -50,11 +50,16 @@ export default function ContactForm({
     if (!turnstileSiteKey) return;
 
     const SCRIPT_ID = "cf-turnstile-script";
-    const scriptUrl = "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit&onload=onTurnstileLoad";
+    const scriptUrl =
+      "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit&onload=onTurnstileLoad";
 
     function renderWidget() {
       if (!turnstileRef.current || turnstileWidgetId.current != null) return;
-      const w = window as unknown as { turnstile?: { render: (el: HTMLElement, opts: Record<string, unknown>) => string } };
+      const w = window as unknown as {
+        turnstile?: {
+          render: (el: HTMLElement, opts: Record<string, unknown>) => string;
+        };
+      };
       if (!w.turnstile) return;
       turnstileWidgetId.current = w.turnstile.render(turnstileRef.current, {
         sitekey: turnstileSiteKey,
@@ -70,7 +75,8 @@ export default function ContactForm({
     }
 
     // Register global callback for script load
-    (window as unknown as Record<string, unknown>).onTurnstileLoad = renderWidget;
+    (window as unknown as Record<string, unknown>).onTurnstileLoad =
+      renderWidget;
 
     const script = document.createElement("script");
     script.id = SCRIPT_ID;
@@ -83,7 +89,9 @@ export default function ContactForm({
   /** Reset the Turnstile widget so the user gets a fresh token for retry. */
   const resetTurnstile = useCallback(() => {
     if (turnstileWidgetId.current == null) return;
-    const w = window as unknown as { turnstile?: { reset: (id: string) => void } };
+    const w = window as unknown as {
+      turnstile?: { reset: (id: string) => void };
+    };
     w.turnstile?.reset(turnstileWidgetId.current);
   }, []);
 
@@ -132,7 +140,7 @@ export default function ContactForm({
         });
 
         if (!res.ok) {
-          const body = await res.json().catch(() => ({})) as {
+          const body = (await res.json().catch(() => ({}))) as {
             error?: string;
             errors?: Record<string, string>;
           };
@@ -152,7 +160,9 @@ export default function ContactForm({
 
         setState("success");
       } catch {
-        setServerError("Network error. Please check your connection and try again.");
+        setServerError(
+          "Network error. Please check your connection and try again.",
+        );
         resetTurnstile();
         setState("error");
       }
@@ -165,8 +175,19 @@ export default function ContactForm({
     return (
       <div class="rounded-md border border-green-200 bg-green-50 p-6 text-center sm:p-8">
         <div class="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
-          <svg class="h-6 w-6 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+          <svg
+            class="h-6 w-6 text-green-600"
+            aria-hidden="true"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M5 13l4 4L19 7"
+            />
           </svg>
         </div>
         <p class="text-lg font-semibold text-gray-900">{successMessage}</p>
@@ -179,8 +200,19 @@ export default function ContactForm({
                 rel="noopener noreferrer"
                 class="inline-flex items-center gap-2 rounded-lg bg-zenml-500 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-zenml-600 transition-colors"
               >
-                <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                <svg
+                  class="h-4 w-4"
+                  aria-hidden="true"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+                  />
                 </svg>
                 {successDownloadLabel ?? "Download Whitepaper"}
               </a>
@@ -217,13 +249,17 @@ export default function ContactForm({
       >
         {fields.map((field) => (
           <div key={field.name}>
-            <label class="mb-1 block text-sm font-medium text-gray-700">
+            <label
+              for={field.name}
+              class="mb-1 block text-sm font-medium text-gray-700"
+            >
               {field.label}
               {field.required && <span class="text-red-500"> *</span>}
             </label>
 
             {field.type === "select" && field.options ? (
               <select
+                id={field.name}
                 name={field.name}
                 required={field.required}
                 class={`w-full rounded-md border px-4 py-2.5 text-sm focus:border-zenml-500 focus:ring-1 focus:ring-zenml-500 outline-none transition-colors ${
@@ -242,6 +278,7 @@ export default function ContactForm({
             ) : field.type === "checkbox" ? (
               <label class="flex items-start gap-2 text-sm text-gray-600">
                 <input
+                  id={field.name}
                   type="checkbox"
                   name={field.name}
                   value="on"
@@ -257,6 +294,7 @@ export default function ContactForm({
               </label>
             ) : (
               <input
+                id={field.name}
                 type={field.type}
                 name={field.name}
                 required={field.required}
@@ -288,9 +326,25 @@ export default function ContactForm({
         >
           {state === "submitting" ? (
             <span class="inline-flex items-center gap-2">
-              <svg class="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
-                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              <svg
+                class="h-4 w-4 animate-spin"
+                aria-hidden="true"
+                viewBox="0 0 24 24"
+                fill="none"
+              >
+                <circle
+                  class="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  stroke-width="4"
+                />
+                <path
+                  class="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                />
               </svg>
               {loadingLabel}
             </span>

--- a/src/components/islands/CookieConsent.tsx
+++ b/src/components/islands/CookieConsent.tsx
@@ -163,18 +163,27 @@ export default function CookieConsent() {
     <>
       {/* Backdrop for preferences modal */}
       {showPrefs && (
-        <button
-          type="button"
+        <div
           class="fixed inset-0 z-[9998] bg-black/40"
           onClick={() => setShowPrefs(false)}
-          aria-label="Close cookie preferences"
+          aria-hidden="true"
         />
       )}
 
       {/* Preferences modal */}
       {showPrefs && (
-        <div class="fixed inset-x-4 bottom-4 top-auto z-[9999] mx-auto max-w-lg rounded-md border border-gray-200 bg-white p-6 shadow-large sm:inset-x-auto sm:bottom-auto sm:top-1/2 sm:left-1/2 sm:-translate-x-1/2 sm:-translate-y-1/2">
-          <h2 class="text-lg font-bold text-gray-900">Cookie Preferences</h2>
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="cookie-preferences-title"
+          class="fixed inset-x-4 bottom-4 top-auto z-[9999] mx-auto max-w-lg rounded-md border border-gray-200 bg-white p-6 shadow-large sm:inset-x-auto sm:bottom-auto sm:top-1/2 sm:left-1/2 sm:-translate-x-1/2 sm:-translate-y-1/2"
+        >
+          <h2
+            id="cookie-preferences-title"
+            class="text-lg font-bold text-gray-900"
+          >
+            Cookie Preferences
+          </h2>
           <p class="mt-1 text-sm text-gray-500">
             Choose which categories of cookies you'd like to allow.
           </p>

--- a/src/components/islands/CookieConsent.tsx
+++ b/src/components/islands/CookieConsent.tsx
@@ -5,18 +5,20 @@
  * Preferences modal allows per-category toggles.
  * Stores consent in localStorage and dynamically injects scripts.
  */
-import { useState, useEffect, useCallback } from "preact/hooks";
+import { useCallback, useEffect, useState } from "preact/hooks";
 import {
   CONSENT_CATEGORIES,
-  TRACKING_SCRIPTS,
   type ConsentCategory,
   type ScriptDefinition,
+  TRACKING_SCRIPTS,
 } from "../../lib/consentConfig";
 import { isProdHostname } from "../../lib/constants";
 
 const STORAGE_KEY = "cookie_consent";
 
 type ConsentState = Record<ConsentCategory, boolean>;
+type CookieConsentWindow = Window &
+  typeof globalThis & { __cookieConsent?: ConsentState };
 
 const DEFAULT_CONSENT: ConsentState = {
   essential: true,
@@ -52,10 +54,14 @@ function readConsent(): ConsentState | null {
   }
 }
 
+function exposeConsent(consent: ConsentState): void {
+  (window as CookieConsentWindow).__cookieConsent = consent;
+}
+
 function writeConsent(consent: ConsentState): void {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(consent));
   // Expose globally so other scripts can check consent
-  (window as any).__cookieConsent = consent;
+  exposeConsent(consent);
 }
 
 /** Inject a script tag if it hasn't been injected yet. */
@@ -86,7 +92,10 @@ function injectScript(script: ScriptDefinition): void {
 /** Inject all scripts for consented categories. */
 function applyConsent(consent: ConsentState): void {
   // Only inject on production domain (www.zenml.io or apex zenml.io)
-  if (typeof window !== "undefined" && !isProdHostname(window.location.hostname)) {
+  if (
+    typeof window !== "undefined" &&
+    !isProdHostname(window.location.hostname)
+  ) {
     return;
   }
 
@@ -107,7 +116,7 @@ export default function CookieConsent() {
     if (saved) {
       setConsent(saved);
       // Expose saved consent globally so other scripts can read it
-      (window as any).__cookieConsent = saved;
+      exposeConsent(saved);
       applyConsent(saved);
       // Don't show banner — already consented
     } else {
@@ -144,12 +153,9 @@ export default function CookieConsent() {
     setShowPrefs(false);
   }, [consent]);
 
-  const toggleCategory = useCallback(
-    (cat: ConsentCategory) => {
-      setConsent((prev) => ({ ...prev, [cat]: !prev[cat] }));
-    },
-    [],
-  );
+  const toggleCategory = useCallback((cat: ConsentCategory) => {
+    setConsent((prev) => ({ ...prev, [cat]: !prev[cat] }));
+  }, []);
 
   if (!visible) return null;
 
@@ -157,9 +163,11 @@ export default function CookieConsent() {
     <>
       {/* Backdrop for preferences modal */}
       {showPrefs && (
-        <div
+        <button
+          type="button"
           class="fixed inset-0 z-[9998] bg-black/40"
           onClick={() => setShowPrefs(false)}
+          aria-label="Close cookie preferences"
         />
       )}
 
@@ -188,7 +196,9 @@ export default function CookieConsent() {
                   <span class="text-sm font-medium text-gray-900">
                     {cat.label}
                     {cat.required && (
-                      <span class="ml-1 text-xs text-gray-400">(always on)</span>
+                      <span class="ml-1 text-xs text-gray-400">
+                        (always on)
+                      </span>
                     )}
                   </span>
                   <p class="text-xs text-gray-500">{cat.description}</p>
@@ -199,12 +209,14 @@ export default function CookieConsent() {
 
           <div class="mt-5 flex gap-3">
             <button
+              type="button"
               onClick={savePreferences}
               class="flex-1 rounded-lg bg-zenml-500 px-4 py-2.5 text-sm font-semibold text-white hover:bg-zenml-600 transition-colors"
             >
               Save preferences
             </button>
             <button
+              type="button"
               onClick={() => setShowPrefs(false)}
               class="rounded-lg border border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
             >
@@ -219,8 +231,8 @@ export default function CookieConsent() {
         <div class="fixed inset-x-0 bottom-0 z-[9998] border-t border-gray-200 bg-white px-4 py-4 shadow-large sm:px-6">
           <div class="mx-auto flex max-w-5xl flex-col items-center gap-4 sm:flex-row">
             <p class="flex-1 text-sm text-gray-600">
-              We use cookies to improve your experience and analyze site traffic.
-              See our{" "}
+              We use cookies to improve your experience and analyze site
+              traffic. See our{" "}
               <a href="/privacy-policy" class="text-zenml-500 underline">
                 privacy policy
               </a>
@@ -228,18 +240,21 @@ export default function CookieConsent() {
             </p>
             <div class="flex gap-3">
               <button
+                type="button"
                 onClick={() => setShowPrefs(true)}
                 class="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
               >
                 Manage
               </button>
               <button
+                type="button"
                 onClick={rejectAll}
                 class="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
               >
                 Reject all
               </button>
               <button
+                type="button"
                 onClick={acceptAll}
                 class="rounded-lg bg-zenml-500 px-4 py-2 text-sm font-semibold text-white hover:bg-zenml-600 transition-colors"
               >

--- a/src/components/islands/DemoRequestForm.tsx
+++ b/src/components/islands/DemoRequestForm.tsx
@@ -11,14 +11,25 @@
  * - "Cal: Embed Failed" — if Cal.com widget fails to load
  * - "Cal: Booking Confirmed" { date, duration } — on successful booking
  */
-import { useState, useCallback, useEffect, useRef } from "preact/hooks";
-import type { PlaceholderField, CalEmbedConfig } from "../../lib/formTypes";
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
+import type { CalEmbedConfig, PlaceholderField } from "../../lib/formTypes";
 import { validateForm } from "../../lib/formValidation";
 
 type FormState = "idle" | "submitting" | "success" | "error";
 
-type PlausibleFn = (name: string, opts?: { props?: Record<string, string> }) => void;
-const getPlausible = () => (window as unknown as { plausible?: PlausibleFn }).plausible;
+type PlausibleFn = (
+  name: string,
+  opts?: { props?: Record<string, string> },
+) => void;
+type CalNamespaceApi = ((...args: unknown[]) => void) & { q: unknown[][] };
+type CalApi = ((...args: unknown[]) => void) & {
+  loaded: boolean;
+  ns: Record<string, CalNamespaceApi>;
+  q: unknown[][];
+};
+type CalWindow = Window & typeof globalThis & { Cal?: CalApi };
+const getPlausible = () =>
+  (window as unknown as { plausible?: PlausibleFn }).plausible;
 
 interface Props {
   endpoint: string;
@@ -57,7 +68,8 @@ export default function DemoRequestForm({
     if (!turnstileSiteKey) return;
     const SCRIPT_ID = "cf-turnstile-script";
     if (document.getElementById(SCRIPT_ID)) return;
-    const scriptUrl = "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit&onload=onTurnstileLoad";
+    const scriptUrl =
+      "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit&onload=onTurnstileLoad";
     const script = document.createElement("script");
     script.id = SCRIPT_ID;
     script.src = scriptUrl;
@@ -73,7 +85,11 @@ export default function DemoRequestForm({
 
     function renderWidget() {
       if (!turnstileRef.current || turnstileWidgetId.current != null) return;
-      const w = window as unknown as { turnstile?: { render: (el: HTMLElement, opts: Record<string, unknown>) => string } };
+      const w = window as unknown as {
+        turnstile?: {
+          render: (el: HTMLElement, opts: Record<string, unknown>) => string;
+        };
+      };
       if (!w.turnstile) return;
       turnstileWidgetId.current = w.turnstile.render(turnstileRef.current, {
         sitekey: turnstileSiteKey,
@@ -86,7 +102,8 @@ export default function DemoRequestForm({
     if (w.turnstile) {
       renderWidget();
     } else {
-      (window as unknown as Record<string, unknown>).onTurnstileLoad = renderWidget;
+      (window as unknown as Record<string, unknown>).onTurnstileLoad =
+        renderWidget;
     }
   }, [turnstileSiteKey]);
 
@@ -97,12 +114,12 @@ export default function DemoRequestForm({
     // Bootstrap Cal.com's queuing API (same IIFE pattern as CalEmbed.astro).
     // Cal.com's embed uses a command-queue pattern: we define a lightweight
     // Cal() function that queues commands, then the real embed.js replays them.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const win = window as any;
+    const win = window as CalWindow;
 
     if (!win.Cal) {
-      const calFn = function (...args: unknown[]) {
+      const calFn = ((...args: unknown[]) => {
         const cal = win.Cal;
+        if (!cal) return;
         if (!cal.loaded) {
           cal.ns = {};
           cal.q = cal.q || [];
@@ -114,11 +131,11 @@ export default function DemoRequestForm({
         }
         if (args[0] === "init") {
           const ns = args[1] as string;
-          const api = function (...innerArgs: unknown[]) {
+          const api = ((...innerArgs: unknown[]) => {
             api.q = api.q || [];
             api.q.push(innerArgs);
-          };
-          api.q = [] as unknown[][];
+          }) as CalNamespaceApi;
+          api.q = [];
           if (typeof ns === "string") {
             cal.ns[ns] = cal.ns[ns] || api;
             cal.ns[ns].q = cal.ns[ns].q || [];
@@ -128,19 +145,22 @@ export default function DemoRequestForm({
           return;
         }
         cal.q.push(args);
-      };
+      }) as CalApi;
       calFn.loaded = false;
       calFn.ns = {};
-      calFn.q = [] as unknown[];
+      calFn.q = [];
       win.Cal = calFn;
     }
+
+    const cal = win.Cal;
+    if (!cal) return;
 
     const { namespace, elementId, calLink, layout } = calConfig;
     const calLayout = layout ?? "month_view";
 
-    win.Cal("init", namespace, { origin: calOrigin });
+    cal("init", namespace, { origin: calOrigin });
     const prefill = submittedDataRef.current;
-    win.Cal.ns[namespace]("inline", {
+    cal.ns[namespace]("inline", {
       elementOrSelector: `#${elementId}`,
       config: {
         layout: calLayout,
@@ -148,31 +168,42 @@ export default function DemoRequestForm({
       },
       calLink,
     });
-    win.Cal.ns[namespace]("ui", { hideEventTypeDetails: false, layout: calLayout });
+    cal.ns[namespace]("ui", {
+      hideEventTypeDetails: false,
+      layout: calLayout,
+    });
 
     // Plausible tracking callbacks
-    win.Cal.ns[namespace]("on", {
+    cal.ns[namespace]("on", {
       action: "bookingSuccessful",
       callback: (e: unknown) => {
-        const detail = (e as { detail?: { data?: { date?: string; duration?: string } } })?.detail?.data;
+        const detail = (
+          e as { detail?: { data?: { date?: string; duration?: string } } }
+        )?.detail?.data;
         getPlausible()?.("Cal: Booking Confirmed", {
           props: { date: detail?.date || "", duration: detail?.duration || "" },
         });
       },
     });
-    win.Cal.ns[namespace]("on", {
+    cal.ns[namespace]("on", {
       action: "linkReady",
-      callback: () => { getPlausible()?.("Cal: Embed Loaded"); },
+      callback: () => {
+        getPlausible()?.("Cal: Embed Loaded");
+      },
     });
-    win.Cal.ns[namespace]("on", {
+    cal.ns[namespace]("on", {
       action: "linkFailed",
-      callback: () => { getPlausible()?.("Cal: Embed Failed"); },
+      callback: () => {
+        getPlausible()?.("Cal: Embed Failed");
+      },
     });
   }, [state, calConfig, calOrigin, calEmbedScript]);
 
   const resetTurnstile = useCallback(() => {
     if (turnstileWidgetId.current == null) return;
-    const w = window as unknown as { turnstile?: { reset: (id: string) => void } };
+    const w = window as unknown as {
+      turnstile?: { reset: (id: string) => void };
+    };
     w.turnstile?.reset(turnstileWidgetId.current);
   }, []);
 
@@ -188,7 +219,8 @@ export default function DemoRequestForm({
       }
       // Handle unchecked checkboxes
       for (const field of fields) {
-        if (field.type === "checkbox" && !(field.name in data)) data[field.name] = "";
+        if (field.type === "checkbox" && !(field.name in data))
+          data[field.name] = "";
       }
 
       const result = validateForm("demo-request", data);
@@ -221,7 +253,9 @@ export default function DemoRequestForm({
             setState("idle");
             return;
           }
-          setServerError(body.error || "Something went wrong. Please try again.");
+          setServerError(
+            body.error || "Something went wrong. Please try again.",
+          );
           resetTurnstile();
           setState("error");
           return;
@@ -232,7 +266,9 @@ export default function DemoRequestForm({
         };
         setState("success");
       } catch {
-        setServerError("Network error. Please check your connection and try again.");
+        setServerError(
+          "Network error. Please check your connection and try again.",
+        );
         resetTurnstile();
         setState("error");
       }
@@ -243,10 +279,12 @@ export default function DemoRequestForm({
   // ── Success state: seamless Cal.com transition ──
   if (state === "success") {
     return (
-      <div class="demo-form-calendar-transition" style={{ animation: "demoFormSlideUp 0.5s ease both" }}>
+      <div
+        class="demo-form-calendar-transition"
+        style={{ animation: "demoFormSlideUp 0.5s ease both" }}
+      >
         <div
           id={calConfig.elementId}
-
           class="min-h-[600px] w-full overflow-auto"
         />
         <p class="mt-4 text-center text-sm text-gray-500">
@@ -273,12 +311,25 @@ export default function DemoRequestForm({
         </div>
       )}
 
-      <form method="POST" action={endpoint} class="space-y-4" onSubmit={handleSubmit} noValidate>
+      <form
+        method="POST"
+        action={endpoint}
+        class="space-y-4"
+        onSubmit={handleSubmit}
+        noValidate
+      >
         {fields.map((field) => (
-          <FieldRenderer key={field.name} field={field} errors={errors} disabled={state === "submitting"} />
+          <FieldRenderer
+            key={field.name}
+            field={field}
+            errors={errors}
+            disabled={state === "submitting"}
+          />
         ))}
 
-        {turnstileSiteKey && <div ref={turnstileRef} class="flex justify-center" />}
+        {turnstileSiteKey && (
+          <div ref={turnstileRef} class="flex justify-center" />
+        )}
 
         <button
           type="submit"
@@ -287,9 +338,25 @@ export default function DemoRequestForm({
         >
           {state === "submitting" ? (
             <span class="inline-flex items-center gap-2">
-              <svg class="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
-                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              <svg
+                class="h-4 w-4 animate-spin"
+                aria-hidden="true"
+                viewBox="0 0 24 24"
+                fill="none"
+              >
+                <circle
+                  class="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  stroke-width="4"
+                />
+                <path
+                  class="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                />
               </svg>
               {loadingLabel}
             </span>
@@ -324,16 +391,22 @@ function FieldRenderer({
 }) {
   return (
     <div>
-      <label class="mb-1 block text-sm font-medium text-gray-700">
+      <label
+        for={field.name}
+        class="mb-1 block text-sm font-medium text-gray-700"
+      >
         {field.label}
         {field.required && <span class="text-red-500"> *</span>}
       </label>
       {field.type === "select" && field.options ? (
         <select
+          id={field.name}
           name={field.name}
           required={field.required}
           class={`w-full rounded-md border px-4 py-2.5 text-sm focus:border-zenml-500 focus:ring-1 focus:ring-zenml-500 outline-none transition-colors ${
-            errors[field.name] ? "border-red-400 bg-red-50" : "border-gray-300 bg-white"
+            errors[field.name]
+              ? "border-red-400 bg-red-50"
+              : "border-gray-300 bg-white"
           }`}
           disabled={disabled}
         >
@@ -346,6 +419,7 @@ function FieldRenderer({
       ) : field.type === "checkbox" ? (
         <label class="flex items-start gap-2 text-sm text-gray-600">
           <input
+            id={field.name}
             type="checkbox"
             name={field.name}
             value="on"
@@ -353,21 +427,30 @@ function FieldRenderer({
             class="mt-0.5 rounded border-gray-300 text-zenml-500 focus:ring-zenml-500"
             disabled={disabled}
           />
-          <span dangerouslySetInnerHTML={{ __html: field.placeholder ?? field.label }} />
+          <span
+            dangerouslySetInnerHTML={{
+              __html: field.placeholder ?? field.label,
+            }}
+          />
         </label>
       ) : (
         <input
+          id={field.name}
           type={field.type}
           name={field.name}
           required={field.required}
           placeholder={field.placeholder}
           class={`w-full rounded-md border px-4 py-2.5 text-sm focus:border-zenml-500 focus:ring-1 focus:ring-zenml-500 outline-none transition-colors ${
-            errors[field.name] ? "border-red-400 bg-red-50" : "border-gray-300 bg-white"
+            errors[field.name]
+              ? "border-red-400 bg-red-50"
+              : "border-gray-300 bg-white"
           }`}
           disabled={disabled}
         />
       )}
-      {errors[field.name] && <p class="mt-1 text-xs text-red-600">{errors[field.name]}</p>}
+      {errors[field.name] && (
+        <p class="mt-1 text-xs text-red-600">{errors[field.name]}</p>
+      )}
     </div>
   );
 }

--- a/src/components/islands/FeatureTabsSlider.tsx
+++ b/src/components/islands/FeatureTabsSlider.tsx
@@ -8,7 +8,7 @@
  * - Click on a tab resets the timer and progress animation
  * - Respects prefers-reduced-motion
  */
-import { useEffect, useRef, useState, useCallback } from "preact/hooks";
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 
 export interface FeatureTab {
   title: string;
@@ -36,7 +36,7 @@ export default function FeatureTabsSlider({
   // Check reduced-motion preference once on mount
   useEffect(() => {
     prefersReducedMotion.current = window.matchMedia(
-      "(prefers-reduced-motion: reduce)"
+      "(prefers-reduced-motion: reduce)",
     ).matches;
   }, []);
 
@@ -56,7 +56,9 @@ export default function FeatureTabsSlider({
       // Reset all progress bars
       barRefs.current.forEach((bar) => {
         if (!bar) return;
-        bar.getAnimations().forEach((a) => a.cancel());
+        bar.getAnimations().forEach((a) => {
+          a.cancel();
+        });
         bar.style.width = "0%";
       });
 
@@ -77,7 +79,7 @@ export default function FeatureTabsSlider({
         }, autoDurationMs);
       }
     },
-    [autoDurationMs, clearAutoplay, tabs.length]
+    [autoDurationMs, clearAutoplay, tabs.length],
   );
 
   // Restart cycle whenever activeIndex changes
@@ -87,17 +89,18 @@ export default function FeatureTabsSlider({
   }, [activeIndex, startCycle, clearAutoplay]);
 
   // Click handler — switch tab and restart cycle
-  const selectTab = useCallback(
-    (index: number) => {
-      setActiveIndex(index);
-    },
-    []
-  );
+  const selectTab = useCallback((index: number) => {
+    setActiveIndex(index);
+  }, []);
 
   return (
     <div class="tab-slider">
       {/* Left: vertical tab menu */}
-      <div class="tab-slider-menu" role="tablist" aria-label="The ZenML Advantage">
+      <div
+        class="tab-slider-menu"
+        role="tablist"
+        aria-label="The ZenML Advantage"
+      >
         {tabs.map((tab, i) => (
           <button
             key={i}

--- a/src/components/islands/LLMOpsFilter.tsx
+++ b/src/components/islands/LLMOpsFilter.tsx
@@ -14,7 +14,13 @@
  * - Paginated results grid
  * - URL state sync for shareability
  */
-import { useEffect, useMemo, useState, useCallback, useRef } from "preact/hooks";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "preact/hooks";
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -102,7 +108,10 @@ function getPagefind(): Promise<PagefindInstance | null> {
 
 /** Extract slug from a Pagefind result URL like "/llmops-database/my-slug" */
 function slugFromUrl(url: string): string {
-  return url.replace(/^\/llmops-database\//, "").replace(/\.html$/, "").replace(/\/$/, "");
+  return url
+    .replace(/^\/llmops-database\//, "")
+    .replace(/\.html$/, "")
+    .replace(/\/$/, "");
 }
 
 // ── URL State ──────────────────────────────────────────────────────
@@ -117,7 +126,15 @@ interface FilterState {
 }
 
 function parseStateFromUrl(): FilterState {
-  if (typeof window === "undefined") return { q: "", tags: [], industry: "", page: 1, tagMode: "and", sort: "newest" };
+  if (typeof window === "undefined")
+    return {
+      q: "",
+      tags: [],
+      industry: "",
+      page: 1,
+      tagMode: "and",
+      sort: "newest",
+    };
   const params = new URLSearchParams(window.location.search);
   return {
     q: params.get("q") || "",
@@ -125,7 +142,9 @@ function parseStateFromUrl(): FilterState {
     industry: params.get("industry") || "",
     page: Math.max(1, parseInt(params.get("page") || "1", 10) || 1),
     tagMode: (params.get("tagMode") === "or" ? "or" : "and") as TagMode,
-    sort: (["newest", "az", "relevance"].includes(params.get("sort") || "") ? params.get("sort") : "newest") as SortMode,
+    sort: (["newest", "az", "relevance"].includes(params.get("sort") || "")
+      ? params.get("sort")
+      : "newest") as SortMode,
   };
 }
 
@@ -150,7 +169,11 @@ function matchesQuery(item: ProcessedItem, q: string): boolean {
   return item.searchText.includes(q.toLowerCase());
 }
 
-function matchesTags(item: LLMOpsIndexItem, selected: string[], mode: TagMode): boolean {
+function matchesTags(
+  item: LLMOpsIndexItem,
+  selected: string[],
+  mode: TagMode,
+): boolean {
   if (!selected.length) return true;
   return mode === "and"
     ? selected.every((tag) => item.llmopsTags.includes(tag))
@@ -173,7 +196,11 @@ function scoreRelevance(item: ProcessedItem, q: string): number {
 
 // ── Sort Logic ────────────────────────────────────────────────────
 
-function sortItems(items: ProcessedItem[], sort: SortMode, q: string): ProcessedItem[] {
+function sortItems(
+  items: ProcessedItem[],
+  sort: SortMode,
+  q: string,
+): ProcessedItem[] {
   const sorted = [...items];
   switch (sort) {
     case "newest":
@@ -208,10 +235,18 @@ function sortItems(items: ProcessedItem[], sort: SortMode, q: string): Processed
 /** Arrow-key navigation within a facet list (ul > li > button). */
 function handleFacetListKeyDown(e: KeyboardEvent): void {
   const { key } = e;
-  if (key !== "ArrowDown" && key !== "ArrowUp" && key !== "Home" && key !== "End") return;
+  if (
+    key !== "ArrowDown" &&
+    key !== "ArrowUp" &&
+    key !== "Home" &&
+    key !== "End"
+  )
+    return;
 
   const list = e.currentTarget as HTMLElement;
-  const buttons = [...list.querySelectorAll<HTMLButtonElement>("button:not([disabled])")];
+  const buttons = [
+    ...list.querySelectorAll<HTMLButtonElement>("button:not([disabled])"),
+  ];
   if (!buttons.length) return;
 
   const idx = buttons.indexOf(document.activeElement as HTMLButtonElement);
@@ -220,11 +255,20 @@ function handleFacetListKeyDown(e: KeyboardEvent): void {
   e.preventDefault();
   let next: number;
   switch (key) {
-    case "ArrowDown": next = (idx + 1) % buttons.length; break;
-    case "ArrowUp": next = (idx - 1 + buttons.length) % buttons.length; break;
-    case "Home": next = 0; break;
-    case "End": next = buttons.length - 1; break;
-    default: return;
+    case "ArrowDown":
+      next = (idx + 1) % buttons.length;
+      break;
+    case "ArrowUp":
+      next = (idx - 1 + buttons.length) % buttons.length;
+      break;
+    case "Home":
+      next = 0;
+      break;
+    case "End":
+      next = buttons.length - 1;
+      break;
+    default:
+      return;
   }
   buttons[next].focus();
 }
@@ -233,7 +277,14 @@ function handleFacetListKeyDown(e: KeyboardEvent): void {
 
 function SearchIcon() {
   return (
-    <svg class="h-4 w-4 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.67">
+    <svg
+      class="h-4 w-4 text-gray-400"
+      aria-hidden="true"
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.67"
+    >
       <circle cx="9" cy="9" r="6" />
       <path d="M13.5 13.5L17 17" stroke-linecap="round" />
     </svg>
@@ -242,7 +293,14 @@ function SearchIcon() {
 
 function CloseIcon() {
   return (
-    <svg class="h-4 w-4" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2">
+    <svg
+      class="h-4 w-4"
+      aria-hidden="true"
+      viewBox="0 0 12 12"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+    >
       <path d="M3 9L9 3M3 3l6 6" />
     </svg>
   );
@@ -250,7 +308,15 @@ function CloseIcon() {
 
 function FilterIcon() {
   return (
-    <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+    <svg
+      class="h-4 w-4"
+      aria-hidden="true"
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.5"
+      stroke-linecap="round"
+    >
       <path d="M3 5h14M5 10h10M7 15h6" />
     </svg>
   );
@@ -258,11 +324,16 @@ function FilterIcon() {
 
 // ── Focus ring class (DRY) ────────────────────────────────────────
 
-const FOCUS_RING = "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 focus-visible:ring-offset-1";
+const FOCUS_RING =
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 focus-visible:ring-offset-1";
 
 // ── Component ──────────────────────────────────────────────────────
 
-export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOpsFilterProps) {
+export default function LLMOpsFilter({
+  tags,
+  industries,
+  pageSize = 24,
+}: LLMOpsFilterProps) {
   const [items, setItems] = useState<ProcessedItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -292,8 +363,14 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
   const drawerCloseRef = useRef<HTMLButtonElement | null>(null);
 
   // Lookup maps
-  const tagMap = useMemo(() => new Map(tags.map((t) => [t.slug, t.name])), [tags]);
-  const industryMap = useMemo(() => new Map(industries.map((i) => [i.slug, i.name])), [industries]);
+  const tagMap = useMemo(
+    () => new Map(tags.map((t) => [t.slug, t.name])),
+    [tags],
+  );
+  const industryMap = useMemo(
+    () => new Map(industries.map((i) => [i.slug, i.name])),
+    [industries],
+  );
 
   // Fetch data
   useEffect(() => {
@@ -305,7 +382,10 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
       .then((data: LLMOpsIndexItem[]) => {
         const processed = data.map((item) => ({
           ...item,
-          searchText: [item.title, item.company, item.summary].filter(Boolean).join(" ").toLowerCase(),
+          searchText: [item.title, item.company, item.summary]
+            .filter(Boolean)
+            .join(" ")
+            .toLowerCase(),
         }));
         setItems(processed);
         setLoading(false);
@@ -316,7 +396,9 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
       });
 
     // Pre-warm Pagefind (non-blocking)
-    getPagefind().then((pf) => { if (pf) setPagefindAvailable(true); });
+    getPagefind().then((pf) => {
+      if (pf) setPagefindAvailable(true);
+    });
   }, []);
 
   // Pagefind search: query changes → debounced full-text search → relevance-ranked slugs
@@ -345,7 +427,10 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
       setPagefindSlugs(slugs);
     }, 200);
 
-    return () => { cancelled = true; clearTimeout(timer); };
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
   }, [query]);
 
   // Close mobile drawer on escape + restore focus
@@ -365,14 +450,18 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
     } else {
       document.body.style.overflow = "";
     }
-    return () => { document.body.style.overflow = ""; };
+    return () => {
+      document.body.style.overflow = "";
+    };
   }, [mobileDrawerOpen]);
 
   // Focus management: focus close button on open, restore on close
   useEffect(() => {
     if (mobileDrawerOpen) {
       // Focus the close button after the drawer animates in
-      requestAnimationFrame(() => { drawerCloseRef.current?.focus(); });
+      requestAnimationFrame(() => {
+        drawerCloseRef.current?.focus();
+      });
     } else {
       // Restore focus to the filter button when drawer closes
       mobileFiltersButtonRef.current?.focus();
@@ -396,7 +485,7 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
   const tagCounts = useMemo(() => {
     const usePagefind = pagefindAvailable && query && pagefindSlugSet !== null;
     const base = items.filter((item) => {
-      if (usePagefind && !pagefindSlugSet!.has(item.slug)) return false;
+      if (usePagefind && !pagefindSlugSet?.has(item.slug)) return false;
       if (!usePagefind && !matchesQuery(item, query)) return false;
       return matchesIndustry(item, selectedIndustry);
     });
@@ -413,7 +502,7 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
   const industryCounts = useMemo(() => {
     const usePagefind = pagefindAvailable && query && pagefindSlugSet !== null;
     const base = items.filter((item) => {
-      if (usePagefind && !pagefindSlugSet!.has(item.slug)) return false;
+      if (usePagefind && !pagefindSlugSet?.has(item.slug)) return false;
       if (!usePagefind && !matchesQuery(item, query)) return false;
       return matchesTags(item, selectedTags, tagMode);
     });
@@ -431,7 +520,8 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
   // slugs as the primary result set; apply tag/industry filters on top.
   // When Pagefind is unavailable (dev mode), fall back to substring matchesQuery().
   const filtered = useMemo(() => {
-    const usePagefindResults = pagefindAvailable && query && pagefindSlugs !== null;
+    const usePagefindResults =
+      pagefindAvailable && query && pagefindSlugs !== null;
 
     let matched: ProcessedItem[];
     if (usePagefindResults) {
@@ -455,15 +545,27 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
     }
 
     // Sort — for relevance with Pagefind, preserve Pagefind's ordering
-    if (usePagefindResults && sort === "relevance") {
-      const slugOrder = new Map(pagefindSlugs!.map((s, i) => [s, i]));
-      matched.sort((a, b) => (slugOrder.get(a.slug) ?? 9999) - (slugOrder.get(b.slug) ?? 9999));
+    if (usePagefindResults && pagefindSlugs && sort === "relevance") {
+      const slugOrder = new Map(pagefindSlugs.map((s, i) => [s, i]));
+      matched.sort(
+        (a, b) =>
+          (slugOrder.get(a.slug) ?? 9999) - (slugOrder.get(b.slug) ?? 9999),
+      );
     } else {
       matched = sortItems(matched, sort, query);
     }
 
     return matched;
-  }, [items, query, selectedTags, selectedIndustry, tagMode, sort, pagefindSlugs, pagefindAvailable]);
+  }, [
+    items,
+    query,
+    selectedTags,
+    selectedIndustry,
+    tagMode,
+    sort,
+    pagefindSlugs,
+    pagefindAvailable,
+  ]);
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
   const safePage = Math.min(page, totalPages);
@@ -493,7 +595,14 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
 
   // Sync URL
   useEffect(() => {
-    writeStateToUrl({ q: query, tags: selectedTags, industry: selectedIndustry, page: safePage, tagMode, sort });
+    writeStateToUrl({
+      q: query,
+      tags: selectedTags,
+      industry: selectedIndustry,
+      page: safePage,
+      tagMode,
+      sort,
+    });
   }, [query, selectedTags, selectedIndustry, safePage, tagMode, sort]);
 
   // Helpers
@@ -503,14 +612,17 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
     const newQuery = (e.target as HTMLInputElement).value;
     setQuery(newQuery);
     // Auto-switch to relevance sort when user starts typing (if Pagefind available)
-    if (newQuery && pagefindAvailable && sort !== "relevance") setSort("relevance");
+    if (newQuery && pagefindAvailable && sort !== "relevance")
+      setSort("relevance");
     // Revert to newest when query is cleared
     if (!newQuery && sort === "relevance") setSort("newest");
     resetPage();
   };
 
   const toggleTag = (slug: string) => {
-    setSelectedTags((prev) => (prev.includes(slug) ? prev.filter((t) => t !== slug) : [...prev, slug]));
+    setSelectedTags((prev) =>
+      prev.includes(slug) ? prev.filter((t) => t !== slug) : [...prev, slug],
+    );
     resetPage();
   };
 
@@ -533,7 +645,9 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
   // Tags to show in sidebar (with search + expand)
   const sidebarTags = useMemo(() => {
     // Sort tags by contextual count descending
-    const sorted = [...tags].sort((a, b) => (tagCounts.get(b.slug) || 0) - (tagCounts.get(a.slug) || 0));
+    const sorted = [...tags].sort(
+      (a, b) => (tagCounts.get(b.slug) || 0) - (tagCounts.get(a.slug) || 0),
+    );
 
     if (sidebarTagSearch) {
       const lower = sidebarTagSearch.toLowerCase();
@@ -552,7 +666,9 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
       <div class="space-y-6">
         {/* Industry facet */}
         <div>
-          <h3 class="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-400">Industry</h3>
+          <h3 class="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-400">
+            Industry
+          </h3>
           <ul class="space-y-1" onKeyDown={handleFacetListKeyDown}>
             {industries.map((ind) => {
               const count = industryCounts.get(ind.slug) || 0;
@@ -573,7 +689,9 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
                     disabled={count === 0 && !isSelected}
                   >
                     <span class="truncate">{ind.name}</span>
-                    <span class={`ml-2 text-xs tabular-nums ${isSelected ? "text-purple-500" : "text-gray-400"}`}>
+                    <span
+                      class={`ml-2 text-xs tabular-nums ${isSelected ? "text-purple-500" : "text-gray-400"}`}
+                    >
                       {count}
                     </span>
                   </button>
@@ -585,19 +703,26 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
 
         {/* Technology facet */}
         <div>
-          <h3 class="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-400">Technologies</h3>
+          <h3 class="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-400">
+            Technologies
+          </h3>
 
           {/* Tag search within sidebar */}
           <div class="relative mb-2">
             <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-2.5">
               <SearchIcon />
             </div>
-            <label for={tagSearchId} class="sr-only">Search technologies</label>
+            <label for={tagSearchId} class="sr-only">
+              Search technologies
+            </label>
             <input
               id={tagSearchId}
               type="search"
               value={sidebarTagSearch}
-              onInput={(e) => { setSidebarTagSearch((e.target as HTMLInputElement).value); setShowAllTags(true); }}
+              onInput={(e) => {
+                setSidebarTagSearch((e.target as HTMLInputElement).value);
+                setShowAllTags(true);
+              }}
               placeholder="Search tags..."
               class={`w-full rounded-md border border-gray-200 py-1.5 pl-8 pr-3 text-sm placeholder-gray-400 focus:border-primary-600 focus:outline-none focus:ring-1 focus:ring-primary-600`}
             />
@@ -622,7 +747,9 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
                     }`}
                   >
                     <span class="truncate">{tag.name}</span>
-                    <span class={`ml-2 text-xs tabular-nums ${isSelected ? "text-blue-500" : "text-gray-400"}`}>
+                    <span
+                      class={`ml-2 text-xs tabular-nums ${isSelected ? "text-blue-500" : "text-gray-400"}`}
+                    >
                       {count}
                     </span>
                   </button>
@@ -664,14 +791,16 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
     const isAndMode = tagMode === "and";
 
     return (
-      <div class="rounded-lg border border-gray-200 bg-gray-50 py-16 text-center" role="status">
+      <output class="block rounded-lg border border-gray-200 bg-gray-50 py-16 text-center">
         <div class="mx-auto max-w-md px-4">
-          <p class="text-lg font-medium text-gray-700">No entries match your filters</p>
+          <p class="text-lg font-medium text-gray-700">
+            No entries match your filters
+          </p>
           <p class="mt-2 text-sm text-gray-500">
             {hasTags && hasIndustry && hasQuery
               ? "Try removing some filters to broaden your search."
               : hasTags && isAndMode && selectedTags.length > 1
-                ? "These tags don't overlap. Try switching to \"Match Any\" mode."
+                ? 'These tags don\'t overlap. Try switching to "Match Any" mode.'
                 : hasQuery
                   ? `No results for "${query}". Try different search terms.`
                   : "Try adjusting your filter selections."}
@@ -681,7 +810,10 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
               <button
                 type="button"
                 class={`rounded-md border border-primary-200 bg-primary-50 px-3 py-1.5 text-sm font-medium text-primary-700 hover:bg-primary-100 ${FOCUS_RING}`}
-                onClick={() => { setTagMode("or"); resetPage(); }}
+                onClick={() => {
+                  setTagMode("or");
+                  resetPage();
+                }}
               >
                 Switch to Match Any
               </button>
@@ -690,7 +822,10 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
               <button
                 type="button"
                 class={`rounded-md border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-600 hover:bg-gray-100 ${FOCUS_RING}`}
-                onClick={() => { setSelectedTags([]); resetPage(); }}
+                onClick={() => {
+                  setSelectedTags([]);
+                  resetPage();
+                }}
               >
                 Clear tags
               </button>
@@ -699,7 +834,10 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
               <button
                 type="button"
                 class={`rounded-md border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-600 hover:bg-gray-100 ${FOCUS_RING}`}
-                onClick={() => { setSelectedIndustry(""); resetPage(); }}
+                onClick={() => {
+                  setSelectedIndustry("");
+                  resetPage();
+                }}
               >
                 Clear industry
               </button>
@@ -708,7 +846,10 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
               <button
                 type="button"
                 class={`rounded-md border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-600 hover:bg-gray-100 ${FOCUS_RING}`}
-                onClick={() => { setQuery(""); resetPage(); }}
+                onClick={() => {
+                  setQuery("");
+                  resetPage();
+                }}
               >
                 Clear search
               </button>
@@ -725,13 +866,18 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
           {/* Suggest popular tags */}
           {popularTags.length > 0 && (
             <div class="mt-6">
-              <p class="mb-2 text-xs font-medium text-gray-400">Popular tags to explore:</p>
+              <p class="mb-2 text-xs font-medium text-gray-400">
+                Popular tags to explore:
+              </p>
               <div class="flex flex-wrap justify-center gap-1.5">
                 {popularTags.slice(0, 6).map((slug) => (
                   <button
                     key={slug}
                     type="button"
-                    onClick={() => { clearAll(); toggleTag(slug); }}
+                    onClick={() => {
+                      clearAll();
+                      toggleTag(slug);
+                    }}
                     class={`rounded-full bg-blue-50 px-2.5 py-1 text-xs font-medium text-blue-700 hover:bg-blue-100 ${FOCUS_RING}`}
                   >
                     {tagMap.get(slug) || slug}
@@ -741,7 +887,7 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
             </div>
           )}
         </div>
-      </div>
+      </output>
     );
   };
 
@@ -749,18 +895,21 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
 
   if (loading) {
     return (
-      <div class="flex items-center justify-center py-20" role="status">
+      <output class="flex items-center justify-center py-20">
         <div class="text-center">
           <div class="mx-auto h-8 w-8 animate-spin rounded-full border-2 border-gray-300 border-t-primary-600" />
           <p class="mt-4 text-sm text-gray-500">Loading LLMOps database...</p>
         </div>
-      </div>
+      </output>
     );
   }
 
   if (error) {
     return (
-      <div class="rounded-lg border border-red-200 bg-red-50 p-6 text-center" role="alert">
+      <div
+        class="rounded-lg border border-red-200 bg-red-50 p-6 text-center"
+        role="alert"
+      >
         <p class="text-sm text-red-700">Failed to load data: {error}</p>
         <button
           type="button"
@@ -786,9 +935,11 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
 
       {/* Mobile drawer backdrop */}
       {mobileDrawerOpen && (
-        <div
+        <button
+          type="button"
           class="fixed inset-0 z-40 bg-black/30 lg:hidden"
           onClick={() => setMobileDrawerOpen(false)}
+          aria-label="Close filters"
         />
       )}
 
@@ -806,7 +957,9 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
       >
         <div class="flex h-full flex-col">
           <div class="flex items-center justify-between border-b border-gray-200 px-4 py-3">
-            <h2 id={MOBILE_DRAWER_TITLE_ID} class="font-semibold text-gray-900">Filters</h2>
+            <h2 id={MOBILE_DRAWER_TITLE_ID} class="font-semibold text-gray-900">
+              Filters
+            </h2>
             <button
               ref={drawerCloseRef}
               type="button"
@@ -859,7 +1012,9 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
             <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
               <SearchIcon />
             </div>
-            <label for="llmops-search" class="sr-only">Search</label>
+            <label for="llmops-search" class="sr-only">
+              Search
+            </label>
             <input
               id="llmops-search"
               type="search"
@@ -871,11 +1026,16 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
           </div>
 
           {/* AND/OR toggle — native radio inputs for accessibility */}
-          <fieldset class="flex items-center gap-1 rounded-lg border border-gray-300 p-1" aria-label="Tag match mode">
+          <fieldset
+            class="flex items-center gap-1 rounded-lg border border-gray-300 p-1"
+            aria-label="Tag match mode"
+          >
             <legend class="sr-only">Tag match mode</legend>
             <label
               class={`cursor-pointer rounded-md px-3 py-1.5 text-xs font-medium transition-colors has-[:focus-visible]:outline-none has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-primary-600 ${
-                tagMode === "and" ? "bg-gray-900 text-white" : "text-gray-600 hover:bg-gray-100"
+                tagMode === "and"
+                  ? "bg-gray-900 text-white"
+                  : "text-gray-600 hover:bg-gray-100"
               }`}
             >
               <input
@@ -883,14 +1043,19 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
                 name="tagMode"
                 value="and"
                 checked={tagMode === "and"}
-                onChange={() => { setTagMode("and"); resetPage(); }}
+                onChange={() => {
+                  setTagMode("and");
+                  resetPage();
+                }}
                 class="sr-only"
               />
               Match All
             </label>
             <label
               class={`cursor-pointer rounded-md px-3 py-1.5 text-xs font-medium transition-colors has-[:focus-visible]:outline-none has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-primary-600 ${
-                tagMode === "or" ? "bg-gray-900 text-white" : "text-gray-600 hover:bg-gray-100"
+                tagMode === "or"
+                  ? "bg-gray-900 text-white"
+                  : "text-gray-600 hover:bg-gray-100"
               }`}
             >
               <input
@@ -898,7 +1063,10 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
                 name="tagMode"
                 value="or"
                 checked={tagMode === "or"}
-                onChange={() => { setTagMode("or"); resetPage(); }}
+                onChange={() => {
+                  setTagMode("or");
+                  resetPage();
+                }}
                 class="sr-only"
               />
               Match Any
@@ -907,11 +1075,16 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
 
           {/* Sort dropdown */}
           <div class="sm:w-40">
-            <label for="llmops-sort" class="sr-only">Sort</label>
+            <label for="llmops-sort" class="sr-only">
+              Sort
+            </label>
             <select
               id="llmops-sort"
               value={sort}
-              onChange={(e) => { setSort((e.target as HTMLSelectElement).value as SortMode); resetPage(); }}
+              onChange={(e) => {
+                setSort((e.target as HTMLSelectElement).value as SortMode);
+                resetPage();
+              }}
               class="w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-700 transition-colors focus:border-primary-600 focus:outline-none focus:ring-1 focus:ring-primary-600"
             >
               <option value="newest">Newest first</option>
@@ -975,14 +1148,18 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
         )}
 
         {/* Results count — live region for screen readers */}
-        <div class="mb-4 text-sm text-gray-500" role="status" aria-live="polite" aria-atomic="true">
+        <output
+          class="mb-4 block text-sm text-gray-500"
+          aria-live="polite"
+          aria-atomic="true"
+        >
           <span aria-hidden="true">
             {filtered.length === items.length
               ? `${items.length} entries`
               : `${filtered.length} of ${items.length} entries`}
           </span>
           <span class="sr-only">{resultsStatusText}</span>
-        </div>
+        </output>
 
         {/* Results grid */}
         {paged.length === 0 ? (
@@ -990,10 +1167,22 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
         ) : (
           <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
             {paged.map((item) => (
+              // biome-ignore lint/a11y/useSemanticElements: This clickable card contains tag buttons, so it cannot safely become a single anchor.
               <div
                 key={item.slug}
                 class="group flex cursor-pointer flex-col rounded-lg border border-gray-200 bg-white p-5 transition-shadow hover:shadow-md"
-                onClick={() => { window.location.href = `/llmops-database/${item.slug}`; }}
+                role="link"
+                tabIndex={0}
+                onClick={() => {
+                  window.location.href = `/llmops-database/${item.slug}`;
+                }}
+                onKeyDown={(e: KeyboardEvent) => {
+                  if (e.target !== e.currentTarget) return;
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    window.location.href = `/llmops-database/${item.slug}`;
+                  }
+                }}
               >
                 <a
                   href={`/llmops-database/${item.slug}`}
@@ -1004,7 +1193,11 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
                 </a>
 
                 <div class="mt-2 flex flex-wrap items-center gap-2 text-xs text-gray-500">
-                  {item.company && <span class="font-medium text-gray-700">{item.company}</span>}
+                  {item.company && (
+                    <span class="font-medium text-gray-700">
+                      {item.company}
+                    </span>
+                  )}
                   {item.year && (
                     <>
                       {item.company && <span aria-hidden="true">&middot;</span>}
@@ -1017,17 +1210,24 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
                       <button
                         type="button"
                         class={`rounded-full bg-purple-50 px-2 py-0.5 text-purple-700 transition-colors hover:bg-purple-100 ${FOCUS_RING}`}
-                        onClick={(e: MouseEvent) => { e.stopPropagation(); selectIndustry(item.industryTags!); }}
+                        onClick={(e: MouseEvent) => {
+                          e.stopPropagation();
+                          const industryTag = item.industryTags;
+                          if (industryTag) selectIndustry(industryTag);
+                        }}
                         aria-label={`Filter by ${industryMap.get(item.industryTags) || item.industryTags}`}
                       >
-                        {industryMap.get(item.industryTags) || item.industryTags}
+                        {industryMap.get(item.industryTags) ||
+                          item.industryTags}
                       </button>
                     </>
                   )}
                 </div>
 
                 {item.summary && (
-                  <p class="mt-2 text-sm text-gray-600 line-clamp-2">{item.summary}</p>
+                  <p class="mt-2 text-sm text-gray-600 line-clamp-2">
+                    {item.summary}
+                  </p>
                 )}
 
                 {item.llmopsTags.length > 0 && (
@@ -1040,8 +1240,15 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
                           type="button"
                           data-tag-chip
                           aria-pressed={isSelected}
-                          aria-label={isSelected ? `Remove filter ${tagMap.get(tagSlug) || tagSlug}` : `Filter by ${tagMap.get(tagSlug) || tagSlug}`}
-                          onClick={(e: MouseEvent) => { e.stopPropagation(); toggleTag(tagSlug); }}
+                          aria-label={
+                            isSelected
+                              ? `Remove filter ${tagMap.get(tagSlug) || tagSlug}`
+                              : `Filter by ${tagMap.get(tagSlug) || tagSlug}`
+                          }
+                          onClick={(e: MouseEvent) => {
+                            e.stopPropagation();
+                            toggleTag(tagSlug);
+                          }}
                           class={`rounded-full px-2 py-0.5 text-xs transition-colors ${FOCUS_RING} ${
                             isSelected
                               ? "bg-primary-600 text-white"
@@ -1066,7 +1273,10 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
 
         {/* Pagination */}
         {totalPages > 1 && (
-          <nav class="mt-8 flex items-center justify-center gap-2" aria-label="Pagination">
+          <nav
+            class="mt-8 flex items-center justify-center gap-2"
+            aria-label="Pagination"
+          >
             <button
               type="button"
               disabled={safePage <= 1}
@@ -1092,7 +1302,13 @@ export default function LLMOpsFilter({ tags, industries, pageSize = 24 }: LLMOps
               }
               return pages.map((p, i) =>
                 p === "..." ? (
-                  <span key={`e${i}`} class="px-1 text-gray-400" aria-hidden="true">&hellip;</span>
+                  <span
+                    key={`e${i}`}
+                    class="px-1 text-gray-400"
+                    aria-hidden="true"
+                  >
+                    &hellip;
+                  </span>
                 ) : (
                   <button
                     key={p}

--- a/src/components/islands/LLMOpsFilter.tsx
+++ b/src/components/islands/LLMOpsFilter.tsx
@@ -1167,27 +1167,13 @@ export default function LLMOpsFilter({
         ) : (
           <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
             {paged.map((item) => (
-              // biome-ignore lint/a11y/useSemanticElements: This clickable card contains tag buttons, so it cannot safely become a single anchor.
               <div
                 key={item.slug}
-                class="group flex cursor-pointer flex-col rounded-lg border border-gray-200 bg-white p-5 transition-shadow hover:shadow-md"
-                role="link"
-                tabIndex={0}
-                onClick={() => {
-                  window.location.href = `/llmops-database/${item.slug}`;
-                }}
-                onKeyDown={(e: KeyboardEvent) => {
-                  if (e.target !== e.currentTarget) return;
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    window.location.href = `/llmops-database/${item.slug}`;
-                  }
-                }}
+                class="group flex flex-col rounded-lg border border-gray-200 bg-white p-5 transition-shadow hover:shadow-md"
               >
                 <a
                   href={`/llmops-database/${item.slug}`}
                   class={`font-semibold text-gray-900 group-hover:text-primary-600 line-clamp-2 ${FOCUS_RING}`}
-                  onClick={(e: MouseEvent) => e.stopPropagation()}
                 >
                   {item.title}
                 </a>
@@ -1210,8 +1196,7 @@ export default function LLMOpsFilter({
                       <button
                         type="button"
                         class={`rounded-full bg-purple-50 px-2 py-0.5 text-purple-700 transition-colors hover:bg-purple-100 ${FOCUS_RING}`}
-                        onClick={(e: MouseEvent) => {
-                          e.stopPropagation();
+                        onClick={() => {
                           const industryTag = item.industryTags;
                           if (industryTag) selectIndustry(industryTag);
                         }}
@@ -1245,8 +1230,7 @@ export default function LLMOpsFilter({
                               ? `Remove filter ${tagMap.get(tagSlug) || tagSlug}`
                               : `Filter by ${tagMap.get(tagSlug) || tagSlug}`
                           }
-                          onClick={(e: MouseEvent) => {
-                            e.stopPropagation();
+                          onClick={() => {
                             toggleTag(tagSlug);
                           }}
                           class={`rounded-full px-2 py-0.5 text-xs transition-colors ${FOCUS_RING} ${

--- a/src/components/islands/ProTestimonialCarousel.tsx
+++ b/src/components/islands/ProTestimonialCarousel.tsx
@@ -7,7 +7,7 @@
  *  - arrow buttons (bottom-right) + dot indicators
  *  - card: white bg, primary-50 border, 1rem radius, 2rem padding
  */
-import { useState, useEffect, useRef, useCallback } from "preact/hooks";
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 
 export interface CarouselTestimonial {
   quote: string;
@@ -92,8 +92,9 @@ export default function ProTestimonialCarousel({
   const slideWidthPercent = 100 / slidesPerView;
 
   return (
-    <div
+    <section
       class="relative"
+      aria-label="Testimonials carousel"
       onMouseEnter={pauseAutoplay}
       onMouseLeave={resumeAutoplay}
     >
@@ -150,6 +151,7 @@ export default function ProTestimonialCarousel({
           {Array.from({ length: dotCount }).map((_, i) => (
             <button
               key={i}
+              type="button"
               onClick={() => goTo(i)}
               aria-label={`Go to slide ${i + 1}`}
               class={`h-2.5 w-2.5 rounded-full transition-colors ${
@@ -164,12 +166,14 @@ export default function ProTestimonialCarousel({
         {/* Arrows */}
         <div class="flex items-center gap-2">
           <button
+            type="button"
             onClick={prev}
             aria-label="Previous testimonials"
             class="flex h-12 w-12 items-center justify-center rounded-full border border-gray-200 bg-white transition-colors hover:bg-gray-50"
           >
             <svg
               class="h-5 w-5 text-gray-700"
+              aria-hidden="true"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -183,12 +187,14 @@ export default function ProTestimonialCarousel({
             </svg>
           </button>
           <button
+            type="button"
             onClick={next}
             aria-label="Next testimonials"
             class="flex h-12 w-12 items-center justify-center rounded-full border border-gray-200 bg-white transition-colors hover:bg-gray-50"
           >
             <svg
               class="h-5 w-5 text-gray-700"
+              aria-hidden="true"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -203,6 +209,6 @@ export default function ProTestimonialCarousel({
           </button>
         </div>
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/components/islands/RoiCalculator.tsx
+++ b/src/components/islands/RoiCalculator.tsx
@@ -2,8 +2,9 @@
  * ROI Calculator — interactive Preact island with three sliders and a results panel.
  * Ported from the Webflow site's embedded calculator widget.
  */
-import { useState, useCallback } from "preact/hooks";
+
 import type { CSSProperties } from "preact";
+import { useCallback, useState } from "preact/hooks";
 import { calculateRoi, type RoiOutputs } from "../../lib/roiCalculator";
 
 // ── Slider config ──────────────────────────────────────────────────
@@ -71,12 +72,9 @@ export default function RoiCalculator() {
     cloudSpendMonthly: values.spend,
   });
 
-  const handleChange = useCallback(
-    (id: string, val: number) => {
-      setValues((prev) => ({ ...prev, [id]: val }));
-    },
-    [],
-  );
+  const handleChange = useCallback((id: string, val: number) => {
+    setValues((prev) => ({ ...prev, [id]: val }));
+  }, []);
 
   return (
     <div style={styles.container}>
@@ -142,8 +140,7 @@ interface SliderInputProps {
 }
 
 function SliderInput({ config, value, onChange }: SliderInputProps) {
-  const pct =
-    ((value - config.min) / (config.max - config.min)) * 100;
+  const pct = ((value - config.min) / (config.max - config.min)) * 100;
 
   return (
     <div style={styles.inputGroup}>
@@ -159,7 +156,7 @@ function SliderInput({ config, value, onChange }: SliderInputProps) {
           step={config.step}
           value={value}
           onInput={(e) =>
-            onChange(parseInt((e.target as HTMLInputElement).value))
+            onChange(parseInt((e.target as HTMLInputElement).value, 10))
           }
           style={{
             ...styles.slider,

--- a/src/components/sections/CalEmbed.astro
+++ b/src/components/sections/CalEmbed.astro
@@ -1,4 +1,5 @@
 ---
+import { CAL_EMBED_SCRIPT, CAL_ORIGIN } from "../../lib/formConstants";
 /**
  * CalEmbed — Cal.com inline calendar widget.
  *
@@ -6,7 +7,6 @@
  * in the target div. Includes a fallback link for ad-blocker users.
  */
 import type { CalEmbedConfig } from "../../lib/formTypes";
-import { CAL_ORIGIN, CAL_EMBED_SCRIPT } from "../../lib/formConstants";
 
 interface Props {
   config: CalEmbedConfig;

--- a/src/components/sections/CaseStudySidebar.astro
+++ b/src/components/sections/CaseStudySidebar.astro
@@ -16,7 +16,15 @@ interface Props {
   pdfDownload?: { label: string; href: string };
 }
 
-const { company, website, mlTeamSize, cloudProvider, industry, useCases, pdfDownload } = Astro.props;
+const {
+  company,
+  website,
+  mlTeamSize,
+  cloudProvider,
+  industry,
+  useCases,
+  pdfDownload,
+} = Astro.props;
 ---
 
 <aside class="rounded-2xl border border-gray-200 bg-gray-50 p-6 lg:p-8">

--- a/src/components/sections/ComparisonTable.astro
+++ b/src/components/sections/ComparisonTable.astro
@@ -10,7 +10,8 @@ import type { ComparisonTableData } from "../../lib/marketingPageTypes";
 
 interface Props extends ComparisonTableData {}
 
-const { eyebrow, headline, subheadline, columnHeaders, headerColors, rows } = Astro.props;
+const { eyebrow, headline, subheadline, columnHeaders, headerColors, rows } =
+  Astro.props;
 const hasIcons = rows.some((r) => r.icon);
 ---
 

--- a/src/components/sections/CustomerStories.astro
+++ b/src/components/sections/CustomerStories.astro
@@ -8,8 +8,8 @@
  *   3. 6 curated testimonials in a 3×2 grid (company logo, quote, avatar)
  */
 import {
-  CUSTOMER_STORIES_HEADER,
   CASE_STUDY_CARDS,
+  CUSTOMER_STORIES_HEADER,
   HOMEPAGE_TESTIMONIALS,
   LLMOPS_BANNER,
 } from "../../lib/homepage";

--- a/src/components/sections/FeatureTabs.astro
+++ b/src/components/sections/FeatureTabs.astro
@@ -6,7 +6,7 @@
  * tab slider (Preact island) matching the original Webflow layout:
  * vertical left menu (40%) + right image panel (60%) with gradient bg.
  */
-import { FEATURE_TABS_HEADER, FEATURE_TABS, STATS } from "../../lib/homepage";
+import { FEATURE_TABS, FEATURE_TABS_HEADER, STATS } from "../../lib/homepage";
 import FeatureTabsSlider from "../islands/FeatureTabsSlider";
 ---
 

--- a/src/components/sections/FeatureValueSection.astro
+++ b/src/components/sections/FeatureValueSection.astro
@@ -19,7 +19,16 @@ interface Props {
   imageSide?: "left" | "right";
 }
 
-const { eyebrow, title, body, bullets, learnMoreHref, learnMoreLabel = "Learn More", image, imageSide = "right" } = Astro.props;
+const {
+  eyebrow,
+  title,
+  body,
+  bullets,
+  learnMoreHref,
+  learnMoreLabel = "Learn More",
+  image,
+  imageSide = "right",
+} = Astro.props;
 const isImageLeft = imageSide === "left";
 ---
 

--- a/src/components/sections/FeaturesHubCTA.astro
+++ b/src/components/sections/FeaturesHubCTA.astro
@@ -1,4 +1,5 @@
 ---
+import type { CtaLink } from "../../lib/marketingPageTypes";
 /**
  * FeaturesHubCTA — dark CTA band at the bottom of the features hub.
  *
@@ -6,7 +7,6 @@
  * Used on /features page.
  */
 import Button from "../Button.astro";
-import type { CtaLink } from "../../lib/marketingPageTypes";
 
 interface Props {
   headline: string;

--- a/src/components/sections/NewsletterSignup.astro
+++ b/src/components/sections/NewsletterSignup.astro
@@ -1,4 +1,5 @@
 ---
+import { BREVO_MAIN_CONFIG } from "../../lib/formConstants";
 /**
  * NewsletterSignup — email signup in a purple rounded card matching Webflow.
  *
@@ -6,7 +7,6 @@
  * Used on the homepage and potentially other pages.
  */
 import { NEWSLETTER } from "../../lib/homepage";
-import { BREVO_MAIN_CONFIG } from "../../lib/formConstants";
 import BrevoNewsletterForm from "./BrevoNewsletterForm.astro";
 
 const privacyHtml = `${NEWSLETTER.privacyNote} <a href="${NEWSLETTER.privacyLink.href}" class="text-white/90 underline hover:text-white">${NEWSLETTER.privacyLink.label}</a>.`;

--- a/src/components/sections/ProFeaturedTestimonial09.astro
+++ b/src/components/sections/ProFeaturedTestimonial09.astro
@@ -18,7 +18,8 @@ interface Props {
   companyLogoAlt?: string;
 }
 
-const { quote, name, title, image, imageAlt, companyLogo, companyLogoAlt } = Astro.props;
+const { quote, name, title, image, imageAlt, companyLogo, companyLogoAlt } =
+  Astro.props;
 ---
 
 <section class="bg-white py-8 sm:py-12">

--- a/src/components/sections/ProTestimonial15Section.astro
+++ b/src/components/sections/ProTestimonial15Section.astro
@@ -1,4 +1,5 @@
 ---
+import type { CarouselTestimonial } from "../islands/ProTestimonialCarousel";
 /**
  * ProTestimonial15Section — wrapper for the testimonial carousel island.
  *
@@ -6,7 +7,6 @@
  * with client:visible for deferred hydration.
  */
 import ProTestimonialCarousel from "../islands/ProTestimonialCarousel";
-import type { CarouselTestimonial } from "../islands/ProTestimonialCarousel";
 
 interface Props {
   testimonials: ReadonlyArray<CarouselTestimonial>;

--- a/src/components/sections/VsCta02.astro
+++ b/src/components/sections/VsCta02.astro
@@ -20,11 +20,20 @@ interface Props {
   padded?: boolean;
 }
 
-const { headline, bullets, primaryCta, secondaryCta, image, variant = "dark", padded = false } = Astro.props;
+const {
+  headline,
+  bullets,
+  primaryCta,
+  secondaryCta,
+  image,
+  variant = "dark",
+  padded = false,
+} = Astro.props;
 
-const bgClass = variant === "gradient"
-  ? "bg-primary-700 bg-[url('/images/gradient_01.webp')] bg-cover bg-center"
-  : "bg-gray-900";
+const bgClass =
+  variant === "gradient"
+    ? "bg-primary-700 bg-[url('/images/gradient_01.webp')] bg-cover bg-center"
+    : "bg-gray-900";
 const paddingClass = padded ? "py-20 sm:py-28" : "py-16 sm:py-20";
 ---
 

--- a/src/components/sections/VsRelatedCompareGrid.astro
+++ b/src/components/sections/VsRelatedCompareGrid.astro
@@ -9,7 +9,11 @@
 interface Props {
   eyebrow?: string;
   headline?: string;
-  items: { title: string; href: string; toolIcon?: { url: string; alt?: string } }[];
+  items: {
+    title: string;
+    href: string;
+    toolIcon?: { url: string; alt?: string };
+  }[];
 }
 
 const { eyebrow, headline, items } = Astro.props;

--- a/src/components/sections/compare/CompareCodeComparison.astro
+++ b/src/components/sections/compare/CompareCodeComparison.astro
@@ -7,6 +7,7 @@
  *
  * Uses Astro's built-in Code component for Shiki syntax highlighting.
  */
+// biome-ignore lint/style/useImportType: Astro component import is used in the template below.
 import { Code } from "astro:components";
 
 type CodeLang = Parameters<typeof Code>[0]["lang"];

--- a/src/components/sections/compare/CompareHero.astro
+++ b/src/components/sections/compare/CompareHero.astro
@@ -18,7 +18,15 @@ interface Props {
   zenmlIconUrl: string;
 }
 
-const { toolName, toolIcon, headline, deck, primaryCta, secondaryCta, zenmlIconUrl } = Astro.props;
+const {
+  toolName,
+  toolIcon,
+  headline,
+  deck,
+  primaryCta,
+  secondaryCta,
+  zenmlIconUrl,
+} = Astro.props;
 ---
 
 <section class="bg-white pt-12 pb-8">

--- a/src/components/sections/compare/CompareStrategyCta.astro
+++ b/src/components/sections/compare/CompareStrategyCta.astro
@@ -22,7 +22,10 @@ interface Props {
 
 const {
   headline,
-  primaryCta = { label: "Start Free Trial", href: "https://cloud.zenml.io/signup" },
+  primaryCta = {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+  },
   advantages = [],
 } = Astro.props;
 ---

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -15,11 +15,11 @@
  * - References use slug-based lookups (not IDs)
  */
 
-import { defineCollection, z } from 'astro:content';
-import { glob } from 'astro/loaders';
-import { readdirSync, existsSync } from 'node:fs';
-import { join, extname, basename } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { defineCollection, z } from "astro:content";
+import { existsSync, readdirSync } from "node:fs";
+import { basename, extname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { glob } from "astro/loaders";
 
 // ============================================================================
 // Reusable Schema Helpers
@@ -41,14 +41,16 @@ export const imageSchema = z.object({
  * IMPORTANT: Optional at top level (73+ items don't have SEO data)
  * All fields inside are also optional for flexibility
  */
-export const seoSchema = z.object({
-  title: z.string().optional(),
-  description: z.string().optional(),
-  canonical: z.string().url().optional(),
-  ogImage: z.string().url().optional(),
-  ogTitle: z.string().optional(),
-  ogDescription: z.string().optional(),
-}).optional();
+export const seoSchema = z
+  .object({
+    title: z.string().optional(),
+    description: z.string().optional(),
+    canonical: z.string().url().optional(),
+    ogImage: z.string().url().optional(),
+    ogTitle: z.string().optional(),
+    ogDescription: z.string().optional(),
+  })
+  .optional();
 
 /**
  * Webflow metadata schema
@@ -62,7 +64,7 @@ export const webflowMetaSchema = z.object({
   collectionId: z.string().optional(), // Omitted if null in Webflow export
   itemId: z.string(),
   exportedAt: z.string(),
-  source: z.enum(['live', 'staged-only']),
+  source: z.enum(["live", "staged-only"]),
   lastPublished: z.string().optional(),
   lastUpdated: z.string().optional(),
   createdOn: z.string().optional(),
@@ -77,7 +79,7 @@ const notionMetaSchema = z.object({
 });
 
 const mlopsMetaSchema = z.object({
-  source: z.literal('sqlite'),
+  source: z.literal("sqlite"),
   entryId: z.number(),
   sourceUrl: z.string().url(),
   exportedAt: z.string(),
@@ -116,7 +118,7 @@ export const baseContentSchema = z.object({
  * Uses import.meta.url for robust path resolution
  */
 function getContentDirAbs(): string {
-  return fileURLToPath(new URL('./content', import.meta.url));
+  return fileURLToPath(new URL("./content", import.meta.url));
 }
 
 /**
@@ -136,8 +138,8 @@ function loadSlugSetFromCollectionDir(collectionDirName: string): Set<string> {
 
   return new Set(
     readdirSync(absDir)
-      .filter((f) => extname(f) === '.md')
-      .map((f) => basename(f, '.md'))
+      .filter((f) => extname(f) === ".md")
+      .map((f) => basename(f, ".md")),
   );
 }
 
@@ -146,17 +148,17 @@ function loadSlugSetFromCollectionDir(collectionDirName: string): Set<string> {
  * Built at config evaluation time by reading filesystem
  */
 const referenceSlugSets = {
-  authors: loadSlugSetFromCollectionDir('authors'),
-  categories: loadSlugSetFromCollectionDir('categories'),
-  tags: loadSlugSetFromCollectionDir('tags'),
-  'llmops-tags': loadSlugSetFromCollectionDir('llmops-tags'),
-  'mlops-tags': loadSlugSetFromCollectionDir('mlops-tags'),
-  'industry-tags': loadSlugSetFromCollectionDir('industry-tags'),
-  'project-tags': loadSlugSetFromCollectionDir('project-tags'),
-  'product-categories': loadSlugSetFromCollectionDir('product-categories'),
-  'integration-types': loadSlugSetFromCollectionDir('integration-types'),
-  advantages: loadSlugSetFromCollectionDir('advantages'),
-  quotes: loadSlugSetFromCollectionDir('quotes'),
+  authors: loadSlugSetFromCollectionDir("authors"),
+  categories: loadSlugSetFromCollectionDir("categories"),
+  tags: loadSlugSetFromCollectionDir("tags"),
+  "llmops-tags": loadSlugSetFromCollectionDir("llmops-tags"),
+  "mlops-tags": loadSlugSetFromCollectionDir("mlops-tags"),
+  "industry-tags": loadSlugSetFromCollectionDir("industry-tags"),
+  "project-tags": loadSlugSetFromCollectionDir("project-tags"),
+  "product-categories": loadSlugSetFromCollectionDir("product-categories"),
+  "integration-types": loadSlugSetFromCollectionDir("integration-types"),
+  advantages: loadSlugSetFromCollectionDir("advantages"),
+  quotes: loadSlugSetFromCollectionDir("quotes"),
 } as const;
 
 /**
@@ -167,14 +169,21 @@ const referenceSlugSets = {
  * @param validSlugs - Optional Set of valid slugs for runtime validation
  * @returns Zod schema that validates slug format and optionally checks existence
  */
-export function slugReference(collectionName: string, validSlugs?: Set<string>) {
-  const base = z.string().describe(`Slug reference to ${collectionName} collection`);
+export function slugReference(
+  collectionName: string,
+  validSlugs?: Set<string>,
+) {
+  const base = z
+    .string()
+    .describe(`Slug reference to ${collectionName} collection`);
 
   if (!validSlugs) return base;
 
   return base.refine(
     (slug) => validSlugs.has(slug),
-    (slug) => ({ message: `Invalid reference: "${slug}" not found in ${collectionName}` })
+    (slug) => ({
+      message: `Invalid reference: "${slug}" not found in ${collectionName}`,
+    }),
   );
 }
 
@@ -186,7 +195,10 @@ export function slugReference(collectionName: string, validSlugs?: Set<string>) 
  * @param validSlugs - Optional Set of valid slugs for runtime validation
  * @returns Zod schema that validates array of slugs
  */
-export function slugReferenceArray(collectionName: string, validSlugs?: Set<string>) {
+export function slugReferenceArray(
+  collectionName: string,
+  validSlugs?: Set<string>,
+) {
   return z.array(slugReference(collectionName, validSlugs)).default([]);
 }
 
@@ -245,7 +257,9 @@ const llmopsTagSchema = simpleTagSchema;
 const mlopsTagSchema = z.object({
   name: z.string(),
   slug: z.string(),
-  categories: z.array(z.enum(['platform', 'tool', 'lifecycle', 'extra'])).default([]),
+  categories: z
+    .array(z.enum(["platform", "tool", "lifecycle", "extra"]))
+    .default([]),
 });
 
 /**
@@ -324,9 +338,12 @@ const blogSchema = z.object({
   featured: z.boolean().default(false),
 
   // Blog-specific fields
-  author: slugReference('authors', referenceSlugSets.authors),
-  category: slugReference('categories', referenceSlugSets.categories).optional(), // 8 posts have no category in Webflow
-  tags: slugReferenceArray('tags', referenceSlugSets.tags),
+  author: slugReference("authors", referenceSlugSets.authors),
+  category: slugReference(
+    "categories",
+    referenceSlugSets.categories,
+  ).optional(), // 8 posts have no category in Webflow
+  tags: slugReferenceArray("tags", referenceSlugSets.tags),
   date: z.coerce.date(),
   readingTime: z.string().optional(),
 
@@ -371,13 +388,16 @@ const integrationSchema = z.object({
   draft: z.boolean().default(false),
 
   // Integration-specific fields
-  integrationType: slugReference('integration-types', referenceSlugSets['integration-types']),
+  integrationType: slugReference(
+    "integration-types",
+    referenceSlugSets["integration-types"],
+  ),
   logo: imageSchema.optional(),
   shortDescription: z.string().optional(),
   docsUrl: z.string().url().optional(),
   githubUrl: z.string().url().optional(),
   mainImage: imageSchema.optional(),
-  relatedBlogPosts: slugReferenceArray('blog'),
+  relatedBlogPosts: slugReferenceArray("blog"),
 
   // Structured detail page fields (all optional for backward compat)
   overviewTitle: z.string().optional(),
@@ -413,8 +433,14 @@ const llmopsSchema = z.object({
   draft: z.boolean().default(false),
 
   // LLMOps-specific fields (ACTUAL field names from transform)
-  llmopsTags: slugReferenceArray('llmops-tags', referenceSlugSets['llmops-tags']),
-  industryTags: slugReference('industry-tags', referenceSlugSets['industry-tags']).optional(),
+  llmopsTags: slugReferenceArray(
+    "llmops-tags",
+    referenceSlugSets["llmops-tags"],
+  ),
+  industryTags: slugReference(
+    "industry-tags",
+    referenceSlugSets["industry-tags"],
+  ).optional(),
   company: z.string().optional(),
   summary: z.string().optional(),
   link: z.string().url().optional(),
@@ -438,12 +464,22 @@ const mlopsDatabaseSchema = z.object({
   draft: z.boolean().default(false),
 
   // MLOps-specific fields
-  mlopsTags: slugReferenceArray('mlops-tags', referenceSlugSets['mlops-tags']),
-  industryTags: slugReference('industry-tags', referenceSlugSets['industry-tags']),
+  mlopsTags: slugReferenceArray("mlops-tags", referenceSlugSets["mlops-tags"]),
+  industryTags: slugReference(
+    "industry-tags",
+    referenceSlugSets["industry-tags"],
+  ),
   company: z.string(),
   companySlug: z.string(),
   platformName: z.string(),
-  contentType: z.enum(['blog', 'video', 'paper', 'slides', 'podcast', 'transcript']),
+  contentType: z.enum([
+    "blog",
+    "video",
+    "paper",
+    "slides",
+    "podcast",
+    "transcript",
+  ]),
   summary: z.string(),
   link: z.string().url(),
   year: z.number().optional(),
@@ -472,7 +508,7 @@ const compareValueSectionSchema = z.object({
   title: z.string(),
   bullets: z.array(z.string()),
   image: imageSchema.optional(),
-  imageSide: z.enum(['left', 'right']).default('right'),
+  imageSide: z.enum(["left", "right"]).default("right"),
 });
 
 /**
@@ -481,9 +517,9 @@ const compareValueSectionSchema = z.object({
  */
 const compareCodeComparisonSchema = z.object({
   zenmlCode: z.string(),
-  zenmlLanguage: z.string().default('python'),
+  zenmlLanguage: z.string().default("python"),
   toolCode: z.string(),
-  toolLanguage: z.string().default('python'),
+  toolLanguage: z.string().default("python"),
 });
 
 /**
@@ -506,9 +542,12 @@ const compareSchema = z.object({
   toolName: z.string().optional(),
   toolIcon: imageSchema.optional(),
   category: z.string().optional(),
-  integrationType: slugReference('integration-types', referenceSlugSets['integration-types']).optional(),
-  advantages: slugReferenceArray('advantages', referenceSlugSets.advantages),
-  quote: slugReference('quotes', referenceSlugSets.quotes).optional(),
+  integrationType: slugReference(
+    "integration-types",
+    referenceSlugSets["integration-types"],
+  ).optional(),
+  advantages: slugReferenceArray("advantages", referenceSlugSets.advantages),
+  quote: slugReference("quotes", referenceSlugSets.quotes).optional(),
   headline: z.string().optional(),
   heroText: z.string().optional(),
   ctaHeadline: z.string().optional(),
@@ -585,7 +624,7 @@ const projectSchema = z.object({
 
   // Project-specific fields
   description: z.string().optional(),
-  tags: slugReferenceArray('project-tags', referenceSlugSets['project-tags']),
+  tags: slugReferenceArray("project-tags", referenceSlugSets["project-tags"]),
   mainImageLink: z.string().url().optional(), // Note: NOT "coverImage"
   previewImage: imageSchema.optional(), // Larger preview image for detail page header
   githubUrl: z.string().url().optional(),
@@ -642,7 +681,7 @@ const featureHubSchema = z.object({
   title: z.string(),
   summary: z.string().optional(),
   category: z.string(),
-  badge: z.enum(['PRO']).optional(),
+  badge: z.enum(["PRO"]).optional(),
   order: z.number().optional(),
 });
 
@@ -654,16 +693,16 @@ const featureHeroSchema = z.object({
 });
 
 const valueBlockSchema = z.object({
-  kind: z.literal('value'),
+  kind: z.literal("value"),
   title: z.string(),
   body: z.string().optional(),
   bullets: z.array(z.string()).optional(),
   image: imageSchema.optional(),
-  imageSide: z.enum(['left', 'right']).optional(),
+  imageSide: z.enum(["left", "right"]).optional(),
 });
 
 const complianceBannerBlockSchema = z.object({
-  kind: z.literal('complianceBanner'),
+  kind: z.literal("complianceBanner"),
   eyebrow: z.string().optional(),
   headline: z.string().optional(),
   body: z.string().optional(),
@@ -690,10 +729,12 @@ const featureTestimonialSchema = z.object({
 const featurePageSchema = baseContentSchema.extend({
   hub: featureHubSchema,
   hero: featureHeroSchema,
-  blocks: z.array(z.discriminatedUnion('kind', [
-    valueBlockSchema,
-    complianceBannerBlockSchema,
-  ])),
+  blocks: z.array(
+    z.discriminatedUnion("kind", [
+      valueBlockSchema,
+      complianceBannerBlockSchema,
+    ]),
+  ),
   testimonial: featureTestimonialSchema.optional(),
   showFinalCta: z.boolean().default(true),
 });
@@ -710,18 +751,22 @@ const caseStudyHubSchema = z.object({
 
 const caseStudySidebarSchema = z.object({
   company: z.string(),
-  website: z.object({
-    label: z.string(),
-    href: z.string().url(),
-  }).optional(),
+  website: z
+    .object({
+      label: z.string(),
+      href: z.string().url(),
+    })
+    .optional(),
   mlTeamSize: z.string().optional(),
   cloudProvider: z.string().optional(),
   industry: z.string().optional(),
   useCases: z.array(z.string()).default([]),
-  pdfDownload: z.object({
-    label: z.string(),
-    href: z.string(),
-  }).optional(),
+  pdfDownload: z
+    .object({
+      label: z.string(),
+      href: z.string(),
+    })
+    .optional(),
 });
 
 /**
@@ -754,12 +799,12 @@ const vsHeroSchema = z.object({
 });
 
 const vsIntroBlockSchema = z.object({
-  kind: z.literal('intro'),
+  kind: z.literal("intro"),
   body: z.string(),
 });
 
 const vsTestimonialBlockSchema = z.object({
-  kind: z.literal('testimonial'),
+  kind: z.literal("testimonial"),
   quote: z.string(),
   name: z.string(),
   title: z.string().optional(),
@@ -768,13 +813,13 @@ const vsTestimonialBlockSchema = z.object({
 });
 
 const vsRelatedCompareBlockSchema = z.object({
-  kind: z.literal('relatedCompare'),
+  kind: z.literal("relatedCompare"),
   eyebrow: z.string().optional(),
   headline: z.string().optional(),
 });
 
 const vsCta02BlockSchema = z.object({
-  kind: z.literal('cta02'),
+  kind: z.literal("cta02"),
   headline: z.string(),
   bullets: z.array(z.string()).default([]),
   primaryCta: ctaSchema,
@@ -792,13 +837,15 @@ const vsCta02BlockSchema = z.object({
  */
 const vsPageSchema = baseContentSchema.extend({
   hero: vsHeroSchema,
-  blocks: z.array(z.discriminatedUnion('kind', [
-    vsIntroBlockSchema,
-    valueBlockSchema,
-    vsTestimonialBlockSchema,
-    vsRelatedCompareBlockSchema,
-    vsCta02BlockSchema,
-  ])),
+  blocks: z.array(
+    z.discriminatedUnion("kind", [
+      vsIntroBlockSchema,
+      valueBlockSchema,
+      vsTestimonialBlockSchema,
+      vsRelatedCompareBlockSchema,
+      vsCta02BlockSchema,
+    ]),
+  ),
 });
 
 // ============================================================================
@@ -814,93 +861,99 @@ const vsPageSchema = baseContentSchema.extend({
 export const collections = {
   // Reference collections (Phase 2D)
   authors: defineCollection({
-    loader: glob({ pattern: '**/*.md', base: './src/content/authors' }),
+    loader: glob({ pattern: "**/*.md", base: "./src/content/authors" }),
     schema: authorSchema,
   }),
   categories: defineCollection({
-    loader: glob({ pattern: '**/*.md', base: './src/content/categories' }),
+    loader: glob({ pattern: "**/*.md", base: "./src/content/categories" }),
     schema: categorySchema,
   }),
   tags: defineCollection({
-    loader: glob({ pattern: '**/*.md', base: './src/content/tags' }),
+    loader: glob({ pattern: "**/*.md", base: "./src/content/tags" }),
     schema: tagSchema,
   }),
-  'llmops-tags': defineCollection({
-    loader: glob({ pattern: '**/*.md', base: './src/content/llmops-tags' }),
+  "llmops-tags": defineCollection({
+    loader: glob({ pattern: "**/*.md", base: "./src/content/llmops-tags" }),
     schema: llmopsTagSchema,
   }),
-  'mlops-tags': defineCollection({
-    loader: glob({ pattern: '**/*.md', base: './src/content/mlops-tags' }),
+  "mlops-tags": defineCollection({
+    loader: glob({ pattern: "**/*.md", base: "./src/content/mlops-tags" }),
     schema: mlopsTagSchema,
   }),
-  'industry-tags': defineCollection({
-    loader: glob({ pattern: '**/*.md', base: './src/content/industry-tags' }),
+  "industry-tags": defineCollection({
+    loader: glob({ pattern: "**/*.md", base: "./src/content/industry-tags" }),
     schema: industryTagSchema,
   }),
-  'project-tags': defineCollection({
-    loader: glob({ pattern: '**/*.md', base: './src/content/project-tags' }),
+  "project-tags": defineCollection({
+    loader: glob({ pattern: "**/*.md", base: "./src/content/project-tags" }),
     schema: projectTagSchema,
   }),
-  'product-categories': defineCollection({
-    loader: glob({ pattern: '**/*.md', base: './src/content/product-categories' }),
+  "product-categories": defineCollection({
+    loader: glob({
+      pattern: "**/*.md",
+      base: "./src/content/product-categories",
+    }),
     schema: productCategorySchema,
   }),
-  'integration-types': defineCollection({
-    loader: glob({ pattern: '**/*.md', base: './src/content/integration-types' }),
+  "integration-types": defineCollection({
+    loader: glob({
+      pattern: "**/*.md",
+      base: "./src/content/integration-types",
+    }),
     schema: integrationTypeSchema,
   }),
   advantages: defineCollection({
-    loader: glob({ pattern: '**/*.md', base: './src/content/advantages' }),
+    loader: glob({ pattern: "**/*.md", base: "./src/content/advantages" }),
     schema: advantageSchema,
   }),
   quotes: defineCollection({
-    loader: glob({ pattern: '**/*.md', base: './src/content/quotes' }),
+    loader: glob({ pattern: "**/*.md", base: "./src/content/quotes" }),
     schema: quoteSchema,
   }),
 
   // Main collection loaders (Phase 2F)
   blog: defineCollection({
-    loader: glob({ pattern: '**/*.md', base: './src/content/blog' }),
+    loader: glob({ pattern: "**/*.md", base: "./src/content/blog" }),
     schema: blogSchema,
   }),
   integrations: defineCollection({
-    loader: glob({ pattern: '**/*.md', base: './src/content/integrations' }),
+    loader: glob({ pattern: "**/*.md", base: "./src/content/integrations" }),
     schema: integrationSchema,
   }),
-  'llmops-database': defineCollection({
-    loader: glob({ pattern: '**/*.md', base: './src/content/llmops-database' }),
+  "llmops-database": defineCollection({
+    loader: glob({ pattern: "**/*.md", base: "./src/content/llmops-database" }),
     schema: llmopsSchema,
   }),
-  'mlops-database': defineCollection({
-    loader: glob({ pattern: '**/*.md', base: './src/content/mlops-database' }),
+  "mlops-database": defineCollection({
+    loader: glob({ pattern: "**/*.md", base: "./src/content/mlops-database" }),
     schema: mlopsDatabaseSchema,
   }),
   compare: defineCollection({
-    loader: glob({ pattern: '**/*.md', base: './src/content/compare' }),
+    loader: glob({ pattern: "**/*.md", base: "./src/content/compare" }),
     schema: compareSchema,
   }),
   team: defineCollection({
-    loader: glob({ pattern: '**/*.md', base: './src/content/team' }),
+    loader: glob({ pattern: "**/*.md", base: "./src/content/team" }),
     schema: teamSchema,
   }),
   projects: defineCollection({
-    loader: glob({ pattern: '**/*.md', base: './src/content/projects' }),
+    loader: glob({ pattern: "**/*.md", base: "./src/content/projects" }),
     schema: projectSchema,
   }),
-  'old-projects': defineCollection({
-    loader: glob({ pattern: '**/*.md', base: './src/content/old-projects' }),
+  "old-projects": defineCollection({
+    loader: glob({ pattern: "**/*.md", base: "./src/content/old-projects" }),
     schema: oldProjectSchema,
   }),
-  'feature-pages': defineCollection({
-    loader: glob({ pattern: '**/*.md', base: './src/content/feature-pages' }),
+  "feature-pages": defineCollection({
+    loader: glob({ pattern: "**/*.md", base: "./src/content/feature-pages" }),
     schema: featurePageSchema,
   }),
-  'case-studies': defineCollection({
-    loader: glob({ pattern: '**/*.md', base: './src/content/case-studies' }),
+  "case-studies": defineCollection({
+    loader: glob({ pattern: "**/*.md", base: "./src/content/case-studies" }),
     schema: caseStudySchema,
   }),
-  'vs-pages': defineCollection({
-    loader: glob({ pattern: '**/*.md', base: './src/content/vs-pages' }),
+  "vs-pages": defineCollection({
+    loader: glob({ pattern: "**/*.md", base: "./src/content/vs-pages" }),
     schema: vsPageSchema,
   }),
 };

--- a/src/content/blog/how-i-rebuilt-zenml-io-in-a-week-with-claude-code.md
+++ b/src/content/blog/how-i-rebuilt-zenml-io-in-a-week-with-claude-code.md
@@ -182,7 +182,7 @@ Cloudflare Pages (and similar platforms) run `astro build` for every deploy, inc
 
 ### 4. The Webflow CDN Isn't Always Cooperative
 
-When migrating 2,397 assets, I needed to download every image from Webflow's CDN (`uploads-ssl.webflow.com`). Most worked fine, but some file IDs consistently returned 403 Forbidden, even with browser-like User-Agent headers. These weren't rate limits; the same IDs failed every time. The workaround was the Webflow code export I'd downloaded as a reference: it contains the same images under older file IDs that still download fine. So the local export became the fallback source for anything the CDN blocked. If you're planning a similar migration, download the code export before you start, even if you think you won't need it.
+When migrating 2,397 assets, I needed to download every image from Webflow's legacy upload CDN. Most worked fine, but some file IDs consistently returned 403 Forbidden, even with browser-like User-Agent headers. These weren't rate limits; the same IDs failed every time. The workaround was the Webflow code export I'd downloaded as a reference: it contains the same images under older file IDs that still download fine. So the local export became the fallback source for anything the CDN blocked. If you're planning a similar migration, download the code export before you start, even if you think you won't need it.
 
 ### 5. Plan Before You Build
 

--- a/src/content/blog/new-features-dashboard-upgrades-various-bugfixes-and-improvements-documentation-updates-and-more.md
+++ b/src/content/blog/new-features-dashboard-upgrades-various-bugfixes-and-improvements-documentation-updates-and-more.md
@@ -23,12 +23,12 @@ tags:
 date: "2025-02-27T00:00:00.000Z"
 readingTime: 3 mins
 mainImage:
-  url: "https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/f9387c9d/67c06200c71cb71e5d245e37_zenml-release-7.png"
+  url: "https://assets.zenml.io/content/blog/db29714b/67c06200c71cb71e5d245e37_zenml-release-7.webp"
 seo:
   title: "New Features: Dashboard Upgrades, Various Bugfixes and Improvements, Documentation Updates and More! - ZenML Blog"
   description: "ZenML 0.75.0 introduces dashboard enhancements that allow users to create and update stack components directly from the dashboard, along with improvements to service connectors, model artifact handling, and documentation. This release streamlines ML workflows with better component management capabilities, enhanced SageMaker integration, and critical fixes for custom flavor components and sorting logic."
   canonical: "https://www.zenml.io/blog/new-features-dashboard-upgrades-various-bugfixes-and-improvements-documentation-updates-and-more"
-  ogImage: "https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/f9387c9d/67c06200c71cb71e5d245e37_zenml-release-7.png"
+  ogImage: "https://assets.zenml.io/content/blog/db29714b/67c06200c71cb71e5d245e37_zenml-release-7.webp"
   ogTitle: "New Features: Dashboard Upgrades, Various Bugfixes and Improvements, Documentation Updates and More! - ZenML Blog"
   ogDescription: "ZenML 0.75.0 introduces dashboard enhancements that allow users to create and update stack components directly from the dashboard, along with improvements to service connectors, model artifact handling, and documentation. This release streamlines ML workflows with better component management capabilities, enhanced SageMaker integration, and critical fixes for custom flavor components and sorting logic."
 ---

--- a/src/content/blog/new-features-enhanced-dashboard-improved-performance-and-streamlined-user-experience.md
+++ b/src/content/blog/new-features-enhanced-dashboard-improved-performance-and-streamlined-user-experience.md
@@ -22,12 +22,12 @@ tags:
 date: "2024-10-28T00:00:00.000Z"
 readingTime: 3 min
 mainImage:
-  url: "https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/8105f52d/671f62a23250bf01acac4d27_zenml-release-3.png"
+  url: "https://assets.zenml.io/content/blog/a64dccb4/671f62a23250bf01acac4d27_zenml-release-3.webp"
 seo:
   title: "New Features: Enhanced Dashboard, Improved Performance, and Streamlined User Experience - ZenML Blog"
   description: "ZenML 0.68.0 introduces several major enhancements including the return of stack components visualization on the dashboard, powerful client-side caching for improved performance, and a streamlined onboarding process that unifies starter and production setups. The release also brings improved artifact management with the new `register_artifact` function, enhanced BentoML integration (v1.3.5), and comprehensive documentation updates, while deprecating legacy features including Python 3.8 support."
   canonical: "https://www.zenml.io/blog/new-features-enhanced-dashboard-improved-performance-and-streamlined-user-experience"
-  ogImage: "https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/8105f52d/671f62a23250bf01acac4d27_zenml-release-3.png"
+  ogImage: "https://assets.zenml.io/content/blog/a64dccb4/671f62a23250bf01acac4d27_zenml-release-3.webp"
   ogTitle: "New Features: Enhanced Dashboard, Improved Performance, and Streamlined User Experience - ZenML Blog"
   ogDescription: "ZenML 0.68.0 introduces several major enhancements including the return of stack components visualization on the dashboard, powerful client-side caching for improved performance, and a streamlined onboarding process that unifies starter and production setups. The release also brings improved artifact management with the new `register_artifact` function, enhanced BentoML integration (v1.3.5), and comprehensive documentation updates, while deprecating legacy features including Python 3.8 support."
 ---

--- a/src/content/blog/new-features-performance-upgrade-improvements-for-major-cloud-providers-and-more.md
+++ b/src/content/blog/new-features-performance-upgrade-improvements-for-major-cloud-providers-and-more.md
@@ -23,12 +23,12 @@ tags:
   - "zenml"
 date: "2025-02-06T00:00:00.000Z"
 mainImage:
-  url: "https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/794f2285/67a4df4fee38a9b994bc0d3d_zenml-release-6.png"
+  url: "https://assets.zenml.io/content/blog/9cb87a3f/67a4df4fee38a9b994bc0d3d_zenml-release-6.webp"
 seo:
   title: "New Features: Performance Upgrade, Improvements for Major Cloud Providers, and More! - ZenML Blog"
   description: "ZenML 0.74.0 introduces key cloud provider features including SageMaker pipeline scheduling, Azure Container Registry implicit authentication, and Vertex AI persistent resource support. The release adds API Tokens for secure, time-boxed API authentication while delivering comprehensive improvements to timezone handling, database performance, and Helm chart deployments."
   canonical: "https://www.zenml.io/blog/new-features-performance-upgrade-improvements-for-major-cloud-providers-and-more"
-  ogImage: "https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/794f2285/67a4df4fee38a9b994bc0d3d_zenml-release-6.png"
+  ogImage: "https://assets.zenml.io/content/blog/9cb87a3f/67a4df4fee38a9b994bc0d3d_zenml-release-6.webp"
   ogTitle: "New Features: Performance Upgrade, Improvements for Major Cloud Providers, and More! - ZenML Blog"
   ogDescription: "ZenML 0.74.0 introduces key cloud provider features including SageMaker pipeline scheduling, Azure Container Registry implicit authentication, and Vertex AI persistent resource support. The release adds API Tokens for secure, time-boxed API authentication while delivering comprehensive improvements to timezone handling, database performance, and Helm chart deployments."
 ---

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,6 @@
 ---
-import Footer from "../components/Footer.astro";
 import PlausibleBridge from "../components/analytics/PlausibleBridge.astro";
+import Footer from "../components/Footer.astro";
 import CookieConsent from "../components/islands/CookieConsent.tsx";
 import Navigation from "../components/Navigation.astro";
 /**

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -1,4 +1,14 @@
 ---
+import BlogTOC from "../components/BlogTOC.astro";
+import Button from "../components/Button.astro";
+import BlogCard from "../components/blog/BlogCard.astro";
+import CategoryBar from "../components/blog/CategoryBar.astro";
+import Image from "../components/Image.astro";
+import FeaturesHubCTA from "../components/sections/FeaturesHubCTA.astro";
+import JsonLd from "../components/seo/JsonLd.astro";
+import { BLOG_FINAL_CTA, BLOG_SIDEBAR_CTA } from "../lib/blog";
+import { SITE_URL } from "../lib/constants";
+import type { SEOProps } from "../lib/seo";
 /**
  * BlogLayout — chrome for blog post detail pages.
  *
@@ -13,16 +23,6 @@
  * - Related posts ("Continue Reading") section
  */
 import BaseLayout from "./BaseLayout.astro";
-import Image from "../components/Image.astro";
-import JsonLd from "../components/seo/JsonLd.astro";
-import BlogTOC from "../components/BlogTOC.astro";
-import BlogCard from "../components/blog/BlogCard.astro";
-import CategoryBar from "../components/blog/CategoryBar.astro";
-import Button from "../components/Button.astro";
-import FeaturesHubCTA from "../components/sections/FeaturesHubCTA.astro";
-import { BLOG_SIDEBAR_CTA, BLOG_FINAL_CTA } from "../lib/blog";
-import type { SEOProps } from "../lib/seo";
-import { SITE_URL } from "../lib/constants";
 
 interface Heading {
   depth: number;
@@ -100,7 +100,6 @@ const {
 // Display title: prefer postTitle (the actual post title), fall back to SEO title
 const displayTitle = postTitle || seoProps.title;
 
-
 // H2-only TOC — consistent with BlogTOC.astro desktop sidebar
 const tocHeadings = headings.filter((h) => h.depth === 2);
 const showTOC = tocHeadings.length >= 3;
@@ -116,7 +115,12 @@ const breadcrumbJsonLd = {
   "@context": "https://schema.org",
   "@type": "BreadcrumbList",
   itemListElement: [
-    { "@type": "ListItem", position: 1, name: "Blog", item: `${SITE_URL}/blog` },
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Blog",
+      item: `${SITE_URL}/blog`,
+    },
     { "@type": "ListItem", position: 2, name: displayTitle },
   ],
 };

--- a/src/layouts/ContentLayout.astro
+++ b/src/layouts/ContentLayout.astro
@@ -1,4 +1,5 @@
 ---
+import type { SEOProps } from "../lib/seo";
 /**
  * ContentLayout — generic prose wrapper for content pages.
  *
@@ -9,7 +10,6 @@
  * Pages that need custom chrome (like BlogLayout) compose over this layout.
  */
 import BaseLayout from "./BaseLayout.astro";
-import type { SEOProps } from "../lib/seo";
 
 interface Props extends SEOProps {
   /** Narrow content column (default) or wide (for pages with sidebars) */

--- a/src/layouts/MinimalLayout.astro
+++ b/src/layouts/MinimalLayout.astro
@@ -1,4 +1,6 @@
 ---
+import PlausibleBridge from "../components/analytics/PlausibleBridge.astro";
+import CookieConsent from "../components/islands/CookieConsent.tsx";
 /**
  * MinimalLayout — lightweight HTML shell WITHOUT Navigation/Footer chrome.
  *
@@ -9,8 +11,6 @@
  * Shares the same <head> SEO contract as BaseLayout via SEOProps.
  */
 import { resolveSeo, type SEOProps } from "../lib/seo";
-import PlausibleBridge from "../components/analytics/PlausibleBridge.astro";
-import CookieConsent from "../components/islands/CookieConsent.tsx";
 import "../styles/global.css";
 
 interface Props extends SEOProps {

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -47,7 +47,7 @@ export function getPrevNext(
   const idx = sortedPosts.findIndex((p) => p.data.slug === currentSlug);
   if (idx === -1) return {};
   return {
-    prev: idx > 0 ? sortedPosts[idx - 1] : undefined,           // newer
+    prev: idx > 0 ? sortedPosts[idx - 1] : undefined, // newer
     next: idx < sortedPosts.length - 1 ? sortedPosts[idx + 1] : undefined, // older
   };
 }
@@ -77,7 +77,11 @@ export function getRelatedPosts(
       return { post: p, score };
     })
     .filter(({ score }) => score > 0)
-    .sort((a, b) => b.score - a.score || b.post.data.date.getTime() - a.post.data.date.getTime());
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        b.post.data.date.getTime() - a.post.data.date.getTime(),
+    );
 
   return scored.slice(0, limit).map(({ post }) => post);
 }
@@ -88,7 +92,9 @@ export function getRelatedPosts(
 
 export type TaxonomyCount = { slug: string; name: string; count: number };
 
-export async function getCategoryCounts(posts: BlogPost[]): Promise<TaxonomyCount[]> {
+export async function getCategoryCounts(
+  posts: BlogPost[],
+): Promise<TaxonomyCount[]> {
   const countMap = new Map<string, number>();
   for (const p of posts) {
     if (p.data.category) {
@@ -108,7 +114,9 @@ export async function getCategoryCounts(posts: BlogPost[]): Promise<TaxonomyCoun
   return result.sort((a, b) => b.count - a.count);
 }
 
-export async function getTagCounts(posts: BlogPost[]): Promise<TaxonomyCount[]> {
+export async function getTagCounts(
+  posts: BlogPost[],
+): Promise<TaxonomyCount[]> {
   const countMap = new Map<string, number>();
   for (const p of posts) {
     for (const tag of p.data.tags) {
@@ -139,7 +147,9 @@ export interface ResolvedAuthor {
   bio?: string;
 }
 
-export async function resolveAuthor(authorSlug?: string): Promise<ResolvedAuthor | undefined> {
+export async function resolveAuthor(
+  authorSlug?: string,
+): Promise<ResolvedAuthor | undefined> {
   if (!authorSlug) return undefined;
   const entry = await getEntry("authors", authorSlug);
   if (!entry) return undefined;
@@ -181,7 +191,8 @@ export function getPaginationItems(
 
   // Adjust if near edges
   if (currentPage - half <= 2) end = Math.min(totalPages - 1, maxVisible - 2);
-  if (currentPage + half >= totalPages - 1) start = Math.max(2, totalPages - maxVisible + 3);
+  if (currentPage + half >= totalPages - 1)
+    start = Math.max(2, totalPages - maxVisible + 3);
 
   if (start > 2) items.push("ellipsis");
   for (let i = start; i <= end; i++) items.push(i);
@@ -209,7 +220,9 @@ export interface BlogSearchEntry {
 }
 
 /** Build the search index payload for all given posts. */
-export async function buildBlogSearchIndex(posts: BlogPost[]): Promise<BlogSearchEntry[]> {
+export async function buildBlogSearchIndex(
+  posts: BlogPost[],
+): Promise<BlogSearchEntry[]> {
   const allCategories = await getCollection("categories");
   const catMap = new Map(allCategories.map((c) => [c.data.slug, c.data.name]));
 
@@ -233,12 +246,24 @@ export const BLOG_SIDEBAR_CTA = {
     "Works with any infrastructure",
     "Secure, metadata-only tracking",
   ],
-  cta: { label: "Start Free Trial", href: "https://cloud.zenml.io/signup", analytics: "Blog-Sidebar-Free-Trial" } as CtaLink,
+  cta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+    analytics: "Blog-Sidebar-Free-Trial",
+  } as CtaLink,
 } as const;
 
 export const BLOG_FINAL_CTA = {
   headline: "Start deploying AI workflows in production today",
   body: "Enterprise-grade AI platform trusted by thousands of companies in production",
-  primaryCta: { label: "Start Free Trial", href: "https://cloud.zenml.io/signup", analytics: "Blog-CTA-Free-Trial" } as CtaLink,
-  secondaryCta: { label: "Book a Demo", href: "/book-your-demo", analytics: "Blog-CTA-Book-Demo" } as CtaLink,
+  primaryCta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+    analytics: "Blog-CTA-Free-Trial",
+  } as CtaLink,
+  secondaryCta: {
+    label: "Book a Demo",
+    href: "/book-your-demo",
+    analytics: "Blog-CTA-Book-Demo",
+  } as CtaLink,
 } as const;

--- a/src/lib/bookADemo.ts
+++ b/src/lib/bookADemo.ts
@@ -5,10 +5,10 @@
  * Renders form UI but doesn't submit. Primary CTA links to /book-your-demo.
  */
 
-import type { SEOProps } from "./seo";
+import { JOB_TITLE_OPTIONS } from "./formConstants";
 import type { PlaceholderField } from "./formTypes";
 import type { CtaLink } from "./marketingPageTypes";
-import { JOB_TITLE_OPTIONS } from "./formConstants";
+import type { SEOProps } from "./seo";
 
 export const BOOK_A_DEMO_SEO: SEOProps = {
   title: "Book a Demo | ZenML",
@@ -25,8 +25,20 @@ export const BOOK_A_DEMO_HERO = {
 };
 
 export const BOOK_A_DEMO_FIELDS: PlaceholderField[] = [
-  { name: "fullName", label: "Full name", type: "text", required: true, placeholder: "Full name" },
-  { name: "email", label: "Work Email", type: "email", required: true, placeholder: "you@company.inc" },
+  {
+    name: "fullName",
+    label: "Full name",
+    type: "text",
+    required: true,
+    placeholder: "Full name",
+  },
+  {
+    name: "email",
+    label: "Work Email",
+    type: "email",
+    required: true,
+    placeholder: "you@company.inc",
+  },
   {
     name: "jobTitle",
     label: "Job Title",
@@ -38,7 +50,8 @@ export const BOOK_A_DEMO_FIELDS: PlaceholderField[] = [
     label: "Privacy agreement",
     type: "checkbox",
     required: true,
-    placeholder: 'You agree to our <a href="/privacy-policy" class="text-zenml-500 underline">privacy policy</a>.',
+    placeholder:
+      'You agree to our <a href="/privacy-policy" class="text-zenml-500 underline">privacy policy</a>.',
   },
 ];
 

--- a/src/lib/bookADemoSuccess.ts
+++ b/src/lib/bookADemoSuccess.ts
@@ -5,8 +5,8 @@
  * Similar to /success-calendar: shows thank-you copy + Cal.com widget.
  */
 
-import type { SEOProps } from "./seo";
 import type { CalEmbedConfig } from "./formTypes";
+import type { SEOProps } from "./seo";
 
 export const BOOK_A_DEMO_SUCCESS_SEO: SEOProps = {
   title: "Book a Demo Success | ZenML",

--- a/src/lib/bookSuccess.ts
+++ b/src/lib/bookSuccess.ts
@@ -4,8 +4,8 @@
  * Route: /book-success (noindex)
  */
 
-import type { SEOProps } from "./seo";
 import type { SuccessPageData } from "./formTypes";
+import type { SEOProps } from "./seo";
 
 export const BOOK_SUCCESS_SEO: SEOProps = {
   title: "Demo Booked | ZenML",

--- a/src/lib/bookYourDemo.ts
+++ b/src/lib/bookYourDemo.ts
@@ -8,10 +8,10 @@
  * Below: testimonial + minimal footer.
  */
 
-import type { SEOProps } from "./seo";
-import type { PlaceholderField, CalEmbedConfig } from "./formTypes";
-
 import { R2_WEBFLOW_BASE } from "./constants";
+import type { CalEmbedConfig, PlaceholderField } from "./formTypes";
+import type { SEOProps } from "./seo";
+
 const R2 = R2_WEBFLOW_BASE;
 
 export const BOOK_YOUR_DEMO_SEO: SEOProps = {

--- a/src/lib/booked.ts
+++ b/src/lib/booked.ts
@@ -4,8 +4,8 @@
  * Route: /booked (noindex)
  */
 
-import type { SEOProps } from "./seo";
 import type { SuccessPageData } from "./formTypes";
+import type { SEOProps } from "./seo";
 
 export const BOOKED_SEO: SEOProps = {
   title: "Thank you for booking a demo!",

--- a/src/lib/brickManual.ts
+++ b/src/lib/brickManual.ts
@@ -5,8 +5,8 @@
  * Flow: email capture → Segment lead → immediate PDF download link.
  */
 
-import type { SEOProps } from "./seo";
 import type { PlaceholderField } from "./formTypes";
+import type { SEOProps } from "./seo";
 
 export const BRICK_MANUAL_SEO: SEOProps = {
   title: "Get Your Build Instructions | ZenML",

--- a/src/lib/careers.ts
+++ b/src/lib/careers.ts
@@ -88,8 +88,10 @@ export const CAREERS_WHY = {
 // ---------------------------------------------------------------------------
 export const CAREERS_HIRING_PROCESS = {
   headline: "Our hiring process",
-  intro: "We understand the hiring process can be super tough for candidates. Therefore, we are working hard to make it as transparent and lean as possible for anyone who applies at ZenML. So, if you are hesitating due to the overhead, don't! We will treat your application with the utmost respect and priority.",
-  afterIntro: "Once you apply our team will carefully review your CV and application in an initial screening. After that your journey with us will follow this outline:",
+  intro:
+    "We understand the hiring process can be super tough for candidates. Therefore, we are working hard to make it as transparent and lean as possible for anyone who applies at ZenML. So, if you are hesitating due to the overhead, don't! We will treat your application with the utmost respect and priority.",
+  afterIntro:
+    "Once you apply our team will carefully review your CV and application in an initial screening. After that your journey with us will follow this outline:",
   steps: [
     {
       number: 1,

--- a/src/lib/case-studies.ts
+++ b/src/lib/case-studies.ts
@@ -9,7 +9,10 @@ export const CASE_STUDIES_HUB_HERO = {
   eyebrow: "Case Studies",
   headline: "Real Teams. Real AI Workflows",
   body: "See how teams are using ZenML to unify their AI platforms—from batch evaluations to real-time serving, traditional ML to GenAI workflows.",
-  primaryCta: { label: "Start Free Trial", href: "https://cloud.zenml.io/signup" },
+  primaryCta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+  },
   secondaryCta: { label: "Use Open Source", href: "/get-started" },
 } as const;
 
@@ -22,6 +25,9 @@ export const CASE_STUDIES_HUB_BANNER = {
 export const CASE_STUDIES_HUB_CTA = {
   headline: "Start deploying reproducible AI workflows today",
   body: "Enterprise-grade MLOps platform trusted by thousands of companies in production.",
-  primaryCta: { label: "Start Free Trial", href: "https://cloud.zenml.io/signup" },
+  primaryCta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+  },
   secondaryCta: { label: "Use Open Source", href: "https://cloud.zenml.io" },
 } as const;

--- a/src/lib/compareDefaults.ts
+++ b/src/lib/compareDefaults.ts
@@ -17,7 +17,7 @@ export interface CompareValueSection {
   title: string;
   bullets: string[];
   image?: { url: string; alt?: string };
-  imageSide: 'left' | 'right';
+  imageSide: "left" | "right";
 }
 
 export interface CompareCategoryDefaults {
@@ -44,53 +44,57 @@ export interface CompareCategoryDefaults {
 // ---------------------------------------------------------------------------
 
 import { R2_WEBFLOW_BASE } from "./constants";
+
 const R2 = R2_WEBFLOW_BASE;
 
 const DASHBOARD_IMAGES = {
   localToProduction: {
     url: `${R2}/514b3df0/6526abf3a9418f8674b15b23_01_Local_to_production.webp`,
-    alt: 'Dashboard mockup showing local-to-production workflow',
+    alt: "Dashboard mockup showing local-to-production workflow",
   },
   collaborationShowcase: {
     url: `${R2}/dc3f971a/65256919ea2f6ed1dc5661a7_03_Collaboration_Showcase.webp`,
-    alt: 'Dashboard mockup showing collaboration features',
+    alt: "Dashboard mockup showing collaboration features",
   },
   productionalizationShowcase: {
     url: `${R2}/8c0fce5c/6526ad04f45d52aff741b914_13_Productionalization_Showcase.webp`,
-    alt: 'Dashboard mockup showing productionalization workflow',
+    alt: "Dashboard mockup showing productionalization workflow",
   },
   vendorLockIn: {
     url: `${R2}/660dfe37/6526b353e6aebd4bab3f07f4_14_Vendor_Lock_in_Showcase.webp`,
-    alt: 'Dashboard mockup showing vendor-neutral architecture',
+    alt: "Dashboard mockup showing vendor-neutral architecture",
   },
   integrationsShowcase: {
     url: `${R2}/b7d6eb47/6526ae31bf639b6c8874a597_05_Integrations_showcase.webp`,
-    alt: 'Dashboard mockup showing integrations',
+    alt: "Dashboard mockup showing integrations",
   },
   portabilityShowcase: {
     url: `${R2}/e46619e4/6526aaa2897996e16fe7dd9c_12_Portability_Showcase.webp`,
-    alt: 'Dashboard mockup showing portability features',
+    alt: "Dashboard mockup showing portability features",
   },
   dataVersioningShowcase: {
     url: `${R2}/e6f711a9/6526aff7c4fdd6c0d6c1ea26_10_Data_Versioning_and_Lineage_Showcase.webp`,
-    alt: 'Dashboard mockup showing data versioning and lineage',
+    alt: "Dashboard mockup showing data versioning and lineage",
   },
   modelControlPlane: {
     url: `${R2}/339bb62b/66e9556fd34d2791885b0c5f_model_control_plane_01.png`,
-    alt: 'Dashboard displaying ML models with versions, authors, and tags',
+    alt: "Dashboard displaying ML models with versions, authors, and tags",
   },
 } as const;
 
 /** Shared final CTA used across all categories */
 const SHARED_FINAL_CTA = {
-  headline: 'Experience the ZenML Difference: Book Your Customized Demo',
+  headline: "Experience the ZenML Difference: Book Your Customized Demo",
   bullets: [
     "See ZenML's superior model orchestration in action",
-    'Discover how ZenML offers more with your existing ML tools',
-    'Find out why data security with ZenML outshines the rest',
+    "Discover how ZenML offers more with your existing ML tools",
+    "Find out why data security with ZenML outshines the rest",
   ],
-  primaryCta: { label: 'Start Free Trial', href: 'https://cloud.zenml.io/signup' },
-  secondaryCta: { label: 'Use Open Source', href: '/get-started' },
+  primaryCta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+  },
+  secondaryCta: { label: "Use Open Source", href: "/get-started" },
   image: DASHBOARD_IMAGES.modelControlPlane,
 };
 
@@ -101,117 +105,126 @@ const SHARED_FINAL_CTA = {
 const ORCHESTRATORS: CompareCategoryDefaults = {
   valueSections: [
     {
-      title: 'Start locally without complicated setup hassle',
+      title: "Start locally without complicated setup hassle",
       bullets: [
-        'ZenML is available as a simple pip package that lets you run and track pipelines locally.',
-        'ZenML integrates with your orchestration layer of choice, avoiding having to learn different paradigms for dev, staging, and prod.',
-        'ZenML integrates with your orchestration layer of choice or can be extended with your own orchestration service.',
+        "ZenML is available as a simple pip package that lets you run and track pipelines locally.",
+        "ZenML integrates with your orchestration layer of choice, avoiding having to learn different paradigms for dev, staging, and prod.",
+        "ZenML integrates with your orchestration layer of choice or can be extended with your own orchestration service.",
       ],
       image: DASHBOARD_IMAGES.localToProduction,
-      imageSide: 'right',
+      imageSide: "right",
     },
     {
-      title: 'Abstract away infrastructure complexity',
+      title: "Abstract away infrastructure complexity",
       bullets: [
-        'Most orchestrators assume some form of infrastructure knowledge to use them maximally — ZenML abstracts that complexity away.',
-        'ZenML separates infrastructure setup like Docker building from the application logic, and automates the tedious parts.',
-        'ZenML focuses on the handovers between MLOps Engineers, ML Engineers, and Data Scientists.',
+        "Most orchestrators assume some form of infrastructure knowledge to use them maximally — ZenML abstracts that complexity away.",
+        "ZenML separates infrastructure setup like Docker building from the application logic, and automates the tedious parts.",
+        "ZenML focuses on the handovers between MLOps Engineers, ML Engineers, and Data Scientists.",
       ],
       image: DASHBOARD_IMAGES.collaborationShowcase,
-      imageSide: 'left',
+      imageSide: "left",
     },
     {
-      title: 'Switch between orchestrators depending on your context',
+      title: "Switch between orchestrators depending on your context",
       bullets: [
-        'You can switch between different orchestration services with a single click — from dev to staging to production.',
-        'The more engineering-minded in the team still retain control over their productionalization because the framework is extensible.',
-        'ZenML handles the pain of packaging your code into Docker to be deployed to your orchestration service of choice.',
+        "You can switch between different orchestration services with a single click — from dev to staging to production.",
+        "The more engineering-minded in the team still retain control over their productionalization because the framework is extensible.",
+        "ZenML handles the pain of packaging your code into Docker to be deployed to your orchestration service of choice.",
       ],
       image: DASHBOARD_IMAGES.productionalizationShowcase,
-      imageSide: 'right',
+      imageSide: "right",
     },
   ],
-  strategyCtaHeadline: 'Outperform Orchestrators: Book Your Free ZenML Strategy Talk',
-  showdownEyebrow: 'Orchestrator Showdown',
-  showdownHeadline: 'Explore the Advantages of ZenML Over Other Orchestrator Tools',
+  strategyCtaHeadline:
+    "Outperform Orchestrators: Book Your Free ZenML Strategy Talk",
+  showdownEyebrow: "Orchestrator Showdown",
+  showdownHeadline:
+    "Explore the Advantages of ZenML Over Other Orchestrator Tools",
   finalCta: SHARED_FINAL_CTA,
 };
 
 const E2E_PLATFORMS: CompareCategoryDefaults = {
   valueSections: [
     {
-      title: 'Run the same workloads on any cloud to gain strategic flexibility',
+      title:
+        "Run the same workloads on any cloud to gain strategic flexibility",
       bullets: [
-        'ZenML does not tie your work to one cloud.',
-        'Define infrastructure as stack components independent of your code.',
-        'Run any code on any stack with minimum fuss.',
+        "ZenML does not tie your work to one cloud.",
+        "Define infrastructure as stack components independent of your code.",
+        "Run any code on any stack with minimum fuss.",
       ],
       image: DASHBOARD_IMAGES.vendorLockIn,
-      imageSide: 'right',
+      imageSide: "right",
     },
     {
-      title: '50+ integrations with the most popular cloud and open-source tools',
+      title:
+        "50+ integrations with the most popular cloud and open-source tools",
       bullets: [
-        'From experiment trackers like MLflow and Weights & Biases to model deployers like Seldon and BentoML, ZenML has integrations for tools across the lifecycle.',
-        'Flexibly run workflows across all clouds or orchestration tools such as Airflow or Kubeflow.',
-        'AWS, GCP, and Azure integrations all supported out of the box.',
+        "From experiment trackers like MLflow and Weights & Biases to model deployers like Seldon and BentoML, ZenML has integrations for tools across the lifecycle.",
+        "Flexibly run workflows across all clouds or orchestration tools such as Airflow or Kubeflow.",
+        "AWS, GCP, and Azure integrations all supported out of the box.",
       ],
       image: DASHBOARD_IMAGES.integrationsShowcase,
-      imageSide: 'left',
+      imageSide: "left",
     },
     {
-      title: 'Avoid getting locked in to a vendor',
+      title: "Avoid getting locked in to a vendor",
       bullets: [
-        'Avoid tangling up code with tooling libraries that make it hard to transition.',
-        'Easily set up multiple MLOps stacks for different teams with different requirements.',
-        'Switch between tools and platforms seamlessly.',
+        "Avoid tangling up code with tooling libraries that make it hard to transition.",
+        "Easily set up multiple MLOps stacks for different teams with different requirements.",
+        "Switch between tools and platforms seamlessly.",
       ],
       image: DASHBOARD_IMAGES.productionalizationShowcase,
-      imageSide: 'right',
+      imageSide: "right",
     },
   ],
-  strategyCtaHeadline: 'Outperform E2E Platforms: Book Your Free ZenML Strategy Talk',
-  showdownEyebrow: 'E2E Platform Showdown',
-  showdownHeadline: 'Explore the Advantages of ZenML Over Other E2E Platform Tools',
+  strategyCtaHeadline:
+    "Outperform E2E Platforms: Book Your Free ZenML Strategy Talk",
+  showdownEyebrow: "E2E Platform Showdown",
+  showdownHeadline:
+    "Explore the Advantages of ZenML Over Other E2E Platform Tools",
   finalCta: SHARED_FINAL_CTA,
 };
 
 const EXPERIMENT_TRACKERS: CompareCategoryDefaults = {
   valueSections: [
     {
-      title: 'Pipelines as experiments',
+      title: "Pipelines as experiments",
       bullets: [
-        'ZenML is built on top of the idea of steps and pipelines, which play together nicely with experiment tracking tools.',
-        'Experiment tracking tools like MLflow are good to track your training runs and hyperparameters while pipelines automate runs.',
-        'ZenML is a management layer on top of your ML experiments, and manages their lifecycle within the context of a pipeline.',
+        "ZenML is built on top of the idea of steps and pipelines, which play together nicely with experiment tracking tools.",
+        "Experiment tracking tools like MLflow are good to track your training runs and hyperparameters while pipelines automate runs.",
+        "ZenML is a management layer on top of your ML experiments, and manages their lifecycle within the context of a pipeline.",
       ],
       image: DASHBOARD_IMAGES.localToProduction,
-      imageSide: 'right',
+      imageSide: "right",
     },
     {
-      title: 'Connect your experiment trackers with your infrastructure securely',
+      title:
+        "Connect your experiment trackers with your infrastructure securely",
       bullets: [
-        'ZenML connectors can be used to establish a secure connection to your production infrastructure with your experiment tracker.',
-        'Keeps the complexity of authentication and authorization away from your code.',
-        'ZenML establishes a link between your experiment trackers and your entire MLOps process.',
+        "ZenML connectors can be used to establish a secure connection to your production infrastructure with your experiment tracker.",
+        "Keeps the complexity of authentication and authorization away from your code.",
+        "ZenML establishes a link between your experiment trackers and your entire MLOps process.",
       ],
       image: DASHBOARD_IMAGES.portabilityShowcase,
-      imageSide: 'left',
+      imageSide: "left",
     },
     {
-      title: 'Provide lineage and provenance for your experiments',
+      title: "Provide lineage and provenance for your experiments",
       bullets: [
-        'Experiment trackers focus mostly on training — while MLOps stretches beyond that.',
-        'ZenML provides an overview of the entire process from feature engineering, to training, to deployment, inference and beyond.',
-        'ZenML can be paired nicely with experiment trackers to provide full reproducibility and auditability over multiple tracking tools.',
+        "Experiment trackers focus mostly on training — while MLOps stretches beyond that.",
+        "ZenML provides an overview of the entire process from feature engineering, to training, to deployment, inference and beyond.",
+        "ZenML can be paired nicely with experiment trackers to provide full reproducibility and auditability over multiple tracking tools.",
       ],
       image: DASHBOARD_IMAGES.dataVersioningShowcase,
-      imageSide: 'right',
+      imageSide: "right",
     },
   ],
-  strategyCtaHeadline: 'Outperform Experiment Trackers: Book Your Free ZenML Strategy Talk',
-  showdownEyebrow: 'Experiment Tracker Showdown',
-  showdownHeadline: 'Explore the Advantages of ZenML Over Other Experiment Tracker Tools',
+  strategyCtaHeadline:
+    "Outperform Experiment Trackers: Book Your Free ZenML Strategy Talk",
+  showdownEyebrow: "Experiment Tracker Showdown",
+  showdownHeadline:
+    "Explore the Advantages of ZenML Over Other Experiment Tracker Tools",
   finalCta: SHARED_FINAL_CTA,
 };
 
@@ -219,39 +232,39 @@ const EXPERIMENT_TRACKERS: CompareCategoryDefaults = {
 const GENERIC: CompareCategoryDefaults = {
   valueSections: [
     {
-      title: 'Open-source and vendor-neutral',
+      title: "Open-source and vendor-neutral",
       bullets: [
-        'ZenML is fully open-source, giving you complete control over your ML infrastructure.',
-        'Avoid platform lock-in — run the same pipelines across any cloud or on-prem environment.',
-        'Benefit from a transparent, community-driven development process.',
+        "ZenML is fully open-source, giving you complete control over your ML infrastructure.",
+        "Avoid platform lock-in — run the same pipelines across any cloud or on-prem environment.",
+        "Benefit from a transparent, community-driven development process.",
       ],
       image: DASHBOARD_IMAGES.localToProduction,
-      imageSide: 'right',
+      imageSide: "right",
     },
     {
-      title: 'Composable stack architecture',
+      title: "Composable stack architecture",
       bullets: [
-        'Choose your own orchestrator, experiment tracker, artifact store, and model deployer.',
-        'Swap infrastructure components without rewriting pipeline code.',
-        'Integrate new tools instantly as they emerge without waiting for vendor support.',
+        "Choose your own orchestrator, experiment tracker, artifact store, and model deployer.",
+        "Swap infrastructure components without rewriting pipeline code.",
+        "Integrate new tools instantly as they emerge without waiting for vendor support.",
       ],
       image: DASHBOARD_IMAGES.integrationsShowcase,
-      imageSide: 'left',
+      imageSide: "left",
     },
     {
-      title: 'Code-first, Python-native workflows',
+      title: "Code-first, Python-native workflows",
       bullets: [
-        'Define pipelines in pure Python with simple decorators — no YAML or DSL to learn.',
-        'Start locally with pip install and scale to production on any cloud.',
-        'Version control your entire ML workflow alongside your application code.',
+        "Define pipelines in pure Python with simple decorators — no YAML or DSL to learn.",
+        "Start locally with pip install and scale to production on any cloud.",
+        "Version control your entire ML workflow alongside your application code.",
       ],
       image: DASHBOARD_IMAGES.productionalizationShowcase,
-      imageSide: 'right',
+      imageSide: "right",
     },
   ],
-  strategyCtaHeadline: 'Book Your Free ZenML Strategy Talk',
-  showdownEyebrow: 'Tool Showdown',
-  showdownHeadline: 'Explore the Advantages of ZenML Over Other Tools',
+  strategyCtaHeadline: "Book Your Free ZenML Strategy Talk",
+  showdownEyebrow: "Tool Showdown",
+  showdownHeadline: "Explore the Advantages of ZenML Over Other Tools",
   finalCta: SHARED_FINAL_CTA,
 };
 
@@ -261,15 +274,17 @@ const GENERIC: CompareCategoryDefaults = {
 
 const CATEGORY_DEFAULTS: Record<string, CompareCategoryDefaults> = {
   orchestrators: ORCHESTRATORS,
-  'e2e-platforms': E2E_PLATFORMS,
-  'experiment-trackers': EXPERIMENT_TRACKERS,
+  "e2e-platforms": E2E_PLATFORMS,
+  "experiment-trackers": EXPERIMENT_TRACKERS,
 };
 
 /**
  * Get category defaults for a compare page.
  * Falls back to generic defaults for unknown categories.
  */
-export function getCategoryDefaults(category: string | undefined): CompareCategoryDefaults {
+export function getCategoryDefaults(
+  category: string | undefined,
+): CompareCategoryDefaults {
   if (!category) return GENERIC;
   return CATEGORY_DEFAULTS[category] ?? GENERIC;
 }
@@ -280,21 +295,24 @@ export function getCategoryDefaults(category: string | undefined): CompareCatego
  */
 export function formatCategoryLabel(category: string): string {
   const labels: Record<string, string> = {
-    orchestrators: 'Orchestrator',
-    'e2e-platforms': 'E2E Platform',
-    'experiment-trackers': 'Experiment Tracker',
-    'llm-observability': 'LLM Observability',
-    'genai-frameworks': 'GenAI Framework',
-    'data-model-versioning': 'Data/Model Versioning',
-    'model-serving': 'Model Serving',
-    'data-annotators': 'Data Annotation',
-    modeling: 'Modeling',
+    orchestrators: "Orchestrator",
+    "e2e-platforms": "E2E Platform",
+    "experiment-trackers": "Experiment Tracker",
+    "llm-observability": "LLM Observability",
+    "genai-frameworks": "GenAI Framework",
+    "data-model-versioning": "Data/Model Versioning",
+    "model-serving": "Model Serving",
+    "data-annotators": "Data Annotation",
+    modeling: "Modeling",
   };
-  return labels[category] ?? category.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+  return (
+    labels[category] ??
+    category.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())
+  );
 }
 
 /** ZenML icon URL on R2 (used in hero lockup and comparison headers) */
 export const ZENML_ICON_URL = `${R2}/e2bdf58e/667037da03e4569db6e31135_zenml_icon.webp`;
 
 /** ZenML icon (local, for code comparison white variant) */
-export const ZENML_ICON_LOCAL = '/images/zenml-icon.webp';
+export const ZENML_ICON_LOCAL = "/images/zenml-icon.webp";

--- a/src/lib/consentConfig.ts
+++ b/src/lib/consentConfig.ts
@@ -6,7 +6,11 @@
  * which scripts to inject) and TrackingScripts (for SSR list).
  */
 
-export type ConsentCategory = "essential" | "analytics" | "marketing" | "personalization";
+export type ConsentCategory =
+  | "essential"
+  | "analytics"
+  | "marketing"
+  | "personalization";
 
 export interface ScriptDefinition {
   /** Unique identifier for deduplication */
@@ -99,19 +103,22 @@ export const CONSENT_CATEGORIES: {
   {
     id: "analytics",
     label: "Analytics",
-    description: "Help us understand how visitors use our site (GA4, Segment, Hotjar).",
+    description:
+      "Help us understand how visitors use our site (GA4, Segment, Hotjar).",
     required: false,
   },
   {
     id: "marketing",
     label: "Marketing",
-    description: "Enable targeted advertising and lead identification (HubSpot, Reo, Apollo).",
+    description:
+      "Enable targeted advertising and lead identification (HubSpot, Reo, Apollo).",
     required: false,
   },
   {
     id: "personalization",
     label: "Personalization",
-    description: "Customize content and experiences (GitHub star count, HubSpot chat).",
+    description:
+      "Customize content and experiences (GitHub star count, HubSpot chat).",
     required: false,
   },
 ];

--- a/src/lib/deployments.ts
+++ b/src/lib/deployments.ts
@@ -25,7 +25,10 @@ export const DEPLOYMENTS_SEO = {
 export const DEPLOYMENTS_HERO = {
   headline: "Flexible Deployment for Your MLOps Needs",
   deck: "Streamline your machine learning workflows with ZenML's adaptable deployment options. Whether you're experimenting locally or scaling to production, ZenML empowers you to orchestrate, manage, and deploy your models with ease.",
-  primaryCta: { label: "Start Free Trial", href: "https://cloud.zenml.io/signup" } as CtaLink,
+  primaryCta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+  } as CtaLink,
   secondaryCta: {
     label: "Read the Documentation",
     href: "https://docs.zenml.io/getting-started/deploying-zenml",
@@ -71,7 +74,10 @@ export const DEPLOYMENTS_COMPARISON = {
   headline: "Choose the Deployment that Fits Your Needs",
   columnHeaders: ["Open Source (Self-hosted)", "Pro"],
   rows: [
-    { feature: "Run pipelines on cloud infra", values: ["Self-hosted", "SaaS / Self-hosted"] },
+    {
+      feature: "Run pipelines on cloud infra",
+      values: ["Self-hosted", "SaaS / Self-hosted"],
+    },
     { feature: "Run pipelines on cloud infra", values: [true, true] },
     { feature: "Managed platform", values: [false, true] },
     { feature: "No setup required", values: [false, true] },
@@ -98,7 +104,8 @@ export const DEPLOYMENTS_SCENARIOS = [
       url: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/7c72dd14/local-deployments.png`,
       alt: "ZenML Default Local Configuration architecture diagram showing User Code, CLI, ZenML Client, and Metadata Store (SQLite).",
     },
-    learnMoreHref: "https://docs.zenml.io/deploying-zenml/deploying-zenml#deployment-scenarios",
+    learnMoreHref:
+      "https://docs.zenml.io/deploying-zenml/deploying-zenml#deployment-scenarios",
   },
   {
     title: "Deploy the ZenML server to start collaborating",
@@ -174,7 +181,8 @@ export const DEPLOYMENTS_TABS = {
       label: "Local",
       badge: "OSS",
       badgeVariant: "default" as const,
-      description: "A FastAPI-based server managing metadata of pipelines, artifacts, and stacks. Free with Apache 2.0 license, perfect for individual projects and small teams starting their MLOps journey.",
+      description:
+        "A FastAPI-based server managing metadata of pipelines, artifacts, and stacks. Free with Apache 2.0 license, perfect for individual projects and small teams starting their MLOps journey.",
       image: {
         url: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/a0c2a2dd/deployment_diagram_1.png`,
         alt: "ZenML OSS deployment architecture showing two user environments with ZenML Client connecting to a centralized ZenML OSS Server, Dashboard, and MySQL Metadata Store.",
@@ -184,7 +192,8 @@ export const DEPLOYMENTS_TABS = {
       label: "SaaS",
       badge: "PRO",
       badgeVariant: "pro" as const,
-      description: "Fully managed ZenML deployment with enhanced collaboration features, RBAC, and enterprise support. Ideal for teams looking for a zero-maintenance MLOps solution.",
+      description:
+        "Fully managed ZenML deployment with enhanced collaboration features, RBAC, and enterprise support. Ideal for teams looking for a zero-maintenance MLOps solution.",
       image: {
         url: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/a44cd000/deployment_diagram_2.png`,
         alt: "ZenML Pro Deployment architecture with control plane, identity provider, Pro Server, PostgreSQL, and two OSS Tenants with Pro Features.",
@@ -194,7 +203,8 @@ export const DEPLOYMENTS_TABS = {
       label: "Self-hosted",
       badge: "PRO",
       badgeVariant: "pro" as const,
-      description: "Enterprise-grade deployment on your infrastructure. Complete control over data and secrets with all Pro features. Perfect for organizations with strict security requirements.",
+      description:
+        "Enterprise-grade deployment on your infrastructure. Complete control over data and secrets with all Pro features. Perfect for organizations with strict security requirements.",
       image: {
         url: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/bac3ad93/deployment_diagram_3.png`,
         alt: "Customer Environment architecture for ZenML Pro showing Pro Metadata Store, Pro Dashboard, ZenML Control Plane, and two Tenants with external service connections.",
@@ -202,12 +212,30 @@ export const DEPLOYMENTS_TABS = {
     },
   ],
   features: [
-    { title: "Fully managed service", body: "ZenML handles deployment, maintenance, and infrastructure." },
-    { title: "Simplified workflow", body: "Allows you to focus on your ML workflows without infrastructure management overhead." },
-    { title: "Scalable architecture", body: "Suitable for teams and organisations looking for a streamlined and scalable solution." },
-    { title: "Full on-prem available", body: "Full on-prem deployment available as well (ask for details)" },
-    { title: "Enhanced observability", body: "Enhanced security features and integrations with cloud services." },
-    { title: "Risk-free evaluation", body: "14-day free trial for thorough testing and POC development." },
+    {
+      title: "Fully managed service",
+      body: "ZenML handles deployment, maintenance, and infrastructure.",
+    },
+    {
+      title: "Simplified workflow",
+      body: "Allows you to focus on your ML workflows without infrastructure management overhead.",
+    },
+    {
+      title: "Scalable architecture",
+      body: "Suitable for teams and organisations looking for a streamlined and scalable solution.",
+    },
+    {
+      title: "Full on-prem available",
+      body: "Full on-prem deployment available as well (ask for details)",
+    },
+    {
+      title: "Enhanced observability",
+      body: "Enhanced security features and integrations with cloud services.",
+    },
+    {
+      title: "Risk-free evaluation",
+      body: "14-day free trial for thorough testing and POC development.",
+    },
   ],
 } as const;
 
@@ -221,7 +249,10 @@ export const DEPLOYMENTS_FINAL_CTA = {
     "Works with any infrastructure",
     "Upgrade to managed Pro features",
   ],
-  primaryCta: { label: "Start Free Trial", href: "https://cloud.zenml.io/signup" } as CtaLink,
+  primaryCta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+  } as CtaLink,
   secondaryCta: { label: "Use Open Source", href: "/get-started" } as CtaLink,
   image: {
     url: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/339bb62b/66e9556fd34d2791885b0c5f_model_control_plane_01.png`,

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -7,14 +7,20 @@
 export const FEATURES_HUB_HERO = {
   headline: "ZenML Features: Your MLOps Framework Solution",
   body: "Tired of setting up new MLOps tools, doing manual deployments, or having non-reproducible experiments? Use ZenML MLOps Framework to transform your ML workflows into production-ready solutions.",
-  primaryCta: { label: "Start Free Trial", href: "https://cloud.zenml.io/signup" },
+  primaryCta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+  },
   secondaryCta: { label: "Use Open Source", href: "/get-started" },
 };
 
 export const FEATURES_HUB_CTA = {
   headline: "Start deploying reproducible AI workflows today",
   body: "Enterprise-grade MLOps platform trusted by thousands of companies in production.",
-  primaryCta: { label: "Start Free Trial", href: "https://cloud.zenml.io/signup" },
+  primaryCta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+  },
   secondaryCta: { label: "Use Open Source", href: "https://cloud.zenml.io" },
 };
 

--- a/src/lib/formConstants.ts
+++ b/src/lib/formConstants.ts
@@ -16,7 +16,8 @@ import type { BrevoFormConfig } from "./formTypes";
  * Set to undefined to disable Turnstile on forms (e.g. during local dev).
  * Create the widget at: https://dash.cloudflare.com → Turnstile → Add widget
  */
-export const TURNSTILE_SITE_KEY: string | undefined = "0x4AAAAAAChe6jgz2GyYLHgE";
+export const TURNSTILE_SITE_KEY: string | undefined =
+  "0x4AAAAAAChe6jgz2GyYLHgE";
 
 // ---------------------------------------------------------------------------
 // Cal.com

--- a/src/lib/formValidation.ts
+++ b/src/lib/formValidation.ts
@@ -5,7 +5,11 @@
  * the Cloudflare Pages Function (server-side).
  */
 
-export type FormType = "demo-request" | "whitepaper" | "brick-manual" | "startup-academic";
+export type FormType =
+  | "demo-request"
+  | "whitepaper"
+  | "brick-manual"
+  | "startup-academic";
 
 interface FieldRule {
   required?: boolean;
@@ -20,20 +24,40 @@ const URL_RE = /^https?:\/\/.+/;
 export const FORM_RULES: Record<FormType, Record<string, FieldRule>> = {
   "demo-request": {
     fullName: { required: true, message: "Full name is required" },
-    email: { required: true, pattern: EMAIL_RE, message: "Valid work email is required" },
+    email: {
+      required: true,
+      pattern: EMAIL_RE,
+      message: "Valid work email is required",
+    },
   },
   whitepaper: {
     fullName: { required: true, message: "Full name is required" },
-    email: { required: true, pattern: EMAIL_RE, message: "Valid work email is required" },
+    email: {
+      required: true,
+      pattern: EMAIL_RE,
+      message: "Valid work email is required",
+    },
   },
   "brick-manual": {
     fullName: { required: true, message: "Full name is required" },
-    email: { required: true, pattern: EMAIL_RE, message: "Valid email is required" },
+    email: {
+      required: true,
+      pattern: EMAIL_RE,
+      message: "Valid email is required",
+    },
   },
   "startup-academic": {
     fullName: { required: true, message: "Full name is required" },
-    email: { required: true, pattern: EMAIL_RE, message: "Valid email is required" },
-    linkedin: { required: true, pattern: URL_RE, message: "LinkedIn URL is required" },
+    email: {
+      required: true,
+      pattern: EMAIL_RE,
+      message: "Valid email is required",
+    },
+    linkedin: {
+      required: true,
+      pattern: URL_RE,
+      message: "LinkedIn URL is required",
+    },
     company: { required: true, message: "Organization name is required" },
     role: { required: true, message: "Please select a role" },
   },

--- a/src/lib/getStarted.ts
+++ b/src/lib/getStarted.ts
@@ -152,6 +152,12 @@ export const GET_STARTED_RESOURCES = {
 export const GET_STARTED_FINAL_CTA = {
   headline: "Ready for the next level?",
   body: "Go beyond open source with ZenML Pro. Get enterprise features, managed infrastructure, RBAC, enhanced security, dedicated support, and more.",
-  primaryCta: { label: "Compare OSS vs Pro", href: "/open-source-vs-pro" } as CtaLink,
-  secondaryCta: { label: "Start Free Trial", href: "https://cloud.zenml.io/signup" } as CtaLink,
+  primaryCta: {
+    label: "Compare OSS vs Pro",
+    href: "/open-source-vs-pro",
+  } as CtaLink,
+  secondaryCta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+  } as CtaLink,
 } as const;

--- a/src/lib/homepage.ts
+++ b/src/lib/homepage.ts
@@ -19,7 +19,10 @@ export const HERO = {
   headline: "The AI Control Plane",
   subheadline:
     "One layer for orchestration, versioning, and governance — from training pipelines to agent evals, local to Kubernetes.",
-  primaryCta: { label: "Start Free Trial", href: "https://cloud.zenml.io/signup" },
+  primaryCta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+  },
   secondaryCta: { label: "Use Open Source", href: "/get-started" },
   githubUrl: "https://github.com/zenml-io/zenml",
   /** Lottie JSON for hero animation (autoplay, no loop, 6.4s, SVG renderer).
@@ -39,18 +42,34 @@ export interface LogoItem {
 }
 
 import { R2_WEBFLOW_BASE } from "./constants";
+
 const R2 = R2_WEBFLOW_BASE;
 
 export const LOGO_CLOUD = {
   label: "Trusted by 1,000s of top companies to standardize their AI workflows",
   logos: [
-    { name: "Airbus", src: `${R2}/6a2ae7e3/670e2f23d254a9be9e02e50f_airbus.svg` },
+    {
+      name: "Airbus",
+      src: `${R2}/6a2ae7e3/670e2f23d254a9be9e02e50f_airbus.svg`,
+    },
     { name: "AXA", src: `${R2}/5f1b0e8a/670e2f23b0b89bea22ecee3c_axa-min.svg` },
-    { name: "Bundeswehr", src: `${R2}/e8e86576/670e2f2398fcad5e2e8f2775_bundeswehr.svg` },
-    { name: "Enel", src: `${R2}/4f6e5fe1/670e2f2349aab64d5e4eeeb3_enel-min.svg` },
-    { name: "JetBrains", src: `${R2}/60b5e34d/670e2f23ee3f2feee5e7e7e2_jetbrains-min.svg` },
+    {
+      name: "Bundeswehr",
+      src: `${R2}/e8e86576/670e2f2398fcad5e2e8f2775_bundeswehr.svg`,
+    },
+    {
+      name: "Enel",
+      src: `${R2}/4f6e5fe1/670e2f2349aab64d5e4eeeb3_enel-min.svg`,
+    },
+    {
+      name: "JetBrains",
+      src: `${R2}/60b5e34d/670e2f23ee3f2feee5e7e7e2_jetbrains-min.svg`,
+    },
     { name: "Koble", src: `${R2}/db4b0c5a/670e2f2331d7f8f62e12458e_koble.svg` },
-    { name: "Leroy Merlin", src: `${R2}/d28fbdf4/670e2f23e2b3ba3756fae38e_leroy_merlin_logo-min.svg` },
+    {
+      name: "Leroy Merlin",
+      src: `${R2}/d28fbdf4/670e2f23e2b3ba3756fae38e_leroy_merlin_logo-min.svg`,
+    },
     { name: "ADEO", src: "/images/logos/adeo.png" },
     { name: "Devoteam", src: "/images/logos/devoteam.svg" },
     { name: "Frontiers", src: "/images/logos/frontiers.webp" },
@@ -63,7 +82,10 @@ export const LOGO_CLOUD = {
     { name: "ALKi", src: "/images/logos/alki.webp" },
     { name: "Altenar", src: "/images/logos/altenar.svg" },
     { name: "Brevo", src: "/images/logos/brevo.webp", maxWidth: "80px" },
-    { name: "Digital Diagnostics", src: "/images/logos/digital-diagnostics.svg" },
+    {
+      name: "Digital Diagnostics",
+      src: "/images/logos/digital-diagnostics.svg",
+    },
     { name: "EarthDaily Agro", src: "/images/logos/earthdaily-agro.png" },
     { name: "Eikon Therapeutics", src: "/images/logos/eikon-therapeutics.svg" },
     { name: "Hemato", src: "/images/logos/hemato.png" },
@@ -209,7 +231,10 @@ export const VALUE_PROPS_CTA = {
   headline: "Ready to Unify Your AI Platform?",
   subtext:
     "Join thousands of teams using ZenML to eliminate chaos and accelerate AI delivery",
-  primaryCta: { label: "Start Free Trial", href: "https://cloud.zenml.io/signup" },
+  primaryCta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+  },
   secondaryCta: { label: "Use Open Source", href: "/get-started" },
 };
 
@@ -422,8 +447,7 @@ export const FAQ = {
         'Yes, ZenML is fully compatible and intended for productionalizing LLM applications. We have examples with <a href="https://www.llamaindex.ai/" class="text-zenml-500 underline" target="_blank" rel="noopener noreferrer">LlamaIndex</a>, <a href="https://openai.com/" class="text-zenml-500 underline" target="_blank" rel="noopener noreferrer">OpenAI</a>, <a href="https://www.langchain.com/" class="text-zenml-500 underline" target="_blank" rel="noopener noreferrer">LangChain</a>, and more. Check out our <a href="/projects" class="text-zenml-500 underline">projects</a> for real-world examples.',
     },
     {
-      question:
-        "How can I build my MLOps/LLMOps platform using ZenML?",
+      question: "How can I build my MLOps/LLMOps platform using ZenML?",
       answer:
         'Start simple with our <a href="https://docs.zenml.io/user-guides" class="text-zenml-500 underline" target="_blank" rel="noopener noreferrer">user guides</a>, then extend with experiment trackers, model deployers, model registries and more from the <a href="https://docs.zenml.io/stacks" class="text-zenml-500 underline" target="_blank" rel="noopener noreferrer">stack components</a> library.',
     },
@@ -446,7 +470,10 @@ export const FINAL_CTA = {
     "Works with any infrastructure",
     "Upgrade to managed Pro features",
   ],
-  primaryCta: { label: "Start Free Trial", href: "https://cloud.zenml.io/signup" },
+  primaryCta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+  },
   secondaryCta: { label: "Use Open Source", href: "/get-started" },
   image: `${R2}/4ab5ef16/66e9556fd34d2791885b0c5f_model_control_plane_01.png`,
   imageAlt:

--- a/src/lib/llmops.ts
+++ b/src/lib/llmops.ts
@@ -16,7 +16,10 @@ export type LLMOpsEntry = CollectionEntry<"llmops-database">;
 
 /** All published entries, sorted by year descending then title A-Z. */
 export async function getAllPublishedEntries(): Promise<LLMOpsEntry[]> {
-  const entries = await getCollection("llmops-database", ({ data }) => !data.draft);
+  const entries = await getCollection(
+    "llmops-database",
+    ({ data }) => !data.draft,
+  );
   return sortByYearDesc(entries);
 }
 
@@ -29,8 +32,16 @@ export function sortByYearDesc(entries: LLMOpsEntry[]): LLMOpsEntry[] {
 }
 
 export type LLMOpsProvenance = {
-  webflow?: { lastPublished?: string; lastUpdated?: string; createdOn?: string };
-  notion?: { publishedAt?: string; lastEditedTime?: string; createdTime?: string };
+  webflow?: {
+    lastPublished?: string;
+    lastUpdated?: string;
+    createdOn?: string;
+  };
+  notion?: {
+    publishedAt?: string;
+    lastEditedTime?: string;
+    createdTime?: string;
+  };
 };
 
 /**
@@ -52,7 +63,7 @@ export function deriveAddedDate(data: LLMOpsProvenance): Date | null {
   for (const raw of candidates) {
     if (!raw) continue;
     const d = new Date(raw);
-    if (!isNaN(d.getTime())) return d;
+    if (!Number.isNaN(d.getTime())) return d;
   }
   return null;
 }
@@ -66,10 +77,10 @@ export function deriveAddedDate(data: LLMOpsProvenance): Date | null {
  * Build once via `buildRelatedIndex()`, then call `getRelatedFromIndex()` per entry.
  */
 export interface RelatedIndex {
-  byTag: Map<string, Set<string>>;       // tag slug → set of entry slugs
-  byIndustry: Map<string, Set<string>>;  // industry slug → set of entry slugs
-  byCompany: Map<string, Set<string>>;   // company name → set of entry slugs
-  entryMap: Map<string, LLMOpsEntry>;    // slug → entry (for lookup)
+  byTag: Map<string, Set<string>>; // tag slug → set of entry slugs
+  byIndustry: Map<string, Set<string>>; // industry slug → set of entry slugs
+  byCompany: Map<string, Set<string>>; // company name → set of entry slugs
+  entryMap: Map<string, LLMOpsEntry>; // slug → entry (for lookup)
 }
 
 /** Build inverted indexes from all entries — call once in getStaticPaths. */
@@ -85,17 +96,26 @@ export function buildRelatedIndex(entries: LLMOpsEntry[]): RelatedIndex {
 
     for (const tag of e.data.llmopsTags) {
       let set = byTag.get(tag);
-      if (!set) { set = new Set(); byTag.set(tag, set); }
+      if (!set) {
+        set = new Set();
+        byTag.set(tag, set);
+      }
       set.add(slug);
     }
     if (e.data.industryTags) {
       let set = byIndustry.get(e.data.industryTags);
-      if (!set) { set = new Set(); byIndustry.set(e.data.industryTags, set); }
+      if (!set) {
+        set = new Set();
+        byIndustry.set(e.data.industryTags, set);
+      }
       set.add(slug);
     }
     if (e.data.company) {
       let set = byCompany.get(e.data.company);
-      if (!set) { set = new Set(); byCompany.set(e.data.company, set); }
+      if (!set) {
+        set = new Set();
+        byCompany.set(e.data.company, set);
+      }
       set.add(slug);
     }
   }
@@ -152,7 +172,10 @@ export function getRelatedFromIndex(
     }
   }
 
-  return topK.map(({ slug }) => index.entryMap.get(slug)!);
+  return topK.flatMap(({ slug }) => {
+    const entry = index.entryMap.get(slug);
+    return entry ? [entry] : [];
+  });
 }
 
 /** @deprecated Use buildRelatedIndex + getRelatedFromIndex for batch lookups. */
@@ -174,13 +197,18 @@ export function getRelatedEntries(
         if (currentTags.has(tag)) score += 3;
       }
       // +2 for same industry
-      if (currentIndustry && e.data.industryTags === currentIndustry) score += 2;
+      if (currentIndustry && e.data.industryTags === currentIndustry)
+        score += 2;
       // +1 for same company
       if (currentCompany && e.data.company === currentCompany) score += 1;
       return { entry: e, score };
     })
     .filter(({ score }) => score > 0)
-    .sort((a, b) => b.score - a.score || a.entry.data.title.localeCompare(b.entry.data.title));
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        a.entry.data.title.localeCompare(b.entry.data.title),
+    );
 
   return scored.slice(0, limit).map(({ entry }) => entry);
 }
@@ -191,7 +219,9 @@ export function getRelatedEntries(
 
 export type TaxonomyCount = { slug: string; name: string; count: number };
 
-export async function getLLMOpsTagCounts(entries: LLMOpsEntry[]): Promise<TaxonomyCount[]> {
+export async function getLLMOpsTagCounts(
+  entries: LLMOpsEntry[],
+): Promise<TaxonomyCount[]> {
   const countMap = new Map<string, number>();
   for (const e of entries) {
     for (const tag of e.data.llmopsTags) {
@@ -207,11 +237,16 @@ export async function getLLMOpsTagCounts(entries: LLMOpsEntry[]): Promise<Taxono
   return result.sort((a, b) => b.count - a.count);
 }
 
-export async function getIndustryTagCounts(entries: LLMOpsEntry[]): Promise<TaxonomyCount[]> {
+export async function getIndustryTagCounts(
+  entries: LLMOpsEntry[],
+): Promise<TaxonomyCount[]> {
   const countMap = new Map<string, number>();
   for (const e of entries) {
     if (e.data.industryTags) {
-      countMap.set(e.data.industryTags, (countMap.get(e.data.industryTags) || 0) + 1);
+      countMap.set(
+        e.data.industryTags,
+        (countMap.get(e.data.industryTags) || 0) + 1,
+      );
     }
   }
 

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -141,7 +141,8 @@ export const NAV_DROPDOWNS: NavDropdown[] = [
           {
             label: "LLMOps Database",
             href: "/llmops-database",
-            description: "A curated knowledge base of real-world implementations",
+            description:
+              "A curated knowledge base of real-world implementations",
             icon: '<path d="M21 5C21 6.65685 16.9706 8 12 8C7.02944 8 3 6.65685 3 5M21 5C21 3.34315 16.9706 2 12 2C7.02944 2 3 3.34315 3 5M21 5V19C21 20.66 17 22 12 22C7 22 3 20.66 3 19V5M21 9.72021C21 11.3802 17 12.7202 12 12.7202C7 12.7202 3 11.3802 3 9.72021M21 14.44C21 16.1 17 17.44 12 17.44C7 17.44 3 16.1 3 14.44"/>',
           },
         ],
@@ -178,19 +179,22 @@ export const NAV_DROPDOWNS: NavDropdown[] = [
           label: "JetBrains",
           href: "/case-study/jetbrains",
           subtitle: "Software",
-          logoUrl: "https://pub-41d587b95acb4b579d9280542922084b.r2.dev/webflow/64a817a2e7e2208272d1ce30/60b5e34d/670e2f23ee3f2feee5e7e7e2_jetbrains-min.svg",
+          logoUrl:
+            "https://pub-41d587b95acb4b579d9280542922084b.r2.dev/webflow/64a817a2e7e2208272d1ce30/60b5e34d/670e2f23ee3f2feee5e7e7e2_jetbrains-min.svg",
         },
         {
           label: "Adeo Leroy Merlin",
           href: "/case-study/adeo-leroy-merlin",
           subtitle: "Retail",
-          logoUrl: "https://pub-41d587b95acb4b579d9280542922084b.r2.dev/webflow/64a817a2e7e2208272d1ce30/c110367c/65c498032806e2ff7daec2bf_ADEO.svg",
+          logoUrl:
+            "https://pub-41d587b95acb4b579d9280542922084b.r2.dev/webflow/64a817a2e7e2208272d1ce30/c110367c/65c498032806e2ff7daec2bf_ADEO.svg",
         },
         {
           label: "Cross Screen Media",
           href: "/case-study/cross-screen-media",
           subtitle: "Media",
-          logoUrl: "https://pub-41d587b95acb4b579d9280542922084b.r2.dev/webflow/64a817a2e7e2208272d1ce30/9f8b5324/68d6a84a1761cbf9538efefa_cross-screen-media.png",
+          logoUrl:
+            "https://pub-41d587b95acb4b579d9280542922084b.r2.dev/webflow/64a817a2e7e2208272d1ce30/9f8b5324/68d6a84a1761cbf9538efefa_cross-screen-media.png",
         },
       ],
       ctaLabel: "View All Case Studies",
@@ -307,6 +311,6 @@ export function isActivePath(currentPath: string, href: string): boolean {
   // Exact match
   if (currentPath === href) return true;
   // Section match: /blog/some-post matches /blog
-  if (currentPath.startsWith(href + "/")) return true;
+  if (currentPath.startsWith(`${href}/`)) return true;
   return false;
 }

--- a/src/lib/newsletterSuccess.ts
+++ b/src/lib/newsletterSuccess.ts
@@ -4,8 +4,8 @@
  * Route: /newsletter-success (noindex)
  */
 
-import type { SEOProps } from "./seo";
 import type { SuccessPageData } from "./formTypes";
+import type { SEOProps } from "./seo";
 
 export const NEWSLETTER_SUCCESS_SEO: SEOProps = {
   title: "ZenML - You've successfully subscribed to our newsletter",

--- a/src/lib/openSourceVsPro.ts
+++ b/src/lib/openSourceVsPro.ts
@@ -5,11 +5,11 @@
  * Content extracted from Webflow HTML snapshot + SEO baseline.
  */
 import type {
-  HeroData,
-  FeatureGridItem,
-  SubwayMapCard,
   ComparisonTableData,
   CtaLink,
+  FeatureGridItem,
+  HeroData,
+  SubwayMapCard,
 } from "./marketingPageTypes";
 
 // ---------------------------------------------------------------------------
@@ -32,7 +32,10 @@ export const OSS_VS_PRO_HERO: HeroData = {
   eyebrow: "From Solo Science to Team Engineering",
   headline: "ZenML Open Source vs Pro",
   deck: "Transform your ML workflows from single-player experiments to multiplayer production systems. ZenML Pro builds on the same open-source foundation you trust: no code rewrites, no metadata migrations required.",
-  primaryCta: { label: "Start Free Trial", href: "https://cloud.zenml.io/signup" },
+  primaryCta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+  },
   secondaryCta: { label: "Use Open Source", href: "/get-started" },
 };
 
@@ -134,9 +137,13 @@ export const OSS_VS_PRO_COMPARISON: ComparisonTableData = {
   rows: [
     {
       feature: "Pipelines",
-      description: "ML pipelines are Python workflows that execute a machine learning task",
+      description:
+        "ML pipelines are Python workflows that execute a machine learning task",
       icon: ICON_PIPELINES,
-      columns: ["Basic Controls with legacy dashboard", "Advanced Controls and modern dashboard"],
+      columns: [
+        "Basic Controls with legacy dashboard",
+        "Advanced Controls and modern dashboard",
+      ],
     },
     {
       feature: "Artifact and Model Control Plane",
@@ -228,6 +235,9 @@ export const OSS_VS_PRO_COMPARISON: ComparisonTableData = {
 export const OSS_VS_PRO_FINAL_CTA = {
   headline: "Start deploying reproducible AI workflows today",
   body: "Enterprise-grade MLOps platform trusted by thousands of companies in production.",
-  primaryCta: { label: "Start Free Trial", href: "https://cloud.zenml.io/signup" },
+  primaryCta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+  },
   secondaryCta: { label: "Use Open Source", href: "https://cloud.zenml.io" },
 } as const;

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -5,11 +5,11 @@
  * Content extracted from Webflow HTML snapshot + SEO baseline.
  */
 import type {
-  FaqData,
   CtaLink,
-  PricingTab,
-  PricingPlan,
+  FaqData,
   PricingCompareTableData,
+  PricingPlan,
+  PricingTab,
 } from "./marketingPageTypes";
 
 // ---------------------------------------------------------------------------
@@ -53,7 +53,11 @@ const SELF_HOSTED_OSS: PricingPlan = {
     "Basic model registry",
     "Self-managed infrastructure",
   ],
-  cta: { label: "Get Started", href: "/get-started", analytics: "OSS-Get-Started" },
+  cta: {
+    label: "Get Started",
+    href: "/get-started",
+    analytics: "OSS-Get-Started",
+  },
   ctaVariant: "secondary",
 };
 
@@ -83,7 +87,11 @@ const SELF_HOSTED_PRO: PricingPlan = {
     "Priority support + custom SLA",
   ],
   comingSoon: ["Advanced Native Scheduling", "Resource Management & Queueing"],
-  cta: { label: "Talk to Sales", href: "/book-your-demo", analytics: "Enterpise-Self-Hosted-Book-Demo" },
+  cta: {
+    label: "Talk to Sales",
+    href: "/book-your-demo",
+    analytics: "Enterpise-Self-Hosted-Book-Demo",
+  },
   ctaVariant: "primary",
   secondaryLink: {
     label: "Or talk to an engineer about deployment",
@@ -129,9 +137,15 @@ const SELF_HOSTED_COMPARE: PricingCompareTableData = {
           link: "https://docs.zenml.io/concepts/snapshots",
           values: [false, true],
         },
-        { feature: "Advanced Native Scheduling", values: [false, "COMING SOON"] },
+        {
+          feature: "Advanced Native Scheduling",
+          values: [false, "COMING SOON"],
+        },
         { feature: "Webhooks & Triggers", values: [false, true] },
-        { feature: "Resource Management & Queueing", values: [false, "COMING SOON"] },
+        {
+          feature: "Resource Management & Queueing",
+          values: [false, "COMING SOON"],
+        },
         { feature: "Codespaces (Remote IDE)", values: [false, true] },
         {
           feature: "Modern Server Side Dashboard",
@@ -160,13 +174,24 @@ const SELF_HOSTED_COMPARE: PricingCompareTableData = {
     {
       heading: "Support",
       rows: [
-        { feature: "Support Level", values: ["Community", "24/7 Priority + SLA"] },
+        {
+          feature: "Support Level",
+          values: ["Community", "24/7 Priority + SLA"],
+        },
       ],
     },
   ],
   ctaButtons: [
-    { label: "Get Started", href: "/get-started", analytics: "OSS-Get-Started" },
-    { label: "Talk to Sales", href: "/book-your-demo", analytics: "Enterpise-Self-Hosted-Book-Demo" },
+    {
+      label: "Get Started",
+      href: "/get-started",
+      analytics: "OSS-Get-Started",
+    },
+    {
+      label: "Talk to Sales",
+      href: "/book-your-demo",
+      analytics: "Enterpise-Self-Hosted-Book-Demo",
+    },
   ],
 };
 
@@ -190,7 +215,11 @@ const SAAS_STARTER: PricingPlan = {
     "Unlimited team members",
     "Basic support",
   ],
-  cta: { label: "Start Free Trial", href: "https://cloud.zenml.io/signup", analytics: "Starter-Free-Trial" },
+  cta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+    analytics: "Starter-Free-Trial",
+  },
   ctaVariant: "secondary",
 };
 
@@ -211,7 +240,11 @@ const SAAS_GROWTH: PricingPlan = {
     "Webhooks & Triggers",
     "Priority support",
   ],
-  cta: { label: "Start Free Trial", href: "https://cloud.zenml.io/signup", analytics: "Growth-Free-Trial" },
+  cta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+    analytics: "Growth-Free-Trial",
+  },
   ctaVariant: "primary",
 };
 
@@ -226,11 +259,12 @@ const SAAS_SCALE: PricingPlan = {
     { label: "snapshots", value: "20" },
   ],
   featuresPrefix: "Everything in Growth, plus:",
-  features: [
-    "Codespaces (Remote IDE)",
-    "Priority support",
-  ],
-  cta: { label: "Start Free Trial", href: "https://cloud.zenml.io/signup", analytics: "Scale-Free-Trial" },
+  features: ["Codespaces (Remote IDE)", "Priority support"],
+  cta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+    analytics: "Scale-Free-Trial",
+  },
   ctaVariant: "secondary",
 };
 
@@ -254,7 +288,11 @@ const SAAS_ENTERPRISE: PricingPlan = {
     "Professional Services",
     "Dedicated support + SLA",
   ],
-  cta: { label: "Book a Demo", href: "/book-your-demo", analytics: "Enterprise-Book-Demo" },
+  cta: {
+    label: "Book a Demo",
+    href: "/book-your-demo",
+    analytics: "Enterprise-Book-Demo",
+  },
   ctaVariant: "secondary",
   secondaryLink: {
     label: "Or talk to an engineer about deployment",
@@ -269,8 +307,14 @@ const SAAS_COMPARE: PricingCompareTableData = {
     {
       heading: "Feature",
       rows: [
-        { feature: "Price", values: ["$399/mo", "$999/mo", "$2,499/mo", "Custom"] },
-        { feature: "Pipeline Runs/mo", values: ["500", "2,000", "5,000", "Unlimited"] },
+        {
+          feature: "Price",
+          values: ["$399/mo", "$999/mo", "$2,499/mo", "Custom"],
+        },
+        {
+          feature: "Pipeline Runs/mo",
+          values: ["500", "2,000", "5,000", "Unlimited"],
+        },
         { feature: "Projects", values: ["1", "3", "10", "Unlimited"] },
         {
           feature: "Snapshots",
@@ -278,7 +322,10 @@ const SAAS_COMPARE: PricingCompareTableData = {
           values: ["1", "5", "20", "Unlimited"],
         },
         { feature: "Workspaces", values: ["1", "1", "1", "Custom"] },
-        { feature: "Team members", values: ["Unlimited", "Unlimited", "Unlimited", "Unlimited"] },
+        {
+          feature: "Team members",
+          values: ["Unlimited", "Unlimited", "Unlimited", "Unlimited"],
+        },
       ],
     },
     {
@@ -292,10 +339,22 @@ const SAAS_COMPARE: PricingCompareTableData = {
     {
       heading: "Advanced Features",
       rows: [
-        { feature: "Advanced Native Scheduling", values: [false, false, false, "COMING SOON"] },
-        { feature: "Webhooks & Triggers", values: [false, false, false, "COMING SOON"] },
-        { feature: "Resource Management & Queueing", values: [false, false, false, "COMING SOON"] },
-        { feature: "Codespaces (Remote IDE)", values: [false, false, false, "COMING SOON"] },
+        {
+          feature: "Advanced Native Scheduling",
+          values: [false, false, false, "COMING SOON"],
+        },
+        {
+          feature: "Webhooks & Triggers",
+          values: [false, false, false, "COMING SOON"],
+        },
+        {
+          feature: "Resource Management & Queueing",
+          values: [false, false, false, "COMING SOON"],
+        },
+        {
+          feature: "Codespaces (Remote IDE)",
+          values: [false, false, false, "COMING SOON"],
+        },
       ],
     },
     {
@@ -311,21 +370,43 @@ const SAAS_COMPARE: PricingCompareTableData = {
           link: "https://security.zenml.io/",
           values: [false, false, false, true],
         },
-        { feature: "Professional Services", values: [false, false, false, "Workshops & Architecture Reviews"] },
+        {
+          feature: "Professional Services",
+          values: [false, false, false, "Workshops & Architecture Reviews"],
+        },
       ],
     },
     {
       heading: "Support",
       rows: [
-        { feature: "Support Level", values: ["Basic", "Priority", "Priority", "Dedicated + SLA"] },
+        {
+          feature: "Support Level",
+          values: ["Basic", "Priority", "Priority", "Dedicated + SLA"],
+        },
       ],
     },
   ],
   ctaButtons: [
-    { label: "Talk to Sales", href: "/book-your-demo", analytics: "Starter-Book-Demo" },
-    { label: "Talk to Sales", href: "/book-your-demo", analytics: "Growth-Book-Demo" },
-    { label: "Talk to Sales", href: "/book-your-demo", analytics: "Scale-Book-Demo" },
-    { label: "Talk to Sales", href: "/book-your-demo", analytics: "Enterprise-Book-Demo" },
+    {
+      label: "Talk to Sales",
+      href: "/book-your-demo",
+      analytics: "Starter-Book-Demo",
+    },
+    {
+      label: "Talk to Sales",
+      href: "/book-your-demo",
+      analytics: "Growth-Book-Demo",
+    },
+    {
+      label: "Talk to Sales",
+      href: "/book-your-demo",
+      analytics: "Scale-Book-Demo",
+    },
+    {
+      label: "Talk to Sales",
+      href: "/book-your-demo",
+      analytics: "Enterprise-Book-Demo",
+    },
   ],
 };
 
@@ -356,7 +437,11 @@ export const PRICING_TABS: readonly PricingTab[] = [
 export const PRICING_STARTUP_BANNER = {
   headline: "Are you startup or academic?",
   body: "Apply for a special price to access ZenML Pro features for early-stage companies building ML-powered products, universities, research institutions, and educational use cases.",
-  cta: { label: "Apply Now", href: "/startups-and-academics", analytics: "Pricing-Startup-Apply" } as CtaLink,
+  cta: {
+    label: "Apply Now",
+    href: "/startups-and-academics",
+    analytics: "Pricing-Startup-Apply",
+  } as CtaLink,
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -419,7 +504,7 @@ export const PRICING_FAQ: FaqData = {
       question:
         "What\u2019s the difference between the managed plans and the open source version?",
       answer:
-        'The open source version gives you complete control but requires you to manage your own infrastructure. Our managed plans (Community and Team) provide a fully hosted environment, automatic updates, guaranteed uptime, and dedicated support. It also includes pro-only features like run templates, model control plane, and RBAC. The Scale plan offers enterprise features on top of either option.',
+        "The open source version gives you complete control but requires you to manage your own infrastructure. Our managed plans (Community and Team) provide a fully hosted environment, automatic updates, guaranteed uptime, and dedicated support. It also includes pro-only features like run templates, model control plane, and RBAC. The Scale plan offers enterprise features on top of either option.",
     },
     {
       question: "What kind of support is included in each plan?",
@@ -455,17 +540,50 @@ export const PRICING_STATS = {
     companyLogo: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/33303c0d/6532977ff6458771fb59387e_hashicorp.webp`,
   },
   logos: [
-    { src: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/da72cb24/652d3ecd4d162d2290427dfe_airbus_defence_space.png`, alt: "Airbus" },
-    { src: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/4ae61c3a/66c84308916684f0d07b57ff_axa-min.svg`, alt: "AXA" },
-    { src: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/5cc09160/bundeswehr.svg`, alt: "Bundeswehr" },
-    { src: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/4ad1f760/66c84308b1e802ab9a246134_enel-min.svg`, alt: "Enel" },
-    { src: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/b6111e84/jetbrains-min.svg`, alt: "JetBrains" },
-    { src: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/52a636b6/66c74d825fbc26b4d09823d1_Brevo-Logo-transparent.webp`, alt: "Brevo" },
-    { src: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/86cd6b7b/cross-screen-media.png`, alt: "Cross Screen Media" },
-    { src: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/c110367c/65c498032806e2ff7daec2bf_ADEO.svg`, alt: "ADEO" },
-    { src: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/356e9829/65c49832a235dab4e3e0a3ce_leroy-merlin.svg`, alt: "Leroy Merlin" },
-    { src: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/cab0c1be/66c84308abf004bb1934e7d3_mann-hummel-min.svg`, alt: "Mann+Hummel" },
-    { src: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/e6c1fbb1/koble.svg`, alt: "Koble" },
+    {
+      src: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/da72cb24/652d3ecd4d162d2290427dfe_airbus_defence_space.png`,
+      alt: "Airbus",
+    },
+    {
+      src: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/4ae61c3a/66c84308916684f0d07b57ff_axa-min.svg`,
+      alt: "AXA",
+    },
+    {
+      src: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/5cc09160/bundeswehr.svg`,
+      alt: "Bundeswehr",
+    },
+    {
+      src: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/4ad1f760/66c84308b1e802ab9a246134_enel-min.svg`,
+      alt: "Enel",
+    },
+    {
+      src: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/b6111e84/jetbrains-min.svg`,
+      alt: "JetBrains",
+    },
+    {
+      src: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/52a636b6/66c74d825fbc26b4d09823d1_Brevo-Logo-transparent.webp`,
+      alt: "Brevo",
+    },
+    {
+      src: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/86cd6b7b/cross-screen-media.png`,
+      alt: "Cross Screen Media",
+    },
+    {
+      src: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/c110367c/65c498032806e2ff7daec2bf_ADEO.svg`,
+      alt: "ADEO",
+    },
+    {
+      src: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/356e9829/65c49832a235dab4e3e0a3ce_leroy-merlin.svg`,
+      alt: "Leroy Merlin",
+    },
+    {
+      src: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/cab0c1be/66c84308abf004bb1934e7d3_mann-hummel-min.svg`,
+      alt: "Mann+Hummel",
+    },
+    {
+      src: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/e6c1fbb1/koble.svg`,
+      alt: "Koble",
+    },
   ],
 } as const;
 
@@ -475,6 +593,14 @@ export const PRICING_STATS = {
 export const PRICING_FINAL_CTA = {
   headline: "Start deploying reproducible AI workflows today",
   body: "Enterprise-grade MLOps platform trusted by thousands of companies in production.",
-  primaryCta: { label: "Start Free Trial", href: "https://cloud.zenml.io/signup", analytics: "Pricing-CTA-Free-Trial" } as CtaLink,
-  secondaryCta: { label: "Use Open Source", href: "/get-started", analytics: "Pricing-CTA-Open-Source" } as CtaLink,
+  primaryCta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+    analytics: "Pricing-CTA-Free-Trial",
+  } as CtaLink,
+  secondaryCta: {
+    label: "Use Open Source",
+    href: "/get-started",
+    analytics: "Pricing-CTA-Open-Source",
+  } as CtaLink,
 } as const;

--- a/src/lib/pro.ts
+++ b/src/lib/pro.ts
@@ -4,7 +4,12 @@
  * Used by src/pages/pro.astro.
  * Content extracted from Webflow HTML snapshot + SEO baseline.
  */
-import type { HeroData, FaqData, CtaLink, FeatureGridItem } from "./marketingPageTypes";
+import type {
+  CtaLink,
+  FaqData,
+  FeatureGridItem,
+  HeroData,
+} from "./marketingPageTypes";
 
 // ---------------------------------------------------------------------------
 // SEO
@@ -14,8 +19,7 @@ export const PRO_SEO = {
   description:
     "Supercharge your MLOps with a fully-managed control plane. Forget the infrastructure setup and security concerns. Get a single pane of glass view into your entire organization.",
   ogTitle: "Managed MLOps for your Cloud - ZenML Pro",
-  ogDescription:
-    "Supercharge your MLOps with a fully-managed control plane.",
+  ogDescription: "Supercharge your MLOps with a fully-managed control plane.",
   ogImage: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/3ae53e01/64b9920cd04b7c4c0340ce50_og-img-0625.jpg`,
 } as const;
 
@@ -25,7 +29,10 @@ export const PRO_SEO = {
 export const PRO_HERO: HeroData = {
   headline: "Supercharge your MLOps with a fully-managed control plane",
   deck: "Forget the infrastructure setup and security concerns. Get a single pane of glass view into your entire organization.",
-  primaryCta: { label: "Start Free Trial", href: "https://cloud.zenml.io/signup" },
+  primaryCta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+  },
   secondaryCta: { label: "Compare OSS vs Pro", href: "/open-source-vs-pro" },
   image: {
     url: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/b6cd9240/652d14664e7b1ba97d692b8a_cloud_main-1.webp`,
@@ -72,7 +79,10 @@ export const PRO_ONBOARDING = {
       body: "Our experts will help your teams to connect your workflow and set up initial automations, streamlining your operations.",
     },
   ] satisfies FeatureGridItem[],
-  primaryCta: { label: "Start Free Trial", href: "https://cloud.zenml.io/signup" } as CtaLink,
+  primaryCta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+  } as CtaLink,
   secondaryCta: { label: "See Plans", href: "/pricing" } as CtaLink,
 } as const;
 
@@ -180,8 +190,14 @@ export const PRO_OSS_GRID = {
       body: "ZenML Pro tenants have an enhanced dashboard with more features including a model control plane to view all your ML models, and the ability to trigger pipelines, do CI/CD and lots more.",
     },
   ] satisfies FeatureGridItem[],
-  primaryCta: { label: "Start Free Trial", href: "https://cloud.zenml.io/signup" } as CtaLink,
-  secondaryCta: { label: "Compare OSS vs Pro", href: "/open-source-vs-pro" } as CtaLink,
+  primaryCta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+  } as CtaLink,
+  secondaryCta: {
+    label: "Compare OSS vs Pro",
+    href: "/open-source-vs-pro",
+  } as CtaLink,
   image: {
     url: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/e88e687c/65324d0f452d2d170268090d_opensource-cloud.svg`,
     alt: "ZenML Cloud toolbox emerging from a box.",
@@ -298,7 +314,10 @@ export const PRO_FINAL_CTA = {
     "Works with any infrastructure",
     "Upgrade to managed Pro features",
   ],
-  primaryCta: { label: "Start Free Trial", href: "https://cloud.zenml.io/signup" } as CtaLink,
+  primaryCta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+  } as CtaLink,
   secondaryCta: { label: "Use Open Source", href: "/get-started" } as CtaLink,
   image: {
     url: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/339bb62b/66e9556fd34d2791885b0c5f_model_control_plane_01.png`,

--- a/src/lib/remark-default-lang.ts
+++ b/src/lib/remark-default-lang.ts
@@ -4,8 +4,9 @@
  * highlighting works on Webflow-migrated content where language
  * identifiers were stripped.
  */
+
+import type { Code, Root } from "mdast";
 import { visit } from "unist-util-visit";
-import type { Root, Code } from "mdast";
 
 export function remarkDefaultLang(defaultLang = "python") {
   return () => (tree: Root) => {

--- a/src/lib/roiCalculator.ts
+++ b/src/lib/roiCalculator.ts
@@ -34,12 +34,15 @@ const AVG_HOURLY_RATE = 150;
  * Calculate monthly ZenML platform cost based on team size and model count.
  * Uses power-function scaling with tier snapping.
  */
-export function calculateZenMLCost(teamSize: number, numModels: number): number {
+export function calculateZenMLCost(
+  teamSize: number,
+  numModels: number,
+): number {
   // Smallest teams get the starter tier
   if (teamSize <= 2 && numModels <= 3) return 99;
 
-  const baseTeamCost = Math.pow(teamSize, 1.2) * 50;
-  const baseModelCost = Math.pow(numModels, 1.1) * 30;
+  const baseTeamCost = teamSize ** 1.2 * 50;
+  const baseModelCost = numModels ** 1.1 * 30;
   const totalCost = baseTeamCost + baseModelCost;
 
   // Snap to pricing tiers
@@ -85,10 +88,7 @@ export function calculateRoi(inputs: RoiInputs): RoiOutputs {
     1 - Math.log10(models || 1) / Math.log10(1000),
   );
   const performanceImpactMonthly = Math.round(
-    models *
-      baseValuePerModel *
-      scaleFactor *
-      Math.min(1.5, 1 + teamSize / 50),
+    models * baseValuePerModel * scaleFactor * Math.min(1.5, 1 + teamSize / 50),
   );
 
   // ROI: annual benefits vs annual cost

--- a/src/lib/scheduleADemo.ts
+++ b/src/lib/scheduleADemo.ts
@@ -5,8 +5,8 @@
  * Uses the "discovery-call-reschedule" Cal.com link.
  */
 
-import type { SEOProps } from "./seo";
 import type { CalEmbedConfig } from "./formTypes";
+import type { SEOProps } from "./seo";
 
 export const SCHEDULE_A_DEMO_SEO: SEOProps = {
   title: "Schedule a Demo | ZenML",

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -6,7 +6,7 @@
  * meta resolution with sensible fallbacks.
  */
 
-import { SITE_URL, DEFAULT_DESCRIPTION, DEFAULT_OG_IMAGE } from "./constants";
+import { DEFAULT_DESCRIPTION, DEFAULT_OG_IMAGE, SITE_URL } from "./constants";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -72,10 +72,7 @@ export function buildCanonical(pathname: string, override?: string): string {
  * - twitterCard → summary_large_image (if ogImage exists), else summary
  * - noindex → false
  */
-export function resolveSeo(
-  props: SEOProps,
-  pathname: string,
-): ResolvedSEO {
+export function resolveSeo(props: SEOProps, pathname: string): ResolvedSEO {
   const description = props.description || DEFAULT_DESCRIPTION;
   const canonical = buildCanonical(pathname, props.canonical);
   const rawOgImage = props.ogImage || DEFAULT_OG_IMAGE || undefined;
@@ -83,7 +80,8 @@ export function resolveSeo(
   const ogImage = rawOgImage?.startsWith("/")
     ? `${SITE_URL}${rawOgImage}`
     : rawOgImage;
-  const twitterCard = props.twitterCard ?? (ogImage ? "summary_large_image" : "summary");
+  const twitterCard =
+    props.twitterCard ?? (ogImage ? "summary_large_image" : "summary");
 
   return {
     title: props.title,

--- a/src/lib/signupForDemo.ts
+++ b/src/lib/signupForDemo.ts
@@ -5,8 +5,8 @@
  * Shares field definitions and fallback CTA from bookADemo module.
  */
 
+import { BOOK_A_DEMO_FALLBACK_CTA, BOOK_A_DEMO_FIELDS } from "./bookADemo";
 import type { SEOProps } from "./seo";
-import { BOOK_A_DEMO_FIELDS, BOOK_A_DEMO_FALLBACK_CTA } from "./bookADemo";
 
 export const SIGNUP_FOR_DEMO_SEO: SEOProps = {
   title: "Signup for Demo | ZenML",

--- a/src/lib/startupsAndAcademics.ts
+++ b/src/lib/startupsAndAcademics.ts
@@ -5,10 +5,10 @@
  * Unique field set (LinkedIn, org, role dropdown).
  */
 
-import type { SEOProps } from "./seo";
+import { STARTUP_ROLE_OPTIONS } from "./formConstants";
 import type { PlaceholderField } from "./formTypes";
 import type { CtaLink } from "./marketingPageTypes";
-import { STARTUP_ROLE_OPTIONS } from "./formConstants";
+import type { SEOProps } from "./seo";
 
 export const STARTUPS_SEO: SEOProps = {
   title: "ZenML for Startups and Academics",
@@ -26,7 +26,13 @@ export const STARTUPS_HERO = {
 };
 
 export const STARTUPS_FIELDS: PlaceholderField[] = [
-  { name: "fullName", label: "Full name", type: "text", required: true, placeholder: "Full name" },
+  {
+    name: "fullName",
+    label: "Full name",
+    type: "text",
+    required: true,
+    placeholder: "Full name",
+  },
   {
     name: "email",
     label: "Company / Organization Email",

--- a/src/lib/successCalendar.ts
+++ b/src/lib/successCalendar.ts
@@ -5,8 +5,8 @@
  * noindex: true (success page, not a landing page)
  */
 
-import type { SEOProps } from "./seo";
 import type { CalEmbedConfig } from "./formTypes";
+import type { SEOProps } from "./seo";
 
 export const SUCCESS_CALENDAR_SEO: SEOProps = {
   title: "Success - Request a Call | ZenML",

--- a/src/lib/whitepaper.ts
+++ b/src/lib/whitepaper.ts
@@ -6,10 +6,10 @@
  * Two-column: left = marketing copy + image, right = form placeholder.
  */
 
-import type { SEOProps } from "./seo";
+import { JOB_TITLE_OPTIONS } from "./formConstants";
 import type { PlaceholderField } from "./formTypes";
 import type { CtaLink } from "./marketingPageTypes";
-import { JOB_TITLE_OPTIONS } from "./formConstants";
+import type { SEOProps } from "./seo";
 
 export const WHITEPAPER_SEO: SEOProps = {
   title: "Architecting an Enterprise-Grade MLOps Platform | ZenML Whitepaper",
@@ -34,21 +34,39 @@ export const WHITEPAPER_CONTENT = {
 };
 
 export const WHITEPAPER_FIELDS: PlaceholderField[] = [
-  { name: "fullName", label: "Full name", type: "text", required: true, placeholder: "Full name" },
-  { name: "email", label: "Work Email", type: "email", required: true, placeholder: "you@company.inc" },
+  {
+    name: "fullName",
+    label: "Full name",
+    type: "text",
+    required: true,
+    placeholder: "Full name",
+  },
+  {
+    name: "email",
+    label: "Work Email",
+    type: "email",
+    required: true,
+    placeholder: "you@company.inc",
+  },
   {
     name: "jobTitle",
     label: "Job Title (optional)",
     type: "select",
     options: JOB_TITLE_OPTIONS,
   },
-  { name: "company", label: "Company (optional)", type: "text", placeholder: "Company" },
+  {
+    name: "company",
+    label: "Company (optional)",
+    type: "text",
+    placeholder: "Company",
+  },
   {
     name: "privacy",
     label: "Privacy agreement",
     type: "checkbox",
     required: true,
-    placeholder: 'You agree to our <a href="/privacy-policy" class="text-zenml-500 underline">privacy policy</a>.',
+    placeholder:
+      'You agree to our <a href="/privacy-policy" class="text-zenml-500 underline">privacy policy</a>.',
   },
 ];
 

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,4 +1,5 @@
 ---
+import Button from "../components/Button.astro";
 /**
  * 404 — custom not-found page.
  *
@@ -8,7 +9,6 @@
  * Route: Astro serves this as /404.html automatically.
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
-import Button from "../components/Button.astro";
 ---
 
 <BaseLayout title="Page Not Found — ZenML" noindex>

--- a/src/pages/api/forms/[formType].ts
+++ b/src/pages/api/forms/[formType].ts
@@ -7,45 +7,20 @@
  * (fire-and-forget via waitUntil), and returns success to the user.
  * Segment routes form data to CRM destinations (Attio, Apollo).
  */
-import type { APIContext } from "astro";
+
 import type { Runtime } from "@astrojs/cloudflare";
+import type { APIContext } from "astro";
+import {
+  FORM_RULES,
+  type FormType,
+  validateForm,
+} from "../../../lib/formValidation";
 
 export const prerender = false;
 
-type FormType = "demo-request" | "whitepaper" | "brick-manual" | "startup-academic";
-
-const VALID_FORM_TYPES = new Set<FormType>([
-  "demo-request",
-  "whitepaper",
-  "brick-manual",
-  "startup-academic",
-]);
-
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const URL_RE = /^https?:\/\/.+/;
-
-/** Per-form required field rules (mirrors src/lib/formValidation.ts). */
-const REQUIRED_FIELDS: Record<FormType, Record<string, { pattern?: RegExp; message: string }>> = {
-  "demo-request": {
-    fullName: { message: "Full name is required" },
-    email: { pattern: EMAIL_RE, message: "Valid work email is required" },
-  },
-  whitepaper: {
-    fullName: { message: "Full name is required" },
-    email: { pattern: EMAIL_RE, message: "Valid work email is required" },
-  },
-  "brick-manual": {
-    fullName: { message: "Full name is required" },
-    email: { pattern: EMAIL_RE, message: "Valid email is required" },
-  },
-  "startup-academic": {
-    fullName: { message: "Full name is required" },
-    email: { pattern: EMAIL_RE, message: "Valid email is required" },
-    linkedin: { pattern: URL_RE, message: "LinkedIn URL is required" },
-    company: { message: "Organization name is required" },
-    role: { message: "Please select a role" },
-  },
-};
+const VALID_FORM_TYPES = new Set<FormType>(
+  Object.keys(FORM_RULES) as FormType[],
+);
 
 /** Fields excluded from the Segment track payload (sensitive or irrelevant for CRM). */
 const EXCLUDED_FIELDS = new Set(["cf-turnstile-response", "privacy"]);
@@ -75,7 +50,7 @@ async function segmentCall(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Basic ${btoa(writeKey + ":")}`,
+      Authorization: `Basic ${btoa(`${writeKey}:`)}`,
     },
     body: JSON.stringify(body),
   });
@@ -106,21 +81,12 @@ export async function POST(context: APIContext): Promise<Response> {
     if (typeof value === "string") data[key] = value;
   }
 
-  // Validate required fields
-  const rules = REQUIRED_FIELDS[formType as FormType];
-  const errors: Record<string, string> = {};
+  const typedFormType = formType as FormType;
 
-  for (const [field, rule] of Object.entries(rules)) {
-    const val = (data[field] ?? "").trim();
-    if (!val) {
-      errors[field] = rule.message;
-    } else if (rule.pattern && !rule.pattern.test(val)) {
-      errors[field] = rule.message;
-    }
-  }
-
-  if (Object.keys(errors).length > 0) {
-    return jsonResponse({ success: false, errors }, 422);
+  // Validate required fields using shared client/server rules
+  const validation = validateForm(typedFormType, data);
+  if (!validation.valid) {
+    return jsonResponse({ success: false, errors: validation.errors }, 422);
   }
 
   // Access Cloudflare runtime for env vars and waitUntil
@@ -133,7 +99,10 @@ export async function POST(context: APIContext): Promise<Response> {
 
   if (turnstileSecret) {
     if (!turnstileToken) {
-      return jsonResponse({ success: false, error: "Bot verification is required" }, 403);
+      return jsonResponse(
+        { success: false, error: "Bot verification is required" },
+        403,
+      );
     }
     const verifyResponse = await fetch(
       "https://challenges.cloudflare.com/turnstile/v0/siteverify",
@@ -148,7 +117,10 @@ export async function POST(context: APIContext): Promise<Response> {
     );
     const result = (await verifyResponse.json()) as { success: boolean };
     if (!result.success) {
-      return jsonResponse({ success: false, error: "Bot verification failed. Please try again." }, 403);
+      return jsonResponse(
+        { success: false, error: "Bot verification failed. Please try again." },
+        403,
+      );
     }
   }
 
@@ -156,7 +128,10 @@ export async function POST(context: APIContext): Promise<Response> {
   const privacyValue = (data.privacy ?? "").trim().toLowerCase();
   if (!/^(on|true|1)$/.test(privacyValue)) {
     return jsonResponse(
-      { success: false, errors: { privacy: "You must agree to the privacy policy" } },
+      {
+        success: false,
+        errors: { privacy: "You must agree to the privacy policy" },
+      },
       422,
     );
   }
@@ -175,7 +150,7 @@ export async function POST(context: APIContext): Promise<Response> {
     const segmentContext = { page: { url: referer }, userAgent };
 
     // Build traits for identify (name, email, company where available)
-    const traitFields = IDENTIFY_TRAITS[formType as FormType] ?? [];
+    const traitFields = IDENTIFY_TRAITS[typedFormType] ?? [];
     const traits: Record<string, string> = {};
     for (const field of traitFields) {
       const val = (data[field] ?? "").trim();

--- a/src/pages/author/[slug].astro
+++ b/src/pages/author/[slug].astro
@@ -6,11 +6,11 @@
  * Generates /author/<slug> for each author in the collection.
  */
 import { getCollection, getEntry } from "astro:content";
-import BaseLayout from "../../layouts/BaseLayout.astro";
 import BlogCard from "../../components/blog/BlogCard.astro";
 import CategoryBar from "../../components/blog/CategoryBar.astro";
 import Image from "../../components/Image.astro";
-import { getMainFeedPosts, getCategoryCounts } from "../../lib/blog";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { getCategoryCounts, getMainFeedPosts } from "../../lib/blog";
 
 export async function getStaticPaths() {
   const authors = await getCollection("authors");
@@ -23,8 +23,13 @@ export async function getStaticPaths() {
 const { author } = Astro.props;
 
 const allPosts = (
-  await getCollection("blog", ({ data }) => !data.draft && data.author === author.data.slug)
-).sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime());
+  await getCollection(
+    "blog",
+    ({ data }) => !data.draft && data.author === author.data.slug,
+  )
+).sort(
+  (a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime(),
+);
 
 // Category bar data
 const allFeedPosts = await getMainFeedPosts();
@@ -35,7 +40,11 @@ const categoryMap = new Map<string, { name: string; slug: string }>();
 for (const post of allPosts) {
   if (post.data.category && !categoryMap.has(post.data.category)) {
     const cat = await getEntry("categories", post.data.category);
-    if (cat) categoryMap.set(post.data.category, { name: cat.data.name, slug: cat.data.slug });
+    if (cat)
+      categoryMap.set(post.data.category, {
+        name: cat.data.name,
+        slug: cat.data.slug,
+      });
   }
 }
 ---

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -6,8 +6,8 @@
  * Resolves author, category, tags, and computes prev/next + related posts.
  */
 import { getEntry, render } from "astro:content";
-import BlogLayout from "../../layouts/BlogLayout.astro";
 import Badge from "../../components/Badge.astro";
+import BlogLayout from "../../layouts/BlogLayout.astro";
 import {
   getAllPublishedPosts,
   getMainFeedPosts,
@@ -46,10 +46,9 @@ const categoryEntry = post.data.category
 const tagEntries = await Promise.all(
   post.data.tags.map((tagSlug: string) => getEntry("tags", tagSlug)),
 );
-const tags = tagEntries.filter(Boolean).map((t) => ({
-  name: t!.data.name,
-  slug: t!.data.slug,
-}));
+const tags = tagEntries.flatMap((t) =>
+  t ? [{ name: t.data.name, slug: t.data.slug }] : [],
+);
 
 // Resolve prev/next/related metadata for cards
 const relatedAuthors = new Map<string, { name: string; slug: string }>();
@@ -61,7 +60,11 @@ for (const r of related) {
   }
   if (r.data.category && !relatedCategories.has(r.data.category)) {
     const cat = await getEntry("categories", r.data.category);
-    if (cat) relatedCategories.set(r.data.category, { name: cat.data.name, slug: cat.data.slug });
+    if (cat)
+      relatedCategories.set(r.data.category, {
+        name: cat.data.name,
+        slug: cat.data.slug,
+      });
   }
 }
 

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -6,20 +6,20 @@
  * Page 2+ handled by blog/page/[page].astro.
  */
 import { getEntry } from "astro:content";
-import BaseLayout from "../../layouts/BaseLayout.astro";
 import BlogCard from "../../components/blog/BlogCard.astro";
 import BlogHero from "../../components/blog/BlogHero.astro";
 import CategoryBar from "../../components/blog/CategoryBar.astro";
 import TagCloud from "../../components/blog/TagCloud.astro";
 import Pagination from "../../components/Pagination.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
 import {
-  getMainFeedPosts,
-  getCategoryCounts,
-  getTagCounts,
-  resolveAuthor,
-  PAGE_SIZE,
-  PAGE_1_GRID_COUNT,
   blogPageHref,
+  getCategoryCounts,
+  getMainFeedPosts,
+  getTagCounts,
+  PAGE_1_GRID_COUNT,
+  PAGE_SIZE,
+  resolveAuthor,
 } from "../../lib/blog";
 
 const allPosts = await getMainFeedPosts();
@@ -30,7 +30,9 @@ const remainingPosts = allPosts.filter((p) => p !== featuredPost);
 
 // Grid posts — fill rest of page 1 (multiple of 3 for clean 3-col grid)
 const gridPosts = remainingPosts.slice(0, PAGE_1_GRID_COUNT);
-const totalPages = 1 + Math.ceil(Math.max(remainingPosts.length - PAGE_1_GRID_COUNT, 0) / PAGE_SIZE);
+const totalPages =
+  1 +
+  Math.ceil(Math.max(remainingPosts.length - PAGE_1_GRID_COUNT, 0) / PAGE_SIZE);
 
 // Taxonomy data
 const categories = await getCategoryCounts(allPosts);
@@ -52,10 +54,13 @@ for (const post of gridPosts) {
   }
   if (post.data.category && !categoryMap.has(post.data.category)) {
     const cat = await getEntry("categories", post.data.category);
-    if (cat) categoryMap.set(post.data.category, { name: cat.data.name, slug: cat.data.slug });
+    if (cat)
+      categoryMap.set(post.data.category, {
+        name: cat.data.name,
+        slug: cat.data.slug,
+      });
   }
 }
-
 ---
 
 <BaseLayout

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -6,26 +6,30 @@
  * Page 1 is handled by blog/index.astro.
  */
 import { getEntry } from "astro:content";
-import BaseLayout from "../../../layouts/BaseLayout.astro";
 import BlogCard from "../../../components/blog/BlogCard.astro";
 import CategoryBar from "../../../components/blog/CategoryBar.astro";
 import TagCloud from "../../../components/blog/TagCloud.astro";
 import Pagination from "../../../components/Pagination.astro";
+import BaseLayout from "../../../layouts/BaseLayout.astro";
 import {
-  getMainFeedPosts,
-  getCategoryCounts,
-  getTagCounts,
-  resolveAuthor,
-  PAGE_SIZE,
-  PAGE_1_GRID_COUNT,
   blogPageHref,
+  getCategoryCounts,
+  getMainFeedPosts,
+  getTagCounts,
+  PAGE_1_GRID_COUNT,
+  PAGE_SIZE,
+  resolveAuthor,
 } from "../../../lib/blog";
 
 export async function getStaticPaths() {
   const allPosts = await getMainFeedPosts();
   const featuredPost = allPosts.find((p) => p.data.featured) ?? allPosts[0];
   const remainingPosts = allPosts.filter((p) => p !== featuredPost);
-  const totalPages = 1 + Math.ceil(Math.max(remainingPosts.length - PAGE_1_GRID_COUNT, 0) / PAGE_SIZE);
+  const totalPages =
+    1 +
+    Math.ceil(
+      Math.max(remainingPosts.length - PAGE_1_GRID_COUNT, 0) / PAGE_SIZE,
+    );
 
   return Array.from({ length: totalPages - 1 }, (_, i) => {
     const page = i + 2;
@@ -58,10 +62,13 @@ for (const post of posts) {
   }
   if (post.data.category && !categoryMap.has(post.data.category)) {
     const cat = await getEntry("categories", post.data.category);
-    if (cat) categoryMap.set(post.data.category, { name: cat.data.name, slug: cat.data.slug });
+    if (cat)
+      categoryMap.set(post.data.category, {
+        name: cat.data.name,
+        slug: cat.data.slug,
+      });
   }
 }
-
 ---
 
 <BaseLayout

--- a/src/pages/blog/rss.xml.ts
+++ b/src/pages/blog/rss.xml.ts
@@ -4,8 +4,9 @@
  * Generates RSS 2.0 matching the feed Webflow auto-generated.
  * Includes atom:link self-reference for feed readers.
  */
-import type { APIRoute } from "astro";
+
 import { getCollection } from "astro:content";
+import type { APIRoute } from "astro";
 import { SITE_URL } from "../../lib/constants";
 
 function escapeXml(s: string): string {
@@ -20,21 +21,19 @@ function escapeXml(s: string): string {
 export const GET: APIRoute = async () => {
   const posts = await getCollection("blog", ({ data }) => !data.draft);
   posts.sort(
-    (a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime()
+    (a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime(),
   );
 
   const feedUrl = `${SITE_URL}/blog/rss.xml`;
   const now = new Date().toUTCString();
-  const newestDate = posts.length > 0
-    ? new Date(posts[0].data.date).toUTCString()
-    : now;
+  const newestDate =
+    posts.length > 0 ? new Date(posts[0].data.date).toUTCString() : now;
 
   const items = posts
     .map((post) => {
       const link = `${SITE_URL}/blog/${post.data.slug}`;
       const pubDate = new Date(post.data.date).toUTCString();
-      const description =
-        post.data.seo?.description ?? post.data.title;
+      const description = post.data.seo?.description ?? post.data.title;
 
       return `    <item>
       <title>${escapeXml(post.data.title)}</title>

--- a/src/pages/blog/search-index.json.ts
+++ b/src/pages/blog/search-index.json.ts
@@ -5,7 +5,7 @@
  * Consumed by the BlogSearch Preact island on demand (lazy-fetched on focus).
  */
 import type { APIRoute } from "astro";
-import { getMainFeedPosts, buildBlogSearchIndex } from "../../lib/blog";
+import { buildBlogSearchIndex, getMainFeedPosts } from "../../lib/blog";
 
 export const prerender = true;
 

--- a/src/pages/book-a-demo-success.astro
+++ b/src/pages/book-a-demo-success.astro
@@ -1,15 +1,15 @@
 ---
+import CalEmbed from "../components/sections/CalEmbed.astro";
 /**
  * Book a Demo Success — thank-you page with Cal.com embed.
  *
  * Route: /book-a-demo-success (noindex)
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
-import CalEmbed from "../components/sections/CalEmbed.astro";
 import {
-  BOOK_A_DEMO_SUCCESS_SEO,
-  BOOK_A_DEMO_SUCCESS_HERO,
   BOOK_A_DEMO_SUCCESS_CAL,
+  BOOK_A_DEMO_SUCCESS_HERO,
+  BOOK_A_DEMO_SUCCESS_SEO,
 } from "../lib/bookADemoSuccess";
 ---
 

--- a/src/pages/book-a-demo.astro
+++ b/src/pages/book-a-demo.astro
@@ -1,17 +1,17 @@
 ---
+import ContactForm from "../components/islands/ContactForm.tsx";
 /**
  * Book a Demo — demo request form.
  *
  * Route: /book-a-demo
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
-import ContactForm from "../components/islands/ContactForm.tsx";
-import { TURNSTILE_SITE_KEY } from "../lib/formConstants";
 import {
-  BOOK_A_DEMO_SEO,
-  BOOK_A_DEMO_HERO,
   BOOK_A_DEMO_FIELDS,
+  BOOK_A_DEMO_HERO,
+  BOOK_A_DEMO_SEO,
 } from "../lib/bookADemo";
+import { TURNSTILE_SITE_KEY } from "../lib/formConstants";
 ---
 
 <BaseLayout

--- a/src/pages/book-success.astro
+++ b/src/pages/book-success.astro
@@ -1,12 +1,12 @@
 ---
+import SuccessPanel from "../components/sections/SuccessPanel.astro";
 /**
  * Book Success — thank-you with link to success-calendar.
  *
  * Route: /book-success (noindex)
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
-import SuccessPanel from "../components/sections/SuccessPanel.astro";
-import { BOOK_SUCCESS_SEO, BOOK_SUCCESS_DATA } from "../lib/bookSuccess";
+import { BOOK_SUCCESS_DATA, BOOK_SUCCESS_SEO } from "../lib/bookSuccess";
 ---
 
 <BaseLayout

--- a/src/pages/book-your-demo.astro
+++ b/src/pages/book-your-demo.astro
@@ -1,4 +1,5 @@
 ---
+import DemoRequestForm from "../components/islands/DemoRequestForm.tsx";
 /**
  * Book Your Demo — conversion-optimized two-column layout.
  *
@@ -9,18 +10,21 @@
  * Below: testimonial + simple footer.
  */
 import MinimalLayout from "../layouts/MinimalLayout.astro";
-import DemoRequestForm from "../components/islands/DemoRequestForm.tsx";
-import { TURNSTILE_SITE_KEY, CAL_ORIGIN, CAL_EMBED_SCRIPT } from "../lib/formConstants";
 import {
-  BOOK_YOUR_DEMO_SEO,
-  BOOK_YOUR_DEMO_HERO,
-  BOOK_YOUR_DEMO_STATS,
-  BOOK_YOUR_DEMO_LOGOS,
-  BOOK_YOUR_DEMO_FORM,
-  BOOK_YOUR_DEMO_FIELDS,
   BOOK_YOUR_DEMO_CAL,
+  BOOK_YOUR_DEMO_FIELDS,
+  BOOK_YOUR_DEMO_FORM,
+  BOOK_YOUR_DEMO_HERO,
+  BOOK_YOUR_DEMO_LOGOS,
+  BOOK_YOUR_DEMO_SEO,
+  BOOK_YOUR_DEMO_STATS,
   BOOK_YOUR_DEMO_TESTIMONIAL,
 } from "../lib/bookYourDemo";
+import {
+  CAL_EMBED_SCRIPT,
+  CAL_ORIGIN,
+  TURNSTILE_SITE_KEY,
+} from "../lib/formConstants";
 ---
 
 <MinimalLayout

--- a/src/pages/booked.astro
+++ b/src/pages/booked.astro
@@ -1,12 +1,12 @@
 ---
+import SuccessPanel from "../components/sections/SuccessPanel.astro";
 /**
  * Booked — thank-you page after Cal.com booking.
  *
  * Route: /booked (noindex)
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
-import SuccessPanel from "../components/sections/SuccessPanel.astro";
-import { BOOKED_SEO, BOOKED_DATA } from "../lib/booked";
+import { BOOKED_DATA, BOOKED_SEO } from "../lib/booked";
 ---
 
 <BaseLayout

--- a/src/pages/brick-manual.astro
+++ b/src/pages/brick-manual.astro
@@ -1,4 +1,5 @@
 ---
+import ContactForm from "../components/islands/ContactForm.tsx";
 /**
  * Brick Manual — email-gated PDF download for conference brick sets.
  *
@@ -6,14 +7,13 @@
  * Flow: QR code scan → email capture → instant PDF download link.
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
-import ContactForm from "../components/islands/ContactForm.tsx";
-import { TURNSTILE_SITE_KEY } from "../lib/formConstants";
 import {
-  BRICK_MANUAL_SEO,
-  BRICK_MANUAL_HERO,
-  BRICK_MANUAL_FIELDS,
   BRICK_MANUAL_DOWNLOAD_URL,
+  BRICK_MANUAL_FIELDS,
+  BRICK_MANUAL_HERO,
+  BRICK_MANUAL_SEO,
 } from "../lib/brickManual";
+import { TURNSTILE_SITE_KEY } from "../lib/formConstants";
 ---
 
 <BaseLayout

--- a/src/pages/careers.astro
+++ b/src/pages/careers.astro
@@ -1,4 +1,5 @@
 ---
+import Button from "../components/Button.astro";
 /**
  * Careers page.
  *
@@ -8,13 +9,12 @@
  * "Why work here" grid, hiring process steps, and open positions.
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
-import Button from "../components/Button.astro";
 import {
-  CAREERS_SEO,
   CAREERS_HERO,
-  CAREERS_MISSION,
-  CAREERS_WHY,
   CAREERS_HIRING_PROCESS,
+  CAREERS_MISSION,
+  CAREERS_SEO,
+  CAREERS_WHY,
 } from "../lib/careers";
 import { OPEN_POSITIONS } from "../lib/company";
 ---

--- a/src/pages/case-studies/index.astro
+++ b/src/pages/case-studies/index.astro
@@ -8,19 +8,22 @@
  * a banner link to the LLMOps database, and a dark CTA band.
  */
 import { getCollection } from "astro:content";
-import BaseLayout from "../../layouts/BaseLayout.astro";
+import Button from "../../components/Button.astro";
 import CaseStudyCard from "../../components/sections/CaseStudyCard.astro";
 import FeaturesHubCTA from "../../components/sections/FeaturesHubCTA.astro";
-import Button from "../../components/Button.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
 import {
-  CASE_STUDIES_HUB_HERO,
   CASE_STUDIES_HUB_BANNER,
   CASE_STUDIES_HUB_CTA,
+  CASE_STUDIES_HUB_HERO,
 } from "../../lib/case-studies";
 
-const allCaseStudies = await getCollection("case-studies", ({ data }) => !data.draft);
+const allCaseStudies = await getCollection(
+  "case-studies",
+  ({ data }) => !data.draft,
+);
 const caseStudies = allCaseStudies.sort(
-  (a, b) => (a.data.hub.order ?? 99) - (b.data.hub.order ?? 99)
+  (a, b) => (a.data.hub.order ?? 99) - (b.data.hub.order ?? 99),
 );
 ---
 

--- a/src/pages/case-study/[slug].astro
+++ b/src/pages/case-study/[slug].astro
@@ -8,12 +8,15 @@
  * Generates /case-study/<slug> for each of the 5 published case studies.
  */
 import { getCollection, render } from "astro:content";
-import BaseLayout from "../../layouts/BaseLayout.astro";
 import CaseStudySidebar from "../../components/sections/CaseStudySidebar.astro";
 import FinalCTA from "../../components/sections/FinalCTA.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
 
 export async function getStaticPaths() {
-  const caseStudies = await getCollection("case-studies", ({ data }) => !data.draft);
+  const caseStudies = await getCollection(
+    "case-studies",
+    ({ data }) => !data.draft,
+  );
   return caseStudies.map((cs) => ({
     params: { slug: cs.data.slug },
     props: { cs },
@@ -26,7 +29,9 @@ const { Content } = await render(cs);
 
 // SEO
 const seoTitle = data.seo?.title || `${data.title} - ZenML Case Study`;
-const seoDescription = data.seo?.description || `How ${data.sidebar.company} uses ZenML to build production AI workflows.`;
+const seoDescription =
+  data.seo?.description ||
+  `How ${data.sidebar.company} uses ZenML to build production AI workflows.`;
 const ogImage = data.seo?.ogImage;
 ---
 

--- a/src/pages/category/[slug].astro
+++ b/src/pages/category/[slug].astro
@@ -6,15 +6,15 @@
  * and TagCloud at bottom.
  */
 import { getCollection, getEntry } from "astro:content";
-import BaseLayout from "../../layouts/BaseLayout.astro";
 import BlogCard from "../../components/blog/BlogCard.astro";
 import CategoryBar from "../../components/blog/CategoryBar.astro";
 import TagCloud from "../../components/blog/TagCloud.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
 import {
-  resolveAuthor,
-  getMainFeedPosts,
   getCategoryCounts,
+  getMainFeedPosts,
   getTagCounts,
+  resolveAuthor,
 } from "../../lib/blog";
 
 export async function getStaticPaths() {
@@ -28,8 +28,13 @@ export async function getStaticPaths() {
 const { category } = Astro.props;
 
 const allPosts = (
-  await getCollection("blog", ({ data }) => !data.draft && data.category === category.data.slug)
-).sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime());
+  await getCollection(
+    "blog",
+    ({ data }) => !data.draft && data.category === category.data.slug,
+  )
+).sort(
+  (a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime(),
+);
 
 // CategoryBar needs all main feed posts for counts
 const mainFeedPosts = await getMainFeedPosts();
@@ -46,10 +51,13 @@ for (const post of allPosts) {
   }
   if (post.data.category && !categoryMap.has(post.data.category)) {
     const cat = await getEntry("categories", post.data.category);
-    if (cat) categoryMap.set(post.data.category, { name: cat.data.name, slug: cat.data.slug });
+    if (cat)
+      categoryMap.set(post.data.category, {
+        name: cat.data.name,
+        slug: cat.data.slug,
+      });
   }
 }
-
 ---
 
 <BaseLayout

--- a/src/pages/cloud-features/ml-models-control-plane.astro
+++ b/src/pages/cloud-features/ml-models-control-plane.astro
@@ -1,4 +1,7 @@
 ---
+import FeatureHero from "../../components/sections/FeatureHero.astro";
+import FeaturesHubCTA from "../../components/sections/FeaturesHubCTA.astro";
+import FeatureValueSection from "../../components/sections/FeatureValueSection.astro";
 /**
  * /cloud-features/ml-models-control-plane — ML Model Control Plane page.
  *
@@ -7,9 +10,6 @@
  * detail pages but with hardcoded content extracted from the Webflow snapshot.
  */
 import BaseLayout from "../../layouts/BaseLayout.astro";
-import FeatureHero from "../../components/sections/FeatureHero.astro";
-import FeatureValueSection from "../../components/sections/FeatureValueSection.astro";
-import FeaturesHubCTA from "../../components/sections/FeaturesHubCTA.astro";
 
 // ── Page data ──────────────────────────────────────────────────────
 
@@ -21,7 +21,10 @@ const hero = {
     url: "https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/cc7b88fb/6525599588d1d0f3aeb57a6b_03.01.  Models - List.webp",
     alt: "Dashboard displaying machine learning models with versioning, owners, and tags",
   },
-  primaryCta: { label: "Start Free Trial", href: "https://cloud.zenml.io/signup" },
+  primaryCta: {
+    label: "Start Free Trial",
+    href: "https://cloud.zenml.io/signup",
+  },
   secondaryCta: { label: "Use Open Source", href: "/get-started" },
 };
 

--- a/src/pages/company.astro
+++ b/src/pages/company.astro
@@ -1,4 +1,5 @@
 ---
+import { getCollection, render } from "astro:content";
 /**
  * Company page.
  *
@@ -8,11 +9,10 @@
  * team member grid (CMS), and open positions.
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
-import { getCollection, render } from "astro:content";
 import {
-  COMPANY_SEO,
-  COMPANY_HERO,
   COMPANY_ABOUT,
+  COMPANY_HERO,
+  COMPANY_SEO,
   COMPANY_VALUES,
   OPEN_POSITIONS,
 } from "../lib/company";
@@ -20,15 +20,15 @@ import {
 // Pull team members from CMS collection, sorted by order
 const allTeam = await getCollection("team");
 const teamMembers = allTeam
-  .filter((m) => !(m.data as any).draft)
-  .sort((a, b) => ((a.data as any).order ?? 99) - ((b.data as any).order ?? 99));
+  .filter((m) => !m.data.draft)
+  .sort((a, b) => (a.data.order ?? 99) - (b.data.order ?? 99));
 
 // Pre-render team member body content (fun facts) — render() is async
 const teamCards = await Promise.all(
   teamMembers.map(async (member) => {
     const { Content } = await render(member);
     return { member, Content };
-  })
+  }),
 );
 
 // Speech bubbles SVG — extracted from Webflow company page (same icon for all 5 values)

--- a/src/pages/compare/[slug].astro
+++ b/src/pages/compare/[slug].astro
@@ -16,21 +16,24 @@
  * 9. VsCta02 (gradient final CTA)
  */
 import { getCollection, getEntry } from "astro:content";
-import BaseLayout from "../../layouts/BaseLayout.astro";
-import CompareHero from "../../components/sections/compare/CompareHero.astro";
-import CompareFeatureHeader from "../../components/sections/compare/CompareFeatureHeader.astro";
 import CompareCodeComparison from "../../components/sections/compare/CompareCodeComparison.astro";
-import CompareStrategyCta from "../../components/sections/compare/CompareStrategyCta.astro";
-import CompareRelatedShowdown from "../../components/sections/compare/CompareRelatedShowdown.astro";
+import CompareFeatureHeader from "../../components/sections/compare/CompareFeatureHeader.astro";
+import CompareHero from "../../components/sections/compare/CompareHero.astro";
 import CompareRelatedBlog from "../../components/sections/compare/CompareRelatedBlog.astro";
+import CompareRelatedShowdown from "../../components/sections/compare/CompareRelatedShowdown.astro";
+import CompareStrategyCta from "../../components/sections/compare/CompareStrategyCta.astro";
 import FeatureValueSection from "../../components/sections/FeatureValueSection.astro";
-import VsTestimonial from "../../components/sections/VsTestimonial.astro";
 import VsCta02 from "../../components/sections/VsCta02.astro";
-import { getCategoryDefaults, ZENML_ICON_URL } from "../../lib/compareDefaults";
+import VsTestimonial from "../../components/sections/VsTestimonial.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
 import { getMainFeedPosts } from "../../lib/blog";
+import { getCategoryDefaults, ZENML_ICON_URL } from "../../lib/compareDefaults";
 
 export async function getStaticPaths() {
-  const compareItems = await getCollection("compare", ({ data }) => !data.draft);
+  const compareItems = await getCollection(
+    "compare",
+    ({ data }) => !data.draft,
+  );
   return compareItems.map((item) => ({
     params: { slug: item.data.slug },
     props: { item },
@@ -47,15 +50,19 @@ const categoryDefaults = getCategoryDefaults(item.data.category);
 // Resolve advantages
 // ---------------------------------------------------------------------------
 const advantageEntries = await Promise.all(
-  item.data.advantages.map((slug: string) => getEntry("advantages", slug))
+  item.data.advantages.map((slug: string) => getEntry("advantages", slug)),
 );
-const advantages = advantageEntries
-  .filter(Boolean)
-  .map((adv) => ({
-    title: adv!.data.title,
-    content: adv!.data.content,
-    image: adv!.data.image,
-  }));
+const advantages = advantageEntries.flatMap((adv) =>
+  adv
+    ? [
+        {
+          title: adv.data.title,
+          content: adv.data.content,
+          image: adv.data.image,
+        },
+      ]
+    : [],
+);
 
 // ---------------------------------------------------------------------------
 // Resolve quote / testimonial
@@ -67,9 +74,15 @@ const quoteEntry = item.data.quote
 // ---------------------------------------------------------------------------
 // Resolve related compare items (same category, excluding self)
 // ---------------------------------------------------------------------------
-const allCompareItems = await getCollection("compare", ({ data }) => !data.draft);
+const allCompareItems = await getCollection(
+  "compare",
+  ({ data }) => !data.draft,
+);
 const relatedCompareItems = allCompareItems
-  .filter((c) => c.data.category === item.data.category && c.data.slug !== item.data.slug)
+  .filter(
+    (c) =>
+      c.data.category === item.data.category && c.data.slug !== item.data.slug,
+  )
   .map((c) => ({
     slug: c.data.slug,
     toolName: c.data.toolName || c.data.title.replace("ZenML vs ", ""),
@@ -88,14 +101,20 @@ let blogPosts: Array<{
 
 if (item.data.relatedBlogSlugs && item.data.relatedBlogSlugs.length > 0) {
   const entries = await Promise.all(
-    item.data.relatedBlogSlugs.map((slug: string) => getEntry("blog", slug))
+    item.data.relatedBlogSlugs.map((slug: string) => getEntry("blog", slug)),
   );
-  blogPosts = entries.filter(Boolean).map((e) => ({
-    slug: e!.data.slug,
-    title: e!.data.title,
-    mainImage: e!.data.mainImage,
-    seoDescription: e!.data.seo?.description,
-  }));
+  blogPosts = entries.flatMap((e) =>
+    e
+      ? [
+          {
+            slug: e.data.slug,
+            title: e.data.title,
+            mainImage: e.data.mainImage,
+            seoDescription: e.data.seo?.description,
+          },
+        ]
+      : [],
+  );
 } else {
   const recentPosts = await getMainFeedPosts();
   blogPosts = recentPosts.slice(0, 3).map((p) => ({
@@ -119,7 +138,9 @@ const rawBody = item.body || "";
 // Extract table HTML (first <table>...</table>, optionally wrapped in div)
 let tableHtml = item.data.featureTableHtml || "";
 if (!tableHtml && rawBody) {
-  const tableMatch = rawBody.match(/(?:<div[^>]*>\s*)?<table[\s\S]*?<\/table>\s*(?:<\/div>)?/i);
+  const tableMatch = rawBody.match(
+    /(?:<div[^>]*>\s*)?<table[\s\S]*?<\/table>\s*(?:<\/div>)?/i,
+  );
   if (tableMatch) tableHtml = tableMatch[0];
 }
 
@@ -160,20 +181,28 @@ if (item.data.finalCta?.bullets?.length) {
 // ---------------------------------------------------------------------------
 // Hero CTAs
 // ---------------------------------------------------------------------------
-const heroPrimaryCta = item.data.heroPrimaryCta || { label: "Start Free Trial", href: "https://cloud.zenml.io/signup" };
-const heroSecondaryCta = item.data.heroSecondaryCta || { label: "Learn More", href: "#feature-comparison" };
+const heroPrimaryCta = item.data.heroPrimaryCta || {
+  label: "Start Free Trial",
+  href: "https://cloud.zenml.io/signup",
+};
+const heroSecondaryCta = item.data.heroSecondaryCta || {
+  label: "Learn More",
+  href: "#feature-comparison",
+};
 
 // ---------------------------------------------------------------------------
 // Strategy CTA headline
 // ---------------------------------------------------------------------------
-const strategyCtaHeadline = item.data.strategyCtaHeadline || categoryDefaults.strategyCtaHeadline;
+const strategyCtaHeadline =
+  item.data.strategyCtaHeadline || categoryDefaults.strategyCtaHeadline;
 
 // ---------------------------------------------------------------------------
 // Final CTA
 // ---------------------------------------------------------------------------
 const finalCta = item.data.finalCta || {
   headline: categoryDefaults.finalCta.headline,
-  bullets: ctaBullets.length > 0 ? ctaBullets : categoryDefaults.finalCta.bullets,
+  bullets:
+    ctaBullets.length > 0 ? ctaBullets : categoryDefaults.finalCta.bullets,
   primaryCta: categoryDefaults.finalCta.primaryCta,
   secondaryCta: categoryDefaults.finalCta.secondaryCta,
   image: categoryDefaults.finalCta.image,
@@ -183,7 +212,8 @@ const finalCta = item.data.finalCta || {
 // SEO
 // ---------------------------------------------------------------------------
 const seoTitle = item.data.seo?.title || `${item.data.title} - ZenML`;
-const seoDescription = item.data.seo?.description || item.data.seoDescription || item.data.heroText;
+const seoDescription =
+  item.data.seo?.description || item.data.seoDescription || item.data.heroText;
 const ogImage = item.data.seo?.ogImage || item.data.openGraphImage?.url;
 ---
 

--- a/src/pages/features/[slug].astro
+++ b/src/pages/features/[slug].astro
@@ -8,15 +8,18 @@
  * Generates /features/<slug> for each of the 12 published feature pages.
  */
 import { getCollection } from "astro:content";
-import BaseLayout from "../../layouts/BaseLayout.astro";
-import FeatureHero from "../../components/sections/FeatureHero.astro";
-import FeatureValueSection from "../../components/sections/FeatureValueSection.astro";
 import FeatureComplianceBanner from "../../components/sections/FeatureComplianceBanner.astro";
+import FeatureHero from "../../components/sections/FeatureHero.astro";
 import FeatureTestimonial from "../../components/sections/FeatureTestimonial.astro";
+import FeatureValueSection from "../../components/sections/FeatureValueSection.astro";
 import FinalCTA from "../../components/sections/FinalCTA.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
 
 export async function getStaticPaths() {
-  const features = await getCollection("feature-pages", ({ data }) => !data.draft);
+  const features = await getCollection(
+    "feature-pages",
+    ({ data }) => !data.draft,
+  );
   return features.map((feature) => ({
     params: { slug: feature.data.slug },
     props: { feature },

--- a/src/pages/features/index.astro
+++ b/src/pages/features/index.astro
@@ -1,4 +1,7 @@
 ---
+import Button from "../../components/Button.astro";
+import FeatureCard from "../../components/sections/FeatureCard.astro";
+import FeaturesCTA05 from "../../components/sections/FeaturesCTA05.astro";
 /**
  * Features hub page — grid of 7 feature category cards.
  *
@@ -8,10 +11,11 @@
  * cards (hardcoded from HUB_CARDS), and a CTA05-style purple panel.
  */
 import BaseLayout from "../../layouts/BaseLayout.astro";
-import FeatureCard from "../../components/sections/FeatureCard.astro";
-import FeaturesCTA05 from "../../components/sections/FeaturesCTA05.astro";
-import Button from "../../components/Button.astro";
-import { FEATURES_HUB_HERO, FEATURES_HUB_CTA, HUB_CARDS } from "../../lib/features";
+import {
+  FEATURES_HUB_CTA,
+  FEATURES_HUB_HERO,
+  HUB_CARDS,
+} from "../../lib/features";
 ---
 
 <BaseLayout

--- a/src/pages/get-started.astro
+++ b/src/pages/get-started.astro
@@ -1,4 +1,8 @@
 ---
+import { getCollection } from "astro:content";
+import { createHighlighter } from "shiki";
+import Button from "../components/Button.astro";
+import FeaturesHubCTA from "../components/sections/FeaturesHubCTA.astro";
 /**
  * Get Started page.
  *
@@ -8,24 +12,24 @@
  * architecture diagram, projects showcase, resources grid, and CTA.
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
-import Button from "../components/Button.astro";
-import FeaturesHubCTA from "../components/sections/FeaturesHubCTA.astro";
-import { getCollection } from "astro:content";
-import { createHighlighter } from "shiki";
-import zenmlDark from "../styles/zenml-dark.json";
 import {
-  GET_STARTED_SEO,
-  GET_STARTED_HERO,
-  GET_STARTED_STEPS,
   GET_STARTED_ARCHITECTURE,
+  GET_STARTED_FINAL_CTA,
+  GET_STARTED_HERO,
   GET_STARTED_PROJECTS,
   GET_STARTED_RESOURCES,
-  GET_STARTED_FINAL_CTA,
+  GET_STARTED_SEO,
+  GET_STARTED_STEPS,
 } from "../lib/getStarted";
+import zenmlDark from "../styles/zenml-dark.json";
+
+type HighlighterTheme = NonNullable<
+  Parameters<typeof createHighlighter>[0]["themes"]
+>[number];
 
 // Highlight code steps at build time with dark theme
 const highlighter = await createHighlighter({
-  themes: [zenmlDark as any],
+  themes: [zenmlDark as HighlighterTheme],
   langs: ["python", "bash"],
 });
 
@@ -39,19 +43,19 @@ const highlightedSteps = GET_STARTED_STEPS.items.map((step) => {
 });
 
 // Pull projects from the CMS collection if it exists
-let projects: { data: { title: string; description?: string; mainImage?: string }; id: string }[] = [];
+let projects: {
+  data: { title: string; description?: string };
+  id: string;
+}[] = [];
 try {
   const allProjects = await getCollection("projects");
-  projects = allProjects
-    .slice(0, 6)
-    .map((p) => ({
-      data: {
-        title: (p.data as any).title ?? p.id,
-        description: (p.data as any).description,
-        mainImage: (p.data as any).mainImage,
-      },
-      id: p.id,
-    }));
+  projects = allProjects.slice(0, 6).map((p) => ({
+    data: {
+      title: p.data.title ?? p.id,
+      description: p.data.description,
+    },
+    id: p.id,
+  }));
 } catch {
   // Collection may not exist yet — show empty state
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,18 @@
 ---
+import AnnouncementBanner from "../components/sections/AnnouncementBanner.astro";
+import ComplianceSection from "../components/sections/ComplianceSection.astro";
+import CustomerStories from "../components/sections/CustomerStories.astro";
+import FAQAccordion from "../components/sections/FAQAccordion.astro";
+import FeatureTabs from "../components/sections/FeatureTabs.astro";
+import FinalCTA from "../components/sections/FinalCTA.astro";
+import Hero from "../components/sections/Hero.astro";
+import IntegrationsMarquee from "../components/sections/IntegrationsMarquee.astro";
+import LogoCloud from "../components/sections/LogoCloud.astro";
+import NewsletterSignup from "../components/sections/NewsletterSignup.astro";
+import NewsSection from "../components/sections/NewsSection.astro";
+import ValueProps from "../components/sections/ValueProps.astro";
+import WhitepaperCTA from "../components/sections/WhitepaperCTA.astro";
+import JsonLd from "../components/seo/JsonLd.astro";
 /**
  * Homepage — the main landing page for zenml.io.
  *
@@ -9,22 +23,8 @@
  * Route: / (homepage)
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
-import JsonLd from "../components/seo/JsonLd.astro";
-import AnnouncementBanner from "../components/sections/AnnouncementBanner.astro";
-import Hero from "../components/sections/Hero.astro";
-import LogoCloud from "../components/sections/LogoCloud.astro";
-import FeatureTabs from "../components/sections/FeatureTabs.astro";
-import ValueProps from "../components/sections/ValueProps.astro";
-import IntegrationsMarquee from "../components/sections/IntegrationsMarquee.astro";
-import WhitepaperCTA from "../components/sections/WhitepaperCTA.astro";
-import CustomerStories from "../components/sections/CustomerStories.astro";
-import NewsSection from "../components/sections/NewsSection.astro";
-import ComplianceSection from "../components/sections/ComplianceSection.astro";
-import NewsletterSignup from "../components/sections/NewsletterSignup.astro";
-import FAQAccordion from "../components/sections/FAQAccordion.astro";
-import FinalCTA from "../components/sections/FinalCTA.astro";
-import { FAQ } from "../lib/homepage";
 import { SITE_URL } from "../lib/constants";
+import { FAQ } from "../lib/homepage";
 
 /** Strip HTML tags from a string (for JSON-LD plain text) */
 function stripHtml(html: string): string {

--- a/src/pages/integration-type/[slug].astro
+++ b/src/pages/integration-type/[slug].astro
@@ -8,8 +8,8 @@
  * Generates /integration-type/<slug> for each integration type.
  */
 import { getCollection } from "astro:content";
-import BaseLayout from "../../layouts/BaseLayout.astro";
 import IntegrationCard from "../../components/integrations/IntegrationCard.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
 
 export async function getStaticPaths() {
   const integrationTypes = await getCollection("integration-types");
@@ -23,7 +23,11 @@ const { integrationType } = Astro.props;
 
 // Get all published integrations of this type
 const allIntegrations = (
-  await getCollection("integrations", ({ data }) => !data.draft && data.integrationType === integrationType.data.slug)
+  await getCollection(
+    "integrations",
+    ({ data }) =>
+      !data.draft && data.integrationType === integrationType.data.slug,
+  )
 ).sort((a, b) => a.data.title.localeCompare(b.data.title));
 ---
 

--- a/src/pages/integrations/[slug].astro
+++ b/src/pages/integrations/[slug].astro
@@ -56,7 +56,9 @@ let compareName: string | undefined;
 if (d.compareSlug) {
   try {
     const compareEntryResult = getEntry("compare", d.compareSlug);
-    const compareEntry = compareEntryResult ? await compareEntryResult : undefined;
+    const compareEntry = compareEntryResult
+      ? await compareEntryResult
+      : undefined;
     if (compareEntry?.data?.toolName) {
       compareName = `ZenML vs ${compareEntry.data.toolName}`;
     }

--- a/src/pages/integrations/index.astro
+++ b/src/pages/integrations/index.astro
@@ -7,9 +7,9 @@
  * Route: /integrations
  */
 import { getCollection } from "astro:content";
-import BaseLayout from "../../layouts/BaseLayout.astro";
 import Button from "../../components/Button.astro";
 import IntegrationCard from "../../components/integrations/IntegrationCard.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
 import { R2_WEBFLOW_BASE } from "../../lib/constants";
 
 // Get all published integrations + types
@@ -18,7 +18,7 @@ const allIntegrations = (
 ).sort((a, b) => a.data.title.localeCompare(b.data.title));
 
 const allTypes = (await getCollection("integration-types")).sort((a, b) =>
-  a.data.name.localeCompare(b.data.name)
+  a.data.name.localeCompare(b.data.name),
 );
 const typeMap = new Map(allTypes.map((t) => [t.data.slug, t.data.name]));
 

--- a/src/pages/interactive-demo-mcp.astro
+++ b/src/pages/interactive-demo-mcp.astro
@@ -1,6 +1,6 @@
 ---
-import MinimalLayout from "../layouts/MinimalLayout.astro";
 import StorylaneEmbed from "../components/sections/StorylaneEmbed.astro";
+import MinimalLayout from "../layouts/MinimalLayout.astro";
 ---
 
 <MinimalLayout title="Live Demo - ZenML Cloud">

--- a/src/pages/live-demo.astro
+++ b/src/pages/live-demo.astro
@@ -1,6 +1,6 @@
 ---
-import MinimalLayout from "../layouts/MinimalLayout.astro";
 import StorylaneEmbed from "../components/sections/StorylaneEmbed.astro";
+import MinimalLayout from "../layouts/MinimalLayout.astro";
 ---
 
 <MinimalLayout title="Live Demo">

--- a/src/pages/llmops-database/[slug].astro
+++ b/src/pages/llmops-database/[slug].astro
@@ -7,9 +7,13 @@
  * Generates /llmops-database/<slug> for each published entry.
  */
 import { getEntry, render } from "astro:content";
-import BaseLayout from "../../layouts/BaseLayout.astro";
 import Badge from "../../components/Badge.astro";
-import { getAllPublishedEntries, buildRelatedIndex, getRelatedFromIndex } from "../../lib/llmops";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import {
+  buildRelatedIndex,
+  getAllPublishedEntries,
+  getRelatedFromIndex,
+} from "../../lib/llmops";
 
 export async function getStaticPaths() {
   const allEntries = await getAllPublishedEntries();
@@ -29,12 +33,11 @@ const { Content } = await render(entry);
 
 // Resolve llmops tags for display names
 const tagEntries = await Promise.all(
-  entry.data.llmopsTags.map((slug: string) => getEntry("llmops-tags", slug))
+  entry.data.llmopsTags.map((slug: string) => getEntry("llmops-tags", slug)),
 );
-const tags = tagEntries.filter(Boolean).map((t) => ({
-  name: t!.data.name,
-  slug: t!.data.slug,
-}));
+const tags = tagEntries.flatMap((t) =>
+  t ? [{ name: t.data.name, slug: t.data.slug }] : [],
+);
 
 // Resolve industry tag
 const industryEntry = entry.data.industryTags
@@ -45,7 +48,9 @@ const industryEntry = entry.data.industryTags
 const relatedWithTags = await Promise.all(
   related.map(async (r) => {
     const rTags = await Promise.all(
-      r.data.llmopsTags.slice(0, 3).map((s: string) => getEntry("llmops-tags", s))
+      r.data.llmopsTags
+        .slice(0, 3)
+        .map((s: string) => getEntry("llmops-tags", s)),
     );
     return {
       slug: r.data.slug,
@@ -53,14 +58,17 @@ const relatedWithTags = await Promise.all(
       company: r.data.company,
       year: r.data.year,
       summary: r.data.summary,
-      tags: rTags.filter(Boolean).map((t) => ({ name: t!.data.name, slug: t!.data.slug })),
+      tags: rTags.flatMap((t) =>
+        t ? [{ name: t.data.name, slug: t.data.slug }] : [],
+      ),
       extraTagCount: Math.max(0, r.data.llmopsTags.length - 3),
     };
-  })
+  }),
 );
 
 // SEO
-const seoTitle = entry.data.seo?.title || `${entry.data.title} - ZenML LLMOps Database`;
+const seoTitle =
+  entry.data.seo?.title || `${entry.data.title} - ZenML LLMOps Database`;
 const seoDescription = entry.data.seo?.description || entry.data.summary;
 const ogImage = entry.data.seo?.ogImage;
 ---

--- a/src/pages/llmops-database/index.astro
+++ b/src/pages/llmops-database/index.astro
@@ -9,9 +9,9 @@
  * Route: /llmops-database
  */
 import { getCollection } from "astro:content";
-import BaseLayout from "../../layouts/BaseLayout.astro";
 import LLMOpsFilter from "../../components/islands/LLMOpsFilter";
 import BrevoNewsletterForm from "../../components/sections/BrevoNewsletterForm.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
 import { BREVO_LLMOPS_CONFIG } from "../../lib/formConstants";
 
 // Resolve tag + industry display names for the filter UI
@@ -24,7 +24,9 @@ const allIndustries = (await getCollection("industry-tags"))
   .sort((a, b) => a.name.localeCompare(b.name));
 
 // Count for hero text (non-draft entries)
-const entryCount = (await getCollection("llmops-database", ({ data }) => !data.draft)).length;
+const entryCount = (
+  await getCollection("llmops-database", ({ data }) => !data.draft)
+).length;
 ---
 
 <BaseLayout

--- a/src/pages/llmops-database/rss.xml.ts
+++ b/src/pages/llmops-database/rss.xml.ts
@@ -5,8 +5,9 @@
  * LLMOps has no top-level `date` field — timestamps come from
  * webflow.lastPublished → lastUpdated → createdOn (all optional strings).
  */
-import type { APIRoute } from "astro";
+
 import { getCollection } from "astro:content";
+import type { APIRoute } from "astro";
 import { SITE_URL } from "../../lib/constants";
 import type { LLMOpsProvenance } from "../../lib/llmops";
 
@@ -33,7 +34,7 @@ function derivePubDate(data: LLMOpsProvenance): Date | null {
   for (const raw of candidates) {
     if (!raw) continue;
     const d = new Date(raw);
-    if (!isNaN(d.getTime())) return d;
+    if (!Number.isNaN(d.getTime())) return d;
   }
   return null;
 }
@@ -41,7 +42,7 @@ function derivePubDate(data: LLMOpsProvenance): Date | null {
 export const GET: APIRoute = async () => {
   const entries = await getCollection(
     "llmops-database",
-    ({ data }) => !data.draft
+    ({ data }) => !data.draft,
   );
 
   // Derive pubDate for sorting + feed

--- a/src/pages/llmops-index.json.ts
+++ b/src/pages/llmops-index.json.ts
@@ -6,15 +6,19 @@
  *
  * Target: <500KB for 1,453 entries (~300 bytes each).
  */
-import type { APIRoute } from "astro";
+
 import { getCollection } from "astro:content";
+import type { APIRoute } from "astro";
 import { deriveAddedDate } from "../lib/llmops";
 
 // Ensure this is pre-rendered at build time
 export const prerender = true;
 
 export const GET: APIRoute = async () => {
-  const entries = await getCollection("llmops-database", ({ data }) => !data.draft);
+  const entries = await getCollection(
+    "llmops-database",
+    ({ data }) => !data.draft,
+  );
 
   const index = entries.map((entry) => ({
     slug: entry.data.slug,

--- a/src/pages/llmops-tags/[slug].astro
+++ b/src/pages/llmops-tags/[slug].astro
@@ -6,13 +6,15 @@
  * Generates /llmops-tags/<slug> for each tag in the collection.
  */
 import { getCollection } from "astro:content";
-import BaseLayout from "../../layouts/BaseLayout.astro";
 import Badge from "../../components/Badge.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
 import { getIndustryTagCounts } from "../../lib/llmops";
 
 export async function getStaticPaths() {
   const llmopsTags = await getCollection("llmops-tags");
-  const tagMap = Object.fromEntries(llmopsTags.map((t) => [t.data.slug, t.data.name]));
+  const tagMap = Object.fromEntries(
+    llmopsTags.map((t) => [t.data.slug, t.data.name]),
+  );
   return llmopsTags.map((tag) => ({
     params: { slug: tag.data.slug },
     props: { tag, tagMap },
@@ -23,7 +25,10 @@ const { tag, tagMap } = Astro.props;
 
 // Get all published LLMOps entries with this tag
 const allEntries = (
-  await getCollection("llmops-database", ({ data }) => !data.draft && data.llmopsTags.includes(tag.data.slug))
+  await getCollection(
+    "llmops-database",
+    ({ data }) => !data.draft && data.llmopsTags.includes(tag.data.slug),
+  )
 ).sort((a, b) => a.data.title.localeCompare(b.data.title));
 
 // Compute top co-occurring industries among entries with this tag

--- a/src/pages/llmops-tags/index.astro
+++ b/src/pages/llmops-tags/index.astro
@@ -7,8 +7,8 @@
  */
 import { getCollection } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
-import { getAllPublishedEntries, getLLMOpsTagCounts } from "../../lib/llmops";
 import type { TaxonomyCount } from "../../lib/llmops";
+import { getAllPublishedEntries, getLLMOpsTagCounts } from "../../lib/llmops";
 
 const entries = await getAllPublishedEntries();
 const usedCounts = await getLLMOpsTagCounts(entries);

--- a/src/pages/mlops-database/[slug].astro
+++ b/src/pages/mlops-database/[slug].astro
@@ -26,10 +26,12 @@ export async function getStaticPaths() {
         props: { entry, related },
       };
     }),
-    ...Object.entries(STALE_RAY_SUMMIT_REDIRECTS).map(([oldSlug, targetSlug]) => ({
-      params: { slug: oldSlug },
-      props: { redirectTo: `/mlops-database/${targetSlug}` },
-    })),
+    ...Object.entries(STALE_RAY_SUMMIT_REDIRECTS).map(
+      ([oldSlug, targetSlug]) => ({
+        params: { slug: oldSlug },
+        props: { redirectTo: `/mlops-database/${targetSlug}` },
+      }),
+    ),
   ];
 }
 

--- a/src/pages/newsletter-signup.astro
+++ b/src/pages/newsletter-signup.astro
@@ -1,15 +1,15 @@
 ---
+import BrevoNewsletterForm from "../components/sections/BrevoNewsletterForm.astro";
 /**
  * Newsletter Signup — dedicated page with Brevo form.
  *
  * Route: /newsletter-signup
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
-import BrevoNewsletterForm from "../components/sections/BrevoNewsletterForm.astro";
 import { BREVO_MAIN_CONFIG } from "../lib/formConstants";
 import {
-  NEWSLETTER_SIGNUP_SEO,
   NEWSLETTER_SIGNUP_CONTENT,
+  NEWSLETTER_SIGNUP_SEO,
 } from "../lib/newsletterSignup";
 
 const { headline, body, privacyHtml, image } = NEWSLETTER_SIGNUP_CONTENT;

--- a/src/pages/newsletter-success.astro
+++ b/src/pages/newsletter-success.astro
@@ -1,14 +1,14 @@
 ---
+import SuccessPanel from "../components/sections/SuccessPanel.astro";
 /**
  * Newsletter Success — subscription confirmed.
  *
  * Route: /newsletter-success (noindex)
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
-import SuccessPanel from "../components/sections/SuccessPanel.astro";
 import {
-  NEWSLETTER_SUCCESS_SEO,
   NEWSLETTER_SUCCESS_DATA,
+  NEWSLETTER_SUCCESS_SEO,
 } from "../lib/newsletterSuccess";
 ---
 

--- a/src/pages/open-source-vs-pro.astro
+++ b/src/pages/open-source-vs-pro.astro
@@ -1,4 +1,8 @@
 ---
+import Button from "../components/Button.astro";
+import ComparisonTable from "../components/sections/ComparisonTable.astro";
+import FeaturesCTA05 from "../components/sections/FeaturesCTA05.astro";
+import VsHero from "../components/sections/VsHero.astro";
 /**
  * Open Source vs Pro page.
  *
@@ -8,17 +12,13 @@
  * subway map readiness section, feature comparison table, final CTA.
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
-import VsHero from "../components/sections/VsHero.astro";
-import ComparisonTable from "../components/sections/ComparisonTable.astro";
-import FeaturesCTA05 from "../components/sections/FeaturesCTA05.astro";
-import Button from "../components/Button.astro";
 import {
-  OSS_VS_PRO_SEO,
-  OSS_VS_PRO_HERO,
-  OSS_VS_PRO_FEATURE_GRID,
-  OSS_VS_PRO_SUBWAY_MAP,
   OSS_VS_PRO_COMPARISON,
+  OSS_VS_PRO_FEATURE_GRID,
   OSS_VS_PRO_FINAL_CTA,
+  OSS_VS_PRO_HERO,
+  OSS_VS_PRO_SEO,
+  OSS_VS_PRO_SUBWAY_MAP,
 } from "../lib/openSourceVsPro";
 
 /* Subway card SVG icons — extracted from Webflow original (40×40, orange #FA9E33) */

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -1,4 +1,8 @@
 ---
+import Button from "../components/Button.astro";
+import FaqSection from "../components/sections/FaqSection.astro";
+import FeaturesHubCTA from "../components/sections/FeaturesHubCTA.astro";
+import PricingComparisonTable from "../components/sections/PricingComparisonTable.astro";
 /**
  * Pricing page.
  *
@@ -10,19 +14,15 @@
  * stats/trust, and final CTA.
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
-import Button from "../components/Button.astro";
-import PricingComparisonTable from "../components/sections/PricingComparisonTable.astro";
-import FaqSection from "../components/sections/FaqSection.astro";
-import FeaturesHubCTA from "../components/sections/FeaturesHubCTA.astro";
 import {
-  PRICING_SEO,
-  PRICING_HERO,
-  PRICING_TABS,
-  PRICING_STARTUP_BANNER,
   PRICING_COMPLIANCE,
   PRICING_FAQ,
-  PRICING_STATS,
   PRICING_FINAL_CTA,
+  PRICING_HERO,
+  PRICING_SEO,
+  PRICING_STARTUP_BANNER,
+  PRICING_STATS,
+  PRICING_TABS,
 } from "../lib/pricing";
 ---
 

--- a/src/pages/pro.astro
+++ b/src/pages/pro.astro
@@ -1,4 +1,12 @@
 ---
+import Button from "../components/Button.astro";
+import FaqSection from "../components/sections/FaqSection.astro";
+import FeatureValueSection from "../components/sections/FeatureValueSection.astro";
+import LogoCloud from "../components/sections/LogoCloud.astro";
+import ProFeaturedTestimonial09 from "../components/sections/ProFeaturedTestimonial09.astro";
+import ProTestimonial02 from "../components/sections/ProTestimonial02.astro";
+import ProTestimonial15Section from "../components/sections/ProTestimonial15Section.astro";
+import VsCta02 from "../components/sections/VsCta02.astro";
 /**
  * ZenML Pro marketing page.
  *
@@ -8,27 +16,19 @@
  * onboarding, feature showcases, compliance, OSS-vs-Pro grid, FAQ, and CTA.
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
-import Button from "../components/Button.astro";
-import FeatureValueSection from "../components/sections/FeatureValueSection.astro";
-import FaqSection from "../components/sections/FaqSection.astro";
-import VsCta02 from "../components/sections/VsCta02.astro";
-import LogoCloud from "../components/sections/LogoCloud.astro";
-import ProFeaturedTestimonial09 from "../components/sections/ProFeaturedTestimonial09.astro";
-import ProTestimonial02 from "../components/sections/ProTestimonial02.astro";
-import ProTestimonial15Section from "../components/sections/ProTestimonial15Section.astro";
 import {
-  PRO_SEO,
-  PRO_HERO,
-  PRO_TRUST_HEADLINE,
-  PRO_FEATURED_TESTIMONIAL,
-  PRO_ONBOARDING,
-  PRO_FEATURES,
   PRO_COMPLIANCE,
-  PRO_OSS_GRID,
-  PRO_HASHICORP_TESTIMONIAL,
-  PRO_TESTIMONIALS,
   PRO_FAQ,
+  PRO_FEATURED_TESTIMONIAL,
+  PRO_FEATURES,
   PRO_FINAL_CTA,
+  PRO_HASHICORP_TESTIMONIAL,
+  PRO_HERO,
+  PRO_ONBOARDING,
+  PRO_OSS_GRID,
+  PRO_SEO,
+  PRO_TESTIMONIALS,
+  PRO_TRUST_HEADLINE,
 } from "../lib/pro";
 ---
 

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -16,8 +16,8 @@
  * Route: /projects/<slug>
  */
 import { getCollection } from "astro:content";
-import BaseLayout from "../../layouts/BaseLayout.astro";
 import Button from "../../components/Button.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
 
 export async function getStaticPaths() {
   const projects = await getCollection("projects", ({ data }) => !data.draft);
@@ -29,14 +29,19 @@ export async function getStaticPaths() {
 
 const { project } = Astro.props;
 
-const seoTitle = project.data.seo?.title || `${project.data.title} - ZenML Projects`;
-const seoDescription = project.data.seo?.description || project.data.description;
+const seoTitle =
+  project.data.seo?.title || `${project.data.title} - ZenML Projects`;
+const seoDescription =
+  project.data.seo?.description || project.data.description;
 
 /**
  * Parse the raw markdown body into three sections matching Webflow's CMS fields.
  * Pattern: #### Pipeline headings → #### Stack Components <ul> → main description
  */
-interface Pipeline { name: string; description: string }
+interface Pipeline {
+  name: string;
+  description: string;
+}
 
 function splitBody(body: string): {
   pipelines: Pipeline[];
@@ -44,39 +49,44 @@ function splitBody(body: string): {
   detailsHtml: string;
 } {
   const pipelines: Pipeline[] = [];
-  let stackHtml = '';
-  let detailsRaw = '';
+  let stackHtml = "";
+  let detailsRaw = "";
 
   // Find the Stack Components marker
-  const stackIdx = body.indexOf('#### Stack Components');
+  const stackIdx = body.indexOf("#### Stack Components");
 
   if (stackIdx === -1) {
     // No pipelines/stack section — entire body is details
-    return { pipelines: [], stackHtml: '', detailsHtml: markdownToHtml(body.trim()) };
+    return {
+      pipelines: [],
+      stackHtml: "",
+      detailsHtml: markdownToHtml(body.trim()),
+    };
   }
 
   // Everything before Stack Components is pipeline entries
   const pipelinesRaw = body.substring(0, stackIdx);
   const pipelineRegex = /####\s+(.+)\n\n([\s\S]*?)(?=####|\s*$)/g;
-  let match;
-  while ((match = pipelineRegex.exec(pipelinesRaw)) !== null) {
+  let match: RegExpExecArray | null = pipelineRegex.exec(pipelinesRaw);
+  while (match !== null) {
     pipelines.push({
       name: match[1].trim(),
       description: match[2].trim(),
     });
+    match = pipelineRegex.exec(pipelinesRaw);
   }
 
   // Extract stack HTML (<ul>...</ul>) and everything after it
   const afterStack = body.substring(stackIdx);
-  const ulStart = afterStack.indexOf('<ul>');
-  const ulEnd = afterStack.indexOf('</ul>');
+  const ulStart = afterStack.indexOf("<ul>");
+  const ulEnd = afterStack.indexOf("</ul>");
 
   if (ulStart !== -1 && ulEnd !== -1) {
     stackHtml = afterStack.substring(ulStart, ulEnd + 5);
     detailsRaw = afterStack.substring(ulEnd + 5).trim();
   } else {
     // No <ul> found — rest is details
-    detailsRaw = afterStack.replace(/####\s+Stack Components\s*/, '').trim();
+    detailsRaw = afterStack.replace(/####\s+Stack Components\s*/, "").trim();
   }
 
   return {
@@ -88,26 +98,28 @@ function splitBody(body: string): {
 
 /** Minimal markdown-to-HTML for the details section (headings + paragraphs). */
 function markdownToHtml(md: string): string {
-  if (!md) return '';
-  return md
-    // Convert ### headings
-    .replace(/^### (.+)$/gm, '<h3>$1</h3>')
-    // Convert #### headings
-    .replace(/^#### (.+)$/gm, '<h4>$1</h4>')
-    // Wrap plain text paragraphs (lines not starting with < or empty)
-    .split('\n\n')
-    .map(block => {
-      const trimmed = block.trim();
-      if (!trimmed) return '';
-      // Already HTML (starts with < tag)
-      if (trimmed.startsWith('<')) return trimmed;
-      return `<p>${trimmed}</p>`;
-    })
-    .filter(Boolean)
-    .join('\n');
+  if (!md) return "";
+  return (
+    md
+      // Convert ### headings
+      .replace(/^### (.+)$/gm, "<h3>$1</h3>")
+      // Convert #### headings
+      .replace(/^#### (.+)$/gm, "<h4>$1</h4>")
+      // Wrap plain text paragraphs (lines not starting with < or empty)
+      .split("\n\n")
+      .map((block) => {
+        const trimmed = block.trim();
+        if (!trimmed) return "";
+        // Already HTML (starts with < tag)
+        if (trimmed.startsWith("<")) return trimmed;
+        return `<p>${trimmed}</p>`;
+      })
+      .filter(Boolean)
+      .join("\n")
+  );
 }
 
-const { pipelines, stackHtml, detailsHtml } = splitBody(project.body || '');
+const { pipelines, stackHtml, detailsHtml } = splitBody(project.body || "");
 ---
 
 <BaseLayout

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -8,8 +8,8 @@
  * Route: /projects
  */
 import { getCollection } from "astro:content";
-import BaseLayout from "../../layouts/BaseLayout.astro";
 import Button from "../../components/Button.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
 
 const allProjects = (
   await getCollection("projects", ({ data }) => !data.draft)

--- a/src/pages/roi-calculator.astro
+++ b/src/pages/roi-calculator.astro
@@ -1,4 +1,6 @@
 ---
+import RoiCalculatorIsland from "../components/islands/RoiCalculator";
+import FeaturesHubCTA from "../components/sections/FeaturesHubCTA.astro";
 /**
  * /roi-calculator — Interactive ROI calculator page.
  *
@@ -7,8 +9,6 @@
  * The calculator logic is a Preact island for client-side reactivity.
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
-import RoiCalculatorIsland from "../components/islands/RoiCalculator";
-import FeaturesHubCTA from "../components/sections/FeaturesHubCTA.astro";
 ---
 
 <BaseLayout

--- a/src/pages/schedule-a-demo.astro
+++ b/src/pages/schedule-a-demo.astro
@@ -1,15 +1,15 @@
 ---
+import CalEmbed from "../components/sections/CalEmbed.astro";
 /**
  * Schedule a Demo — Cal.com reschedule booking page.
  *
  * Route: /schedule-a-demo
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
-import CalEmbed from "../components/sections/CalEmbed.astro";
 import {
-  SCHEDULE_A_DEMO_SEO,
-  SCHEDULE_A_DEMO_HERO,
   SCHEDULE_A_DEMO_CAL,
+  SCHEDULE_A_DEMO_HERO,
+  SCHEDULE_A_DEMO_SEO,
 } from "../lib/scheduleADemo";
 ---
 

--- a/src/pages/signup-for-demo.astro
+++ b/src/pages/signup-for-demo.astro
@@ -1,16 +1,16 @@
 ---
+import ContactForm from "../components/islands/ContactForm.tsx";
 /**
  * Signup for Demo — identical form to /book-a-demo, different route.
  *
  * Route: /signup-for-demo
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
-import ContactForm from "../components/islands/ContactForm.tsx";
 import { TURNSTILE_SITE_KEY } from "../lib/formConstants";
 import {
-  SIGNUP_FOR_DEMO_SEO,
-  SIGNUP_FOR_DEMO_HERO,
   SIGNUP_FOR_DEMO_FIELDS,
+  SIGNUP_FOR_DEMO_HERO,
+  SIGNUP_FOR_DEMO_SEO,
 } from "../lib/signupForDemo";
 ---
 

--- a/src/pages/startups-and-academics.astro
+++ b/src/pages/startups-and-academics.astro
@@ -1,16 +1,16 @@
 ---
+import ContactForm from "../components/islands/ContactForm.tsx";
 /**
  * Startups and Academics — application form for ZenML Pro program.
  *
  * Route: /startups-and-academics
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
-import ContactForm from "../components/islands/ContactForm.tsx";
 import { TURNSTILE_SITE_KEY } from "../lib/formConstants";
 import {
-  STARTUPS_SEO,
-  STARTUPS_HERO,
   STARTUPS_FIELDS,
+  STARTUPS_HERO,
+  STARTUPS_SEO,
 } from "../lib/startupsAndAcademics";
 ---
 

--- a/src/pages/success-calendar.astro
+++ b/src/pages/success-calendar.astro
@@ -1,15 +1,15 @@
 ---
+import CalEmbed from "../components/sections/CalEmbed.astro";
 /**
  * Success Calendar — post-form thank-you page with Cal.com embed.
  *
  * Route: /success-calendar (noindex)
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
-import CalEmbed from "../components/sections/CalEmbed.astro";
 import {
-  SUCCESS_CALENDAR_SEO,
-  SUCCESS_CALENDAR_HERO,
   SUCCESS_CALENDAR_CAL,
+  SUCCESS_CALENDAR_HERO,
+  SUCCESS_CALENDAR_SEO,
 } from "../lib/successCalendar";
 ---
 

--- a/src/pages/tags/[slug].astro
+++ b/src/pages/tags/[slug].astro
@@ -6,15 +6,15 @@
  * and TagCloud at the bottom.
  */
 import { getCollection, getEntry } from "astro:content";
-import BaseLayout from "../../layouts/BaseLayout.astro";
 import BlogCard from "../../components/blog/BlogCard.astro";
 import CategoryBar from "../../components/blog/CategoryBar.astro";
 import TagCloud from "../../components/blog/TagCloud.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
 import {
-  resolveAuthor,
-  getMainFeedPosts,
   getCategoryCounts,
+  getMainFeedPosts,
   getTagCounts,
+  resolveAuthor,
 } from "../../lib/blog";
 
 export async function getStaticPaths() {
@@ -28,8 +28,13 @@ export async function getStaticPaths() {
 const { tag } = Astro.props;
 
 const allPosts = (
-  await getCollection("blog", ({ data }) => !data.draft && data.tags.includes(tag.data.slug))
-).sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime());
+  await getCollection(
+    "blog",
+    ({ data }) => !data.draft && data.tags.includes(tag.data.slug),
+  )
+).sort(
+  (a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime(),
+);
 
 // CategoryBar needs all main feed posts for counts
 const mainFeedPosts = await getMainFeedPosts();
@@ -46,10 +51,13 @@ for (const post of allPosts) {
   }
   if (post.data.category && !categoryMap.has(post.data.category)) {
     const cat = await getEntry("categories", post.data.category);
-    if (cat) categoryMap.set(post.data.category, { name: cat.data.name, slug: cat.data.slug });
+    if (cat)
+      categoryMap.set(post.data.category, {
+        name: cat.data.name,
+        slug: cat.data.slug,
+      });
   }
 }
-
 ---
 
 <BaseLayout

--- a/src/pages/vs/[slug].astro
+++ b/src/pages/vs/[slug].astro
@@ -11,16 +11,19 @@
  * Generates /vs/<slug> for each of the 3 VS category pages.
  */
 import { getCollection } from "astro:content";
-import BaseLayout from "../../layouts/BaseLayout.astro";
-import VsHero from "../../components/sections/VsHero.astro";
 import FeatureValueSection from "../../components/sections/FeatureValueSection.astro";
-import VsTestimonial from "../../components/sections/VsTestimonial.astro";
-import VsRelatedCompareGrid from "../../components/sections/VsRelatedCompareGrid.astro";
 import VsCta02 from "../../components/sections/VsCta02.astro";
+import VsHero from "../../components/sections/VsHero.astro";
+import VsRelatedCompareGrid from "../../components/sections/VsRelatedCompareGrid.astro";
+import VsTestimonial from "../../components/sections/VsTestimonial.astro";
+import BaseLayout from "../../layouts/BaseLayout.astro";
 
 export async function getStaticPaths() {
   const vsPages = await getCollection("vs-pages", ({ data }) => !data.draft);
-  const compareEntries = await getCollection("compare", ({ data }) => !data.draft);
+  const compareEntries = await getCollection(
+    "compare",
+    ({ data }) => !data.draft,
+  );
 
   return vsPages.map((page) => {
     // Filter compare entries by this page's category

--- a/src/pages/whitepaper-architecting-an-enterprise-grade-mlops-platform.astro
+++ b/src/pages/whitepaper-architecting-an-enterprise-grade-mlops-platform.astro
@@ -1,4 +1,5 @@
 ---
+import ContactForm from "../components/islands/ContactForm.tsx";
 /**
  * Whitepaper Landing Page — gated content with form.
  *
@@ -7,12 +8,11 @@
  * On success, reveals PDF download link.
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
-import ContactForm from "../components/islands/ContactForm.tsx";
 import { TURNSTILE_SITE_KEY } from "../lib/formConstants";
 import {
-  WHITEPAPER_SEO,
   WHITEPAPER_CONTENT,
   WHITEPAPER_FIELDS,
+  WHITEPAPER_SEO,
 } from "../lib/whitepaper";
 ---
 


### PR DESCRIPTION
## Summary
- Fix `pnpm check` by adding the missing `@types/mdast` dev dependency for the remark plugin typing.
- Fix `pnpm validate:content` by removing the literal legacy Webflow host mention from the Claude Code migration blog post.
- Fix `pnpm lint` across `src/`, including Biome formatting, accessibility cleanups, and typed replacements for unsafe casts.
- Simplify-review follow-up: share form validation rules between the API route and `src/lib/formValidation.ts` so client/server rules cannot drift.
- Retry R2 image optimization for three release-note posts; updated hero/OG URLs to verified WebP assets. Refs #52.

## Validation
- `pnpm check` ✅ — 0 errors, 1 existing TypeScript hint in `CalEmbed.astro`
- `pnpm validate:content` ✅ — 0 errors, 9 existing warnings
- `pnpm lint` ✅
- `pnpm build` ✅

## Notes
- This PR is stacked on #54 / `feat/ahrefs-audit-improvements`.
- The R2 WebP URLs were verified with HTTP 200 before commit.
- The simplify pass reviewed the full diff for reuse, quality, and efficiency before committing.


## Follow-up review fixes
- Removed focusable full-screen cookie preferences backdrop; preferences panel now has dialog semantics.
- Removed pseudo-link semantics from LLMOps result cards so nested title links and tag buttons remain clean interactive targets.

Additional validation after follow-up:
- `pnpm lint` ✅
- `pnpm check` ✅ — 0 errors, 1 existing TypeScript hint in `CalEmbed.astro`
