### PR TITLE
pricing: consolidate to one CTA per plan (#76)

### DIFF
--- a/src/components/sections/PricingPlanCards.astro
+++ b/src/components/sections/PricingPlanCards.astro
@@ -128,18 +128,6 @@ const checkIcon =
                   {plan.cta.label}
                 </Button>
               </div>
-              <a
-                href={plan.secondaryLink.href}
-                class:list={[
-                  "mt-3 block text-center text-sm font-medium transition-colors",
-                  plan.highlighted
-                    ? "text-zenml-500 hover:text-zenml-600"
-                    : "text-gray-500 hover:text-gray-700",
-                ]}
-                data-analytics={plan.secondaryLink.analytics}
-              >
-                {plan.secondaryLink.label} <span aria-hidden="true">&rarr;</span>
-              </a>
 
               {/* Includes */}
               <hr class="my-5 border-gray-200" />

--- a/src/lib/marketingPageTypes.ts
+++ b/src/lib/marketingPageTypes.ts
@@ -121,7 +121,6 @@ export interface PricingPlan {
   features: string[];
   cta: CtaLink;
   ctaVariant?: "primary" | "secondary";
-  secondaryLink: CtaLink;
   /** Visually emphasized card (brand border + tint + shadow). */
   highlighted?: boolean;
 }

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -132,11 +132,6 @@ export const PRICING_PLANS: PricingPlan[] = [
       analytics: "OSS-Get-Started",
     },
     ctaVariant: "secondary",
-    secondaryLink: {
-      label: "Explore the docs",
-      href: "/docs",
-      analytics: "Pricing-OSS-Docs",
-    },
   },
   {
     id: "scale",
@@ -174,11 +169,6 @@ export const PRICING_PLANS: PricingPlan[] = [
       analytics: "Pricing-Scale-Book-Demo",
     },
     ctaVariant: "primary",
-    secondaryLink: {
-      label: "Talk to an engineer",
-      href: "/book-your-demo",
-      analytics: "Pricing-Scale-Talk-Engineer",
-    },
   },
   {
     id: "enterprise",
@@ -196,16 +186,11 @@ export const PRICING_PLANS: PricingPlan[] = [
       "Air-gapped deployment",
     ],
     cta: {
-      label: "Talk to sales",
+      label: "Talk to an engineer",
       href: "/book-your-demo",
       analytics: "Enterprise-Book-Demo",
     },
     ctaVariant: "secondary",
-    secondaryLink: {
-      label: "See the full comparison",
-      href: "#compare-table",
-      analytics: "Pricing-Enterprise-Compare",
-    },
   },
 ];
 
@@ -326,7 +311,7 @@ export const PRICING_COMPARE: PricingCompareTableData = {
       analytics: "Pricing-Scale-Book-Demo",
     },
     {
-      label: "Talk to sales",
+      label: "Talk to an engineer",
       href: "/book-your-demo",
       variant: "secondary",
       analytics: "Enterprise-Book-Demo",

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -297,26 +297,12 @@ export const PRICING_COMPARE: PricingCompareTableData = {
       ],
     },
   ],
-  ctaButtons: [
-    {
-      label: "Get Started",
-      href: "/get-started",
-      variant: "secondary",
-      analytics: "OSS-Get-Started",
-    },
-    {
-      label: "Book a demo",
-      href: "/book-your-demo",
-      variant: "primary",
-      analytics: "Pricing-Scale-Book-Demo",
-    },
-    {
-      label: "Talk to an engineer",
-      href: "/book-your-demo",
-      variant: "secondary",
-      analytics: "Enterprise-Book-Demo",
-    },
-  ],
+  // Derived from PRICING_PLANS so the per-plan CTA is the single source of truth
+  // for label / href / analytics / variant across both the card and the table row.
+  ctaButtons: PRICING_PLANS.map((plan) => ({
+    ...plan.cta,
+    variant: plan.ctaVariant ?? "primary",
+  })),
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Each pricing plan card now shows exactly one CTA. Enterprise primary relabeled `Talk to sales` → `Talk to an engineer` (the historically high-performing label per usability review). Open Source and Scale primaries unchanged.
- Comparison-table CTA row label updated in lockstep so the Enterprise CTA reads the same in both places.
- Follow-up commit derives `PRICING_COMPARE.ctaButtons` from `PRICING_PLANS` so the per-plan CTA is the single source of truth for label / href / analytics / variant across the card and the table row.

## Plausible measurement
Existing event names kept verbatim for historical-series continuity — no Plausible dashboard changes required:
- `OSS-Get-Started`, `Pricing-Scale-Book-Demo`, `Enterprise-Book-Demo` — unchanged, still firing
- `Pricing-OSS-Docs`, `Pricing-Scale-Talk-Engineer`, `Pricing-Enterprise-Compare` — DOM elements removed; events naturally taper to zero

Note: the `Enterprise-Book-Demo` event now fires on a button labeled "Talk to an engineer" — intentional, picking continuity over name-label match.

## Diff
4 files, +8 / -50 lines.

## Test plan
- [x] `pnpm astro check` — 0 errors / 0 warnings
- [x] `pnpm check:surface` — pass
- [x] `pnpm astro build` — pass
- [x] Desktop (1440×900) visual review — each card has one CTA, no awkward whitespace, Enterprise button reads "Talk to an engineer"
- [x] Mobile (390×844) visual review — cards stack cleanly, divider tight to the button
- [x] Plausible bridge smoke test — `OSS-Get-Started` / `Pricing-Scale-Book-Demo` / `Enterprise-Book-Demo` all fire with `surface=unified` from both the plan cards and the comparison-table CTA row
- [x] `/zenml-voice` review — labels on-voice; "Talk to an engineer" stronger than the label it replaces
- [ ] Post-merge: confirm Plausible dashboard still shows traffic on the three preserved goals

Closes #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)