### PR TITLE
pricing(table): dedupe Plans & pricing section + polish (#77)

### DIFF
--- a/src/components/sections/PricingComparisonTable.astro
+++ b/src/components/sections/PricingComparisonTable.astro
@@ -28,12 +28,12 @@ const colCount = data.columnHeaders.length;
     </h2>
     {data.subheading && <p class="mt-2 text-gray-600">{data.subheading}</p>}
   </div>
-  <div class="overflow-x-auto">
+  <div class="overflow-x-auto rounded-md border border-gray-200">
     <table class="w-full min-w-[600px] border-collapse text-sm">
       {/* Column headers */}
       <thead>
-        <tr class="border-b-2 border-gray-200">
-          <th class="py-3 pr-4 text-left font-medium text-gray-500">Plans</th>
+        <tr class="border-b border-gray-200">
+          <th class="px-4 py-3 text-left font-medium text-gray-500">Plans</th>
           {data.columnHeaders.map((header) => (
             <th class="px-4 py-3 text-center font-bold text-gray-900">{header}</th>
           ))}
@@ -46,7 +46,7 @@ const colCount = data.columnHeaders.length;
             <tr>
               <td
                 colspan={colCount + 1}
-                class="bg-gray-50 px-0 py-2 text-xs font-bold uppercase tracking-wider text-gray-500"
+                class="bg-gray-50 px-4 py-2.5 text-xs font-bold uppercase tracking-wider text-gray-500"
               >
                 {section.heading}
               </td>
@@ -54,10 +54,10 @@ const colCount = data.columnHeaders.length;
             {/* Data rows */}
             {section.rows.map((row, rowIdx) => (
               <tr class:list={[
-                "border-b border-gray-100",
+                "border-b border-gray-200",
                 rowIdx % 2 === 1 ? "bg-gray-50/50" : "",
               ]}>
-                <td class="py-3 pr-4 font-medium text-gray-900">
+                <td class="px-4 py-3 font-medium text-gray-900">
                   {row.link ? (
                     <a
                       href={row.link}
@@ -95,10 +95,10 @@ const colCount = data.columnHeaders.length;
           </>
         ))}
         {/* CTA button row */}
-        <tr class="border-t-2 border-gray-200">
+        <tr class="border-t border-gray-200">
           <td></td>
           {data.ctaButtons.map((cta) => (
-            <td class="px-4 py-4 text-center">
+            <td class="px-4 pt-5 pb-4 text-center">
               <Button
                 href={cta.href}
                 size="sm"

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -218,21 +218,6 @@ export const PRICING_COMPARE: PricingCompareTableData = {
   columnHeaders: ["Open Source", "Scale", "Enterprise"],
   sections: [
     {
-      heading: "Plans & pricing",
-      rows: [
-        { feature: "Price", values: ["Free", "From $399 / mo", "Custom"] },
-        {
-          feature: "Deployment scenario",
-          values: ["Self-hosted", "SaaS", "SaaS + Self-hosted"],
-        },
-        {
-          feature: "Monthly executions",
-          values: ["Unlimited", "500 – 5,000", "Unlimited"],
-        },
-        { feature: "Projects", values: ["Unlimited", "Up to 10", "Unlimited"] },
-      ],
-    },
-    {
       heading: "Core platform",
       rows: [
         {


### PR DESCRIPTION
## Summary
- **Commit 1 — dedupe**: Delete the entire `Plans & pricing` section from `PRICING_COMPARE.sections`. Every row in that section restated a fact already present on the plan cards above (Price, Deployment scenario, Monthly executions, Projects). The two duplications the ticket names — "Self-hosted" and "500 executions" — both lived here. Feature-comparison sections (Core platform, Pro control plane, Agent runtime, Enterprise & governance, Support) all untouched. Section count 6 → 5; row count 21 → 17.
- **Commit 2 — `/i-audit` polish**: Tightens borders, paddings, spacing on `PricingComparisonTable.astro` driven by an audit pass scoped to those three dimensions only. Adds an outer `rounded-md border border-gray-200` frame matching the plan cards, normalizes 4 different border treatments down to one (1px gray-200 everywhere internal), gives the section heading band + feature column proper left inset for the new frame.

## Diff
2 files, +6 / -23 lines.

## Test plan
- [x] `pnpm astro check` — no new errors introduced (1 pre-existing error in `scripts/og/template.tsx:9` from PR #75 — missing `@types/react`, unrelated to this PR's diff)
- [x] `pnpm check:surface` — pass
- [x] `pnpm astro build` — pass (9.7s)
- [x] Desktop visual (1440×900): table opens at "CORE PLATFORM"; no Self-hosted/500/Up-to-10/From-$399 strings inside the table body; outer frame echoes plan-card framing; section heading band properly inset
- [x] Mobile visual (390×844): outer rounded frame visible; horizontal scroll preserved (table 600px wide vs viewport 356px); section headers inset
- [x] CTA row: still renders the three buttons from #76's refactor (Get Started / Book a demo / Talk to an engineer) — Plausible event names unchanged
- [ ] Post-merge: confirm Plausible dashboard still shows traffic on `OSS-Get-Started`, `Pricing-Scale-Book-Demo`, `Enterprise-Book-Demo`

## Notes for reviewer
- Dark-mode variants intentionally NOT added — that work lives on `feature/dark-mode`. The Tailwind tokens used here (`gray-200`, `gray-50`) are dark-mode-compatible when that branch wires up `dark:` overrides on this file (memory note: "Wave 8" already touches this component).
- No conflict expected with PR #83 (`feat/pricing-one-cta-per-plan`): that PR touches `PRICING_PLANS` and `PRICING_COMPARE.ctaButtons`; this PR touches `PRICING_COMPARE.sections`. Non-overlapping hunks.

Closes #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)