### PR TITLE
Refresh: CrewAI Alternatives — 8 Agent Frameworks for Production Workflows

### DIFF
--- a/src/content/blog/crewai-alternatives.md
+++ b/src/content/blog/crewai-alternatives.md
@@ -1,5 +1,5 @@
 ---
-title: "We Tried and Tested 7 CrewAI Alternatives to Build Automated AI Workflows"
+title: "CrewAI Alternatives: 8 Agent Frameworks for Production Workflows"
 slug: "crewai-alternatives"
 draft: false
 webflow:
@@ -23,25 +23,29 @@ readingTime: 17 mins
 mainImage:
   url: "https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/31fdfde6/68a564f72c519b02fa18ec5a_crewai-alternatives.png"
 seo:
-  title: "We Tried and Tested 7 CrewAI Alternatives to Build Automated AI Workflows - ZenML Blog"
-  description: "Discover the top 7 CrewAI alternatives you can leverage to build automated AI workflows."
+  title: "CrewAI Alternatives: 8 Agent Frameworks for Production Workflows - ZenML Blog"
+  description: "Compare the best CrewAI alternatives for building production AI workflows, including LangGraph, AutoGen, Google ADK, OpenAI Agents SDK, Pydantic AI, Langflow, Flowise, and LlamaIndex."
   canonical: "https://www.zenml.io/blog/crewai-alternatives"
   ogImage: "https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/31fdfde6/68a564f72c519b02fa18ec5a_crewai-alternatives.png"
-  ogTitle: "We Tried and Tested 7 CrewAI Alternatives to Build Automated AI Workflows - ZenML Blog"
-  ogDescription: "Discover the top 7 CrewAI alternatives you can leverage to build automated AI workflows."
+  ogTitle: "CrewAI Alternatives: 8 Agent Frameworks for Production Workflows - ZenML Blog"
+  ogDescription: "Compare the best CrewAI alternatives for building production AI workflows, including LangGraph, AutoGen, Google ADK, OpenAI Agents SDK, Pydantic AI, Langflow, Flowise, and LlamaIndex."
 ---
 
-Your CrewAI demos looked great. Production did not.
+*Last updated: May 2026.*
 
-How to make it better? You need strict state control, clean handoffs, real human approvals, memory that survives jobs, and deploy targets that match your stack and budget. Without that, agents drift, runs cannot be reproduced, and audits stall.
+CrewAI can get multi-agent demos working fast. Production asks harder questions.
 
-We tried and tested 7 real alternatives and ran the same tasks across each one. In this CrewAI alternatives guide, you will see exactly which CrewAI jobs these alternatives replace, where they win, and where they fall short.
+The question is not whether CrewAI can build useful crews. It can. The harder question is whether its abstraction, pricing model, deployment path, state model, observability, and governance fit the way your team wants to run agents in production. If your workflows need strict state control, clean handoffs, human approvals, resumable runs, durable memory, and deployment targets that match your stack, it is worth comparing CrewAI with alternatives that make those trade-offs differently.
+
+We reviewed 8 real alternatives and mapped each one to the CrewAI jobs it can replace, where it wins, and where it falls short.
 
 We close with a practical path to operate agents at scale by wrapping your chosen framework with ZenML for the outer loop: versioning, lineage, evaluations, and dependable deployment.
 
+The timing matters because agentic AI has moved past the experiment-only phase. McKinsey's 2025 global AI survey found that 23% of respondents said their organizations were already scaling an agentic AI system somewhere in the enterprise, while another 39% had begun experimenting with agents. That shift changes the buying criteria. Teams are no longer only asking, "Can I build a multi-agent demo?" They are asking, "Can I control state, resume failed runs, approve risky actions, trace tool calls, evaluate outputs, and deploy the system without rewriting it six months later?"
+
 ## TL;DR
 
-<ul><li><strong>Why look for alternatives:</strong> Managed plans can sting, some teams need fine-grained control, and extra prompt layers can add latency and confusion for the model.</li><li><strong>Who should care:</strong> Machine learning engineers, MLOps teams, and AI developers shipping agentic apps where auditability, human review, and stable deployment matter.</li><li><strong>What to expect:</strong> A side-by-side view of seven options, mapped to features you’d normally use CrewAI for – multi-agent orchestration, workflow authoring, memory, HITL, observability/evals, RAG depth, deployment, and logging.</li></ul>
+<ul><li><strong>Why look for alternatives:</strong> CrewAI is strong for quickly building crews and flows, but teams may want a different abstraction for typed outputs, graph-based state, deterministic workflows, visual building, RAG-heavy agents, lower infrastructure control, or stricter production governance.</li><li><strong>Who should care:</strong> ML engineers, MLOps teams, platform teams, and AI developers shipping agentic workflows where auditability, human approval, resumability, cost visibility, and deployment control matter.</li><li><strong>What to expect:</strong> A side-by-side view of eight options, mapped to features you’d normally use CrewAI for: multi-agent orchestration, workflow authoring, typed outputs, memory, HITL, observability, evaluations, RAG depth, deployment, and logging.</li></ul>
 
 ## The Need for a CrewAI Alternative?
 
@@ -52,17 +56,17 @@ Why might you need a [CrewAI](https://www.crewai.com/) alternative in the first 
   <figcaption>Reasons you need a CrewAI alternatives</figcaption>
 </figure>
 
-### Reason 1. Managed plans are extremely expensive
+### Reason 1. Managed pricing and infrastructure control may not fit every team
 
-If you’re scaling concurrent agents with heavy tool use, per-step or per-node pricing stacks quickly. Open-source cores look free until you add tracing, evals, storage, and background jobs. Teams that can self-host usually do so to keep variable costs under control and to integrate with existing observability.
+CrewAI’s public pricing now includes a free Basic plan with a limited number of workflow executions and a custom Enterprise plan. That makes the cost question more nuanced than “open source versus paid.” Teams should evaluate how many runs they expect, whether they need private infrastructure, how much they will spend on model calls and observability, and whether they want to self-host the surrounding state, tracing, evaluation, and deployment stack.
 
 ### Reason 2. You need fine-grained control or specialized tooling
 
-Agentic apps are no longer single-model chats. You need threads, state snapshots, resumable runs, event logs, and first-class interrupts.
+Agentic apps are no longer single-model chats. You need threads, state snapshots, resumable runs, event logs, human approvals, and clear ownership of tool execution.
 
-You might also want MCP integration for tool servers, or a ‘hard’ workflow language, so not every routing decision is left to the LLM.
+CrewAI has added more production-oriented building blocks, including Flows for event-driven workflows, state management, MCP integrations, memory, knowledge, and observability options. The reason to compare alternatives is not that CrewAI has none of these features. It is that different teams may want a stricter graph runtime, a lower-level SDK, stronger typed outputs, deeper RAG primitives, or a visual builder.
 
-Alternatives like LangGraph give you a stateful graph runtime with checkpoints and time travel; others like Google’s ADK bring workflow agents for sequential, loop, and parallel patterns.
+For example, LangGraph emphasizes stateful graph orchestration with persistence and checkpointing. Google ADK gives teams workflow agents for sequential, loop, and parallel patterns inside the Google Cloud and Gemini ecosystem. Pydantic AI gives Python teams typed outputs and validation-first agent APIs.
 
 ### Reason 3. Quality degradation caused by extra prompt layers
 
@@ -102,9 +106,13 @@ Also, look at deployment options – can you self-host it on your infrastructure
 
 Production readiness means having not just fancy demos, but the reliability and support needed for long-term maintenance.
 
+### 4. State, Durability, and Governance
+
+For production agent systems, the hard part is not just getting an agent to call tools. It is controlling what happens across long-running, multi-step work. We looked for support for checkpoints, resumable runs, human approvals, durable state, audit trails, tracing, and clear ownership of tool execution. These details matter when agents touch customer data, internal systems, financial actions, or workflows that cannot simply be restarted from scratch.
+
 ## What are the Best Alternatives to CrewAI?
 
-We tested seven promising alternatives to CrewAI, each offering a different approach to building AI workflows. The table below gives a quick overview of these tools and their key strengths:
+We reviewed eight promising alternatives to CrewAI, each offering a different approach to building AI workflows. The table below gives a quick overview of these tools and their key strengths:
 
   
 
@@ -113,7 +121,7 @@ We tested seven promising alternatives to CrewAI, each offering a different appr
   
   
 
-<table class="comparison-table"> <thead> <tr> <th>CrewAI Alternative</th> <th>Key Feature</th> <th>Best For</th> <th>Deployment Model (Open source and/or managed)</th> </tr> </thead> <tbody> <tr> <td>AutoGen</td> <td>Multi-agent teams with event-driven orchestration and human-in-the-loop support</td> <td>Research-driven multi-agent runs and quick experiments</td> <td>Open source</td> </tr> <tr> <td>LangGraph</td> <td>Stateful graph orchestration with checkpoints, replay, and HITL pauses</td> <td>Controlled agent workflows that need auditability and replay</td> <td>Open source and managed (LangGraph Platform)</td> </tr> <tr> <td>Google ADK</td> <td>Workflow agents (sequential, parallel, loop) with strong GCP integration</td> <td>Gemini-first agent systems with structured workflow control</td> <td>Open source and managed (Agent Engine, Cloud Run, GKE)</td> </tr> <tr> <td>OpenAI Agents SDK</td> <td>Agent, tool, and handoff primitives with HITL approvals</td> <td>Teams building on OpenAI stack with minimal glue code</td> <td>Open source</td> </tr> <tr> <td>Langflow</td> <td>Visual flow builder for LLM agents and tools</td> <td>Builders who prefer UI-based flow design and rapid iteration</td> <td>Open source and managed (public Langflow server)</td> </tr> <tr> <td>FlowiseAI</td> <td>Node-based builder with agentic RAG patterns</td> <td>Quick prototyping of RAG-enabled agents</td> <td>Open source and managed</td> </tr> <tr> <td>LlamaIndex</td> <td>Deep RAG stack with workflow orchestration</td> <td>Data-heavy agents requiring advanced retrieval</td> <td>Open source and managed (LlamaDeploy)</td> </tr> </tbody></table>
+<table class="comparison-table"> <thead> <tr> <th>CrewAI Alternative</th> <th>Key Feature</th> <th>Best For</th> <th>Deployment Model (Open source and/or managed)</th> </tr> </thead> <tbody> <tr> <td>AutoGen</td> <td>Multi-agent teams with event-driven orchestration and human-in-the-loop support</td> <td>Research-driven multi-agent runs and quick experiments</td> <td>Open source</td> </tr> <tr> <td>LangGraph</td> <td>Stateful graph orchestration with checkpoints, replay, and HITL pauses</td> <td>Controlled agent workflows that need auditability and replay</td> <td>Open source and managed (LangGraph Platform)</td> </tr> <tr> <td>Google ADK</td> <td>Workflow agents (sequential, parallel, loop) with strong GCP integration</td> <td>Gemini-first agent systems with structured workflow control</td> <td>Open source and managed (Agent Engine, Cloud Run, GKE)</td> </tr> <tr> <td>OpenAI Agents SDK</td> <td>Agent, tool, and handoff primitives with HITL approvals</td> <td>Teams building on OpenAI stack with minimal glue code</td> <td>Open source</td> </tr> <tr> <td>Pydantic AI</td> <td>Type-safe Python agents with structured outputs, model-provider flexibility, MCP support, Logfire observability, and durable execution options</td> <td>Python teams that want production-grade agent APIs, validation, typed outputs, and clearer control over data contracts</td> <td>Open source framework with commercial observability through Pydantic Logfire</td> </tr> <tr> <td>Langflow</td> <td>Visual flow builder for LLM agents and tools</td> <td>Builders who prefer UI-based flow design and rapid iteration</td> <td>Open source and managed (public Langflow server)</td> </tr> <tr> <td>FlowiseAI</td> <td>Node-based builder with agentic RAG patterns</td> <td>Quick prototyping of RAG-enabled agents</td> <td>Open source and managed</td> </tr> <tr> <td>LlamaIndex</td> <td>Deep RAG stack with workflow orchestration</td> <td>Data-heavy agents requiring advanced retrieval</td> <td>Open source framework, LlamaCloud managed services, and llama-deploy for workflow deployment</td> </tr> </tbody></table>
 
 ## 1. AutoGen
 
@@ -139,7 +147,7 @@ However, the freedom AutoGen provides comes at the cost of guidance. With no pre
   <img src="https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/e603a240/68a55e79f6ab623343536b1c_langgraph-homepage.png" alt="__wf_reserved_inherit" />
 </figure>
 
-[LangGraph](https://www.langchain.com/langgraph) is a stateful orchestration framework. Every step writes a checkpoint you can rewind to or branch from, which means you can pause for human input and later resume without losing context. Studio gives you a debugging view and integrates tightly with LangSmith for traces and evals.
+[LangGraph](https://www.langchain.com/langgraph) is a stateful orchestration framework. When compiled with a checkpointer, LangGraph saves graph state as checkpoints, which enables human-in-the-loop workflows, conversational memory, time-travel debugging, and fault-tolerant execution. Studio gives you a debugging view and integrates tightly with LangSmith for traces and evals.
 
 ### Features
 
@@ -157,17 +165,17 @@ The downside is that LangGraph’s richness comes with complexity. There is some
   <img src="https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/cec58e5b/68a55ea943a86d0ea04636b2_agent-development-kit-google-homepage.png" alt="__wf_reserved_inherit" />
 </figure>
 
-[Google’s Agent Development Kit](https://google.github.io/adk-docs/) (ADK) is a flexible, modular framework for developing and deploying AI agents. Announced as part of the Vertex AI ecosystem, it’s Google’s answer to making agent-building more like standard software development.
+[Google’s Agent Development Kit](https://google.github.io/adk-docs/) (ADK) is a flexible, modular framework for developing and deploying AI agents. It is Google’s open-source, code-first framework for building, debugging, and deploying reliable agents, and it now sits within Google’s broader Gemini Enterprise Agent Platform story.
 
 ### Features
 
-<ul><li>ADK is designed for creating modular and scalable applications by composing multiple specialized agents in a hierarchy. It supports both deterministic <code>Workflow Agents</code> (like <code>SequentialAgent</code> and <code>ParallelAgent</code>) for predictable pipelines and dynamic, LLM-driven routing for more adaptive behavior.</li><li>Includes content moderation and guardrail features to keep agent outputs in check. It also makes it easy to register skills (tools/functions) that agents can use; wrapping a Python function or a Vertex API call as a skill is straightforward.</li><li>ADK treats sessions and memory as first-class concepts. It has abstractions for maintaining conversation state, storing long-term memory, etc. You can configure a Session for an agent (with short-term memory) and attach external memory modules (like a vector store for long-term facts).</li><li>Being on Vertex AI, ADK works seamlessly with Google’s models (like PaLM) and services. It offers enterprise necessities like IAM-based access control, audit logs, and multiple deployment options.</li></ul>
+<ul><li>ADK is designed for creating modular and scalable applications by composing multiple specialized agents in a hierarchy. It supports both deterministic <code>Workflow Agents</code> (like <code>SequentialAgent</code> and <code>ParallelAgent</code>) for predictable pipelines and dynamic, LLM-driven routing for more adaptive behavior.</li><li>Includes content moderation and guardrail features to keep agent outputs in check. It also makes it easy to register skills (tools/functions) that agents can use; wrapping a Python function or a Vertex API call as a skill is straightforward.</li><li>ADK treats sessions and memory as first-class concepts. It has abstractions for maintaining conversation state, storing long-term memory, etc. You can configure a Session for an agent (with short-term memory) and attach external memory modules (like a vector store for long-term facts).</li><li>ADK is optimized for the Google/Gemini ecosystem and integrates with Google Cloud deployment paths such as Agent Engine, Cloud Run, and GKE. It is a natural fit for teams already standardizing on Gemini and Google Cloud infrastructure.</li></ul>
 
 ### Pros and Cons
 
 The ADK’s primary advantage is that it brings software engineering discipline to agent development. It was *‘designed to make agent development feel more like software development,’* meaning you get clearer abstractions, versioning, and testing practices. For organizations already using Google Cloud, ADK is a natural fit – it’s optimized for Google’s models (Gemini, etc.) and easily plugs into GCP for data and deployment.
 
-In terms of downsides, ADK is relatively new (version 0.1.x) and evolving. As such, some features might be in preview or not be as polished. There may be a learning curve to grasp all its concepts (workflow agents, sessions, state, etc.), especially if you’re not familiar with Google’s terminology.
+In terms of downsides, ADK is still evolving quickly, and teams should check the current docs before committing to specific deployment, observability, or language-support assumptions. There may be a learning curve to grasp all its concepts (workflow agents, sessions, state, etc.), especially if you’re not familiar with Google’s terminology.
 
 ## 4. OpenAI Agents SDK
 
@@ -183,35 +191,53 @@ The [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/) is a lig
 
 ### Pros and Cons
 
-The OpenAI Agents SDK’s major advantage is simplicity and tight integration with OpenAI models. If you are already using GPT-5 and other older versions too, this SDK feels very natural – it’s basically an extension of the API’s function-calling mechanism. You can get an agent up and running with just a few lines of code.
+The OpenAI Agents SDK’s major advantage is simplicity and tight integration with OpenAI models. If your application already uses OpenAI’s APIs, the Agents SDK feels natural because it gives you first-party primitives for agents, tools, handoffs, guardrails, sessions, tracing, and human review. You can get an agent up and running with just a few lines of code.
 
-On the downside, the Agents SDK is somewhat opinionated towards the OpenAI way of doing things. It assumes a chat-centric agent that decides on function calls (tools) as needed. If your needs fall outside that paradigm, say, complex parallel workflows or long-running agents that need checkpoints, you might hit limitations.
+On the downside, the Agents SDK is somewhat opinionated towards the OpenAI way of doing things. It assumes a chat-centric agent that decides on function calls (tools) as needed. If your needs fall outside that paradigm, say complex graph orchestration, deep framework-agnostic state management, or long-running workflows with durable checkpointing across arbitrary infrastructure, you may still prefer a graph runtime such as LangGraph or a workflow/runtime layer designed specifically around durable execution.
 
-## 5. Langflow
+## 5. Pydantic AI
+
+<figure>
+  <img src="https://assets.zenml.io/content/blog/b1fce104/pydantic-ai-homepage.avif" alt="Pydantic AI homepage" />
+</figure>
+
+[Pydantic AI](https://pydantic.dev/docs/ai/overview/) is an open-source Python agent framework from the team behind Pydantic. It is a strong CrewAI alternative for teams that want agent logic to feel closer to typed application code than role-play-style task delegation. Instead of centering the abstraction on agents with backstories, Pydantic AI focuses on type-safe inputs, structured outputs, tool definitions, dependency injection, model-provider flexibility, and production observability.
+
+### Features
+
+<ul><li><strong>Type-safe agent design:</strong> Pydantic AI lets you define agents with typed dependencies, tools, and output schemas. This makes it a good fit when the agent’s response needs to become application data, not just text.</li><li><strong>Structured outputs and validation:</strong> Since it builds on Pydantic, the framework is especially strong when you need reliable JSON-like outputs, validated fields, and clear failure modes around malformed model responses.</li><li><strong>Model-provider flexibility:</strong> Pydantic AI is model-agnostic and supports providers such as OpenAI, Anthropic, Gemini, Bedrock, Groq, Mistral, Cohere, xAI, Hugging Face, OpenRouter, and others.</li><li><strong>MCP support:</strong> Pydantic AI supports Model Context Protocol in multiple ways, including connecting agents to local or remote MCP servers and using agents inside MCP servers.</li><li><strong>Observability through Logfire:</strong> Pydantic Logfire gives teams traces for LLM calls, tool calls, agent behavior, cost monitoring, and broader application context through OpenTelemetry-compatible observability.</li><li><strong>Durable execution options:</strong> Pydantic AI now documents durable execution support for agents that need to preserve progress across failures, restarts, asynchronous workflows, and human-in-the-loop approvals.</li></ul>
+
+### Pros and Cons
+
+Pydantic AI’s biggest advantage is that it brings agent development closer to normal production Python engineering. If your team already relies on Pydantic, FastAPI, typed schemas, and strict validation, the mental model is familiar. It is also a good fit for agents that need structured outputs, tool calls with clear contracts, and validation before data is passed into the rest of your system.
+
+The trade-off is that Pydantic AI is not trying to be the same kind of role-based multi-agent framework as CrewAI. You can build multi-agent systems with it, and the docs describe multiple-agent patterns, but teams looking for a higher-level “crew of specialists” metaphor may find CrewAI faster to prototype with. Pydantic AI is the better fit when correctness, type safety, observability, and application integration matter more than a visual or role-play-style abstraction.
+
+## 6. Langflow
 
 <figure>
   <img src="https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/c733b5d9/68a55ee9be0265cd732479e6_langflow-homepage.png" alt="__wf_reserved_inherit" />
 </figure>
 
-[Langflow](https://www.langflow.org/) is an open-source visual builder for LLM workflows; a no-code interface on top of LangChain. It lets you design chains of prompts, tools, and logic by drawing diagrams instead of writing code, which can dramatically speed up prototyping and collaboration.
+[Langflow](https://www.langflow.org/) is an open-source, Python-based visual builder for AI applications. It supports agents, MCP, multiple LLMs, vector stores, and tool integrations, making it a strong option for teams that want a visual workflow layer without committing to a single model provider.
 
 ### Features
 
-<ul><li>Provides a canvas UI where you can drag-and-drop nodes representing components (LLMs, prompts, tools, memory stores, etc.) and connect them to define the flow of information. This visual approach makes it intuitive to map out an agent’s reasoning.</li><li>Comes with a library of pre-built nodes for common tasks (LLMs, web search, database queries, conditional logic, etc.). You can configure each node’s parameters through the UI, saving time since you don’t need to implement these from scratch.</li><li>Lets you run a workflow step by step, tweaking prompts or parameters on the fly to refine behavior. Once you're satisfied, export the workflow to a Python script for integration or version control.</li><li>Memory is handled through dedicated components, like <code>Message History</code> or vector store integrations, that you can add to your flow just like any other component.</li></ul>
+<ul><li>Provides a canvas UI where you can drag-and-drop nodes representing components (LLMs, prompts, tools, memory stores, etc.) and connect them to define the flow of information. This visual approach makes it intuitive to map out an agent’s reasoning.</li><li>Comes with a library of pre-built nodes for common tasks (LLMs, web search, database queries, conditional logic, etc.). You can configure each node’s parameters through the UI, saving time since you don’t need to implement these from scratch.</li><li>Lets you iterate visually, adjust prompts and parameters, and run flows through the UI or API. This makes it useful for prototyping, sharing workflows with non-specialists, and turning approved flows into application-facing endpoints.</li><li>Memory is handled through dedicated components, like <code>Message History</code> or vector store integrations, that you can add to your flow just like any other component.</li></ul>
 
 ### Pros and Cons
 
 Langflow’s obvious advantage is accessibility. It lowers the barrier to entry – even those with limited programming skills can set up a complex agent workflow. This makes it perfect for rapid prototyping and for communication between technical and non-technical team members. The visual nature means easy iteration; you can modify prompts, switch models, add a new tool, and immediately test the effect.
 
-On the downside, visual tools can sometimes be limiting for very complex logic. Large flows might become messy on a canvas, and certain conditional logic or looping isn’t as easy to represent. In CrewAI or code, you could write an if-statement or a loop; in Langflow, you will need workarounds as the UI primarily represents directed acyclic graphs (DAGs) of tasks.
+On the downside, visual tools can sometimes be limiting for very complex logic. Large flows might become messy on a canvas, and certain conditional logic or looping isn’t as easy to represent. For complex production control flow, code-first frameworks can still be easier to test, version, and review. Large visual flows can become hard to reason about, and teams may eventually move critical logic into code once the prototype stabilizes.
 
-## 6. FlowiseAI
+## 7. FlowiseAI
 
 <figure>
   <img src="https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/d6e35dfa/68a55f030a0e760b1f1638a9_flowiseai-homepage.png" alt="__wf_reserved_inherit" />
 </figure>
 
-[Flowise](https://flowiseai.com/) is another open-source visual workflow builder for LLMs, similar to Langflow. It lets you create, test, and deploy AI agent chains through a browser UI. Flowise’s focus is on the quick deployment of these workflows.
+[Flowise](https://flowiseai.com/) is another open-source visual workflow builder for LLMs, similar to Langflow. It lets you create, test, and deploy AI agent chains through a browser UI. Flowise’s focus is on building, testing, and operationalizing agent and LLM workflows through visual builders, APIs, SDKs, tracing, evaluations, HITL, and workspace features.
 
 ### Features
 
@@ -219,17 +245,17 @@ On the downside, visual tools can sometimes be limiting for very complex logic. 
 
 ### Pros and Cons
 
-FlowiseAI’s strengths lie in its production-oriented design. It is arguably more geared towards enterprise use than some other visual builders. Features like built-in monitoring hooks, horizontal scaling, and an API for integration show that it’s ready to not just toy around, but serve real users at scale.
+FlowiseAI’s strengths lie in its production-oriented design. It is arguably more geared towards enterprise use than some other visual builders. Features such as tracing and analytics, evaluations, human-in-the-loop support, API/CLI/SDK access, embedded chatbot options, and team workspaces make Flowise more than a simple demo canvas.
 
 While FlowiseAI supports multi-agent setups and API deployment, its memory management is limited to short-term conversational context out of the box. Persistent, long-term memory or advanced knowledge integration often requires custom modules or external services, adding development overhead.
 
-## 7. LlamaIndex
+## 8. LlamaIndex
 
 <figure>
   <img src="https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/f5a31ff0/68a55f3475521225deb39cd8_llamaindex-homepage.png" alt="__wf_reserved_inherit" />
 </figure>
 
-[LlamaIndex](https://www.llamaindex.ai/) (formerly GPT Index) is an open-source framework focused on connecting LLMs with external data sources for retrieval-augmented generation (RAG). It’s not a full agent orchestrator like CrewAI, but it can augment or replace parts of CrewAI’s functionality when your agents need to work with a lot of knowledge or documents.
+[LlamaIndex](https://www.llamaindex.ai/) (formerly GPT Index) is an open-source framework focused on connecting LLMs with external data sources for retrieval-augmented generation (RAG). It started as a data/RAG framework, but LlamaIndex now also provides agents and workflow abstractions for building multi-step, data-heavy agent systems. It is still strongest when the agent’s main job depends on retrieval, document understanding, indexing, and context augmentation.
 
 ### Features
 
@@ -239,7 +265,7 @@ While FlowiseAI supports multi-agent setups and API deployment, its memory manag
 
 The main strength of LlamaIndex is depth in data-centric tasks. If your application is about question answering, report generation, or chatbots over proprietary data, LlamaIndex is tailor-made for that. It excels at building knowledge-aware agents – for instance, a research assistant that can cite sources from your document repository.
 
-However, LlamaIndex is narrower in scope than the other alternatives here. It was not originally designed for orchestrating multiple independent agents or complex tool use; it was designed to augment an LLM with knowledge. As a result, some things are rudimentary. For example, tool use in LlamaIndex is largely about picking the right index or doing a search – it’s not as general-purpose as, say, AutoGen or OpenAI’s Agents, where an agent can plan an arbitrary sequence of diverse API calls.
+However, LlamaIndex is narrower in scope than the other alternatives here. It was not originally designed for orchestrating multiple independent agents or complex tool use; it was designed to augment an LLM with knowledge. As a result, some things are rudimentary. The limitation is not that LlamaIndex lacks agent workflows. It is that its center of gravity is still data-rich, retrieval-heavy applications. If your core problem is general-purpose workflow orchestration, strict graph state, or broad multi-agent collaboration without a strong RAG/document component, LangGraph, AutoGen, Google ADK, OpenAI Agents SDK, or Pydantic AI may be a cleaner starting point.
 
 ## How ZenML Helps in Closing the Outer Loop Around CrewAI and Its Alternatives
 
@@ -251,7 +277,7 @@ All the alternatives above (and CrewAI itself) focus on the ‘inner loop’ of 
 
 The other half is the ‘outer loop’: everything needed to put that agent into production use and keep it running reliably.
 
-This is where [ZenML](https://www.zenml.io/) – an open-source MLOps + [LLMOps framework](https://docs.zenml.io/user-guides/llmops-guide) – comes in. ZenML is not an agent framework by itself; rather, it acts as a complement to whichever agent or workflow framework you choose (CrewAI or any alternative).
+This is where [ZenML](https://www.zenml.io/) comes in. ZenML is an AI control plane for orchestration, versioning, and governance across training pipelines, LLM workflows, and agent evaluations, from local development to Kubernetes. It is not an agent framework by itself; rather, it acts as a complement to whichever agent or workflow framework you choose (CrewAI or any alternative).
 
 It provides the plumbing to manage your agents’ lifecycle, from deployment to monitoring to evaluation. In practical terms, ZenML fills the gaps around agent frameworks.
 
@@ -310,7 +336,7 @@ Need to scale out to handle more load? ZenML can run parallel instances of your 
 
 In short, while frameworks like CrewAI, LangGraph, AutoGen, etc., help you define *what* your AI agents do (the inner loop), ZenML focuses on *how* those agents are put into real-world operation (the outer loop). It provides the missing pieces for reliability, reproducibility, and maintainability.
 
-**📚 Relevant alternative articles you must read:**
+**Related reads:**
 
 <ul><li><a href="https://www.zenml.io/blog/langgraph-alternatives">LangGraph Alternatives</a></li><li><a href="https://www.zenml.io/blog/llamaindex-alternatives">LlamaIndex Alternatives</a></li><li><a href="https://www.zenml.io/blog/kedro-alternatives">Kedro Alternatives</a></li></ul>
 
@@ -318,6 +344,28 @@ In short, while frameworks like CrewAI, LangGraph, AutoGen, etc., help you defin
 
 There’s no single best CrewAI alternative; the right pick depends on your use case, team skills, and production needs. Based on our testing, here’s how they stack up:
 
-<ul><li><strong>For maximum control and production reliability</strong> → <strong>LangGraph:</strong> Ideal for building auditable, debuggable workflows with explicit state management, checkpoints, and replay.</li><li><strong>For open-ended problem-solving and research</strong> → <strong>AutoGen:</strong> Best for dynamic, multi-agent collaboration where the solution path isn’t fixed and agents can negotiate tasks in free-form conversation.</li><li><strong>For rapid, visual prototyping and non-technical collaboration</strong> → <strong>Langflow:</strong> A UI-first builder that speeds up experimentation and communication between technical and business teams.</li><li><strong>For fast prototyping and production deployment</strong> → <strong>FlowiseAI:</strong> Combines a visual editor with REST API deployment, scaling, and monitoring, making it a strong bridge from prototype to production.</li><li><strong>For RAG-heavy applications</strong> → <strong>LlamaIndex:</strong> Best-in-class for retrieval, indexing, and enabling agents to work over large, complex, or private knowledge bases.</li></ul>
+<ul><li><strong>For maximum graph control and durable state</strong> → <strong>LangGraph:</strong> Best for auditable workflows with explicit state, checkpoints, persistence, HITL, and time-travel debugging.</li><li><strong>For open-ended multi-agent collaboration</strong> → <strong>AutoGen:</strong> Best for research-style or conversational multi-agent systems where agents coordinate dynamically.</li><li><strong>For Google Cloud and Gemini-first teams</strong> → <strong>Google ADK:</strong> Best for teams that want workflow agents, structured orchestration, and Google Cloud deployment paths.</li><li><strong>For OpenAI-first application teams</strong> → <strong>OpenAI Agents SDK:</strong> Best for teams that want first-party primitives for agents, tools, handoffs, guardrails, sessions, tracing, and human review.</li><li><strong>For typed Python agent applications</strong> → <strong>Pydantic AI:</strong> Best for teams that need structured outputs, validation, typed dependencies, MCP support, and production observability.</li><li><strong>For rapid visual prototyping</strong> → <strong>Langflow:</strong> Best for teams that want a visual builder for agent and RAG workflows.</li><li><strong>For visual workflows with operational features</strong> → <strong>Flowise:</strong> Best for builders who want visual agent flows, APIs, evaluations, HITL, and team/workspace features.</li><li><strong>For RAG-heavy and document-heavy applications</strong> → <strong>LlamaIndex:</strong> Best for agents that need retrieval, indexing, document parsing, context augmentation, and data-centric workflows.</li></ul>
 
-*If you’re interested in taking your AI agent projects to the next level, consider joining the ZenML waitlist. We’re building out first-class support for agentic frameworks (like CrewAI and AutoGen) in ZenML, and we’d love early feedback from users pushing the boundaries of what AI agents can do. With ZenML, you can seamlessly integrate whichever agent framework you choose into robust, production-grade workflows.* **Join our waitlist** to get started. 👇
+## FAQ
+
+### What is the best CrewAI alternative for production agent workflows?
+
+LangGraph is usually the strongest alternative when you need explicit graph control, checkpointing, persistence, human-in-the-loop workflows, and time-travel debugging. Pydantic AI is a strong option when typed outputs and validation matter most. Google ADK is a natural fit for Google Cloud and Gemini-first teams.
+
+### What is the best CrewAI alternative for Python developers?
+
+For Python developers, the strongest shortlist is LangGraph, AutoGen, Pydantic AI, OpenAI Agents SDK, and LlamaIndex. Choose LangGraph for graph orchestration, AutoGen for flexible multi-agent conversations, Pydantic AI for typed outputs, OpenAI Agents SDK for OpenAI-first apps, and LlamaIndex for RAG-heavy agents.
+
+### Is CrewAI still worth using?
+
+Yes. CrewAI is still a strong option for teams that want a simple, role-based abstraction for crews, tasks, tools, memory, knowledge, and flows. The reason to evaluate alternatives is not that CrewAI is bad. It is that different teams need different levels of control over state, deployment, observability, typed outputs, and governance.
+
+### Should I use CrewAI or LangGraph?
+
+Use CrewAI if you want to quickly model a team of role-based agents and tasks. Use LangGraph if you need explicit state transitions, durable checkpoints, human-in-the-loop pauses, and more control over graph execution.
+
+### Should I use CrewAI or Pydantic AI?
+
+Use CrewAI if the role-and-task abstraction matches your workflow. Use Pydantic AI if your agents need typed outputs, validated data contracts, dependency injection, MCP support, and stronger alignment with normal Python application engineering.
+
+*If you are moving from agent prototypes to production workflows, ZenML gives you the outer loop around whichever agent framework you choose: orchestration, artifact and metadata tracking, evaluation, deployment, and governance from local development to Kubernetes. Use ZenML OSS to start locally, or explore ZenML’s managed platform if your team needs a shared control plane for production AI workflows.*


### PR DESCRIPTION
## Summary

Refreshes [We Tried and Tested 7 CrewAI Alternatives](https://www.zenml.io/blog/crewai-alternatives) based on the audit dated 2026-05-11.

**Title + framing**
- Retitled to "CrewAI Alternatives: 8 Agent Frameworks for Production Workflows"
- Updated all SEO + OG title/description fields
- Added "Last updated: May 2026" banner at top of body

**Content additions**
- McKinsey 2025 agentic-AI adoption stat after the intro
- New Evaluation Criterion: State, Durability, and Governance
- New section on **Pydantic AI** (#5) with R2-hosted hero image
- New FAQ section with 5 questions for SERP/AI-answer visibility
- Renumbered Langflow → #6, Flowise → #7, LlamaIndex → #8

**Updated framing / corrected stale claims**
- Reason 1 (pricing): reflects CrewAI's free Basic tier + Enterprise plan instead of "extremely expensive"
- Reason 2: acknowledges CrewAI's Flows, MCP, memory, observability
- LangGraph: corrected checkpointer language per current docs
- Google ADK: removed PaLM/0.1.x references; now reflects Gemini Enterprise Agent Platform
- OpenAI Agents SDK: removed GPT-5 specific reference; updated limitations to reference durable execution
- Langflow / Flowise / LlamaIndex: current positioning per official docs
- ZenML positioning: control-plane framing; waitlist CTA → OSS + managed CTA

## Test plan

- [ ] Cloudflare Pages preview renders the post correctly
- [ ] New Pydantic AI section displays with hero image
- [ ] Comparison table shows 8 rows (Pydantic AI between OpenAI SDK and Langflow)
- [ ] FAQ section appears before the final CTA
- [ ] Tool sections numbered 1-8 in order (AutoGen, LangGraph, ADK, OpenAI SDK, Pydantic AI, Langflow, Flowise, LlamaIndex)
- [ ] All external links resolve
- [ ] "Last updated: May 2026" banner visible at top