### PR TITLE
Remove Senior Platform Engineer - Cloud & Infrastructure JD

### DIFF
--- a/src/lib/company.ts
+++ b/src/lib/company.ts
@@ -98,9 +98,4 @@ export const OPEN_POSITIONS = [
     type: "Full-time",
     href: "https://zenml.notion.site/Product-Engineer-ZenML-Kitaru-341f8dff2538800aa826c2624894dfc8",
   },
-  {
-    title: "Senior Platform Engineer - Cloud & Infrastructure (f/m/d)",
-    type: "Full-time",
-    href: "https://zenml.notion.site/Senior-Platform-Engineer-Cloud-Infrastructure-f-m-d-2d2f8dff253880e3811deb82ecace05b",
-  },
 ] as const;


### PR DESCRIPTION
## Summary
- Removes the Senior Platform Engineer - Cloud & Infrastructure (f/m/d) listing from `src/lib/company.ts`, which is the single source of truth consumed by both `/careers` and `/company`.
- Closes #61.

## Note on naming
The issue references "Senior Platform Engineer - **Customer Facing**", but the only Senior Platform Engineer role currently in the repo is the **Cloud & Infrastructure** one. Confirmed with Alex that this is the intended role to remove.

## Test plan
- [x] `pnpm check` passes (0 errors, 0 warnings)
- [ ] Preview deploy: verify `/careers` and `/company` show only the remaining Product Engineer role under Open Positions