### PR TITLE
get-started(tabs): unified ZenML + Kitaru onboarding in one URL

### DIFF
--- a/src/lib/getStarted.ts
+++ b/src/lib/getStarted.ts
@@ -223,7 +223,7 @@ if __name__ == "__main__":
 // ---------------------------------------------------------------------------
 export const GET_STARTED_KITARU = {
   steps: {
-    headline: "Make your agent survive a crash",
+    headline: "Pause for a human, survive a crash",
     items: [
       {
         title: "Install Kitaru",
@@ -231,42 +231,36 @@ export const GET_STARTED_KITARU = {
         code: "pip install kitaru",
       },
       {
-        title: "Write your first flow",
-        body: "Wrap an agent you already have — PydanticAI, the OpenAI or Anthropic SDKs, raw Python — and mark the expensive calls as <code>@checkpoint</code>:",
-        code: `from kitaru import flow, checkpoint
+        title: "Add a human-in-the-loop gate",
+        body: "Wrap an agent you already have, checkpoint the expensive calls, and <code>wait</code> for a human before anything ships:",
+        code: `from kitaru import flow, checkpoint, wait
 from kitaru.adapters.pydantic_ai import KitaruAgent
 from pydantic_ai import Agent
 
-# Wrap your existing PydanticAI agent — no rewrite.
-# Use any agent framework or raw Python
-agent = KitaruAgent(
-    Agent("openai:gpt-5.4", system_prompt="You research and summarize topics."),
-)
+# Wrap an agent you already have — no rewrite.
+agent = KitaruAgent(Agent("openai:gpt-5.4", system_prompt="You draft customer replies."))
 
 
 @checkpoint
-def research(topic: str) -> str:
-    return agent.run_sync(f"Research: {topic}").output
-
-
-@checkpoint
-def summarize(notes: str) -> str:
-    # Crash here and \`research\` stays cached on replay —
-    # no re-burning tokens on work that already succeeded.
-    return agent.run_sync(f"Summarize: {notes}").output
+def draft_reply(ticket: str) -> str:
+    # Persisted. Crash after this and it never re-runs.
+    return agent.run_sync(f"Draft a reply to: {ticket}").output
 
 
 @flow
-def research_flow(topic: str) -> str:
-    return summarize(research(topic))
+def support_flow(ticket: str) -> str:
+    reply = draft_reply(ticket)
+    # Suspends the run, frees the compute, resumes when a human answers — minutes or days later.
+    approved = wait(schema=bool, question=f"Send this?\\n\\n{reply}")
+    return reply if approved else "escalated to a human"
 
 
 if __name__ == "__main__":
-    research_flow.run("durable agents")`,
+    print(support_flow.run("my invoice is wrong").wait())`,
       },
       {
-        title: "Run it, kill it, replay it",
-        body: "Run it. Kill it mid-flight. Run it again — completed checkpoints are restored from cache, only the broken step re-executes.",
+        title: "Run it, walk away, resume it",
+        body: "Run it. It pauses at the approval gate and releases compute. Answer hours later and it resumes from where it stopped — no idle container, no lost work.",
         code: "python flow.py",
       },
     ],

--- a/src/lib/getStarted.ts
+++ b/src/lib/getStarted.ts
@@ -20,10 +20,10 @@ import type { CtaLink } from "./marketingPageTypes";
 export const GET_STARTED_SEO = {
   title: "Get Started with ZenML or Kitaru | ZenML",
   description:
-    "Set up ZenML for ML pipelines or Kitaru for durable agent workflows. Pick the runtime that matches your work, install, and run locally.",
+    "Set up ZenML for ML and data pipelines, Kitaru for durable agents — install, run locally, and bring both into the same workflow.",
   ogTitle: "Get Started with ZenML or Kitaru",
   ogDescription:
-    "Set up ZenML for ML pipelines or Kitaru for durable agent workflows. Pick the runtime that matches your work.",
+    "Set up ZenML for ML and data pipelines, Kitaru for durable agents — install, run locally, and bring both into the same workflow.",
   ogImage: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/3ae53e01/64b9920cd04b7c4c0340ce50_og-img-0625.jpg`,
 } as const;
 
@@ -33,7 +33,7 @@ export const GET_STARTED_SEO = {
 export const GET_STARTED_HERO = {
   eyebrow: "Open Source",
   headline: "Get started.",
-  deck: "Pick the runtime that matches your work. Set it up yourself with the docs, or book a demo for a guided walkthrough.",
+  deck: "ZenML runs your ML and data pipelines. Kitaru keeps agents alive across crashes, waits, and retries. Plenty of teams run both.",
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -115,7 +115,7 @@ export interface GetStartedResources {
 // ---------------------------------------------------------------------------
 export const GET_STARTED_ZENML = {
   steps: {
-    headline: "Start in 3 simple steps",
+    headline: "Build your first pipeline",
     items: [
       {
         title: "Install ZenML",
@@ -123,29 +123,38 @@ export const GET_STARTED_ZENML = {
         code: "pip install 'zenml[local]'",
       },
       {
-        title: "Write your first pipeline",
-        body: "Create a simple <code>run.py</code> file with a basic workflow:",
-        code: `from zenml import step, pipeline
+        title: "Track inputs and outputs",
+        body: "Wire two steps into a training pipeline — ZenML tracks every input and output as a versioned artifact:",
+        code: `from sklearn.base import ClassifierMixin
+from sklearn.datasets import load_iris
+from sklearn.svm import SVC
+from zenml import step, pipeline
 
 
 @step
-def basic_step() -> str:
-    """A simple step that returns a greeting message."""
-    return "Hello World!"
+def load_data() -> tuple[list, list]:
+    X, y = load_iris(return_X_y=True)
+    return X, y
+
+
+@step
+def train_model(X: list, y: list) -> ClassifierMixin:
+    # The returned model is versioned + tracked as an artifact automatically.
+    return SVC().fit(X, y)
 
 
 @pipeline
-def basic_pipeline():
-    """A simple pipeline with just one step."""
-    basic_step()
+def training_pipeline():
+    X, y = load_data()
+    train_model(X, y)
 
 
 if __name__ == "__main__":
-    basic_pipeline()`,
+    training_pipeline()`,
       },
       {
         title: "Run your pipeline locally",
-        body: "ZenML automatically tracks the execution and stores artifacts.",
+        body: "Run it locally. The pipeline executes, artifacts are versioned, and the run shows up in your dashboard.",
         code: "python run.py",
       },
     ],
@@ -214,7 +223,7 @@ if __name__ == "__main__":
 // ---------------------------------------------------------------------------
 export const GET_STARTED_KITARU = {
   steps: {
-    headline: "Start in 3 simple steps",
+    headline: "Make your agent survive a crash",
     items: [
       {
         title: "Install Kitaru",
@@ -223,28 +232,41 @@ export const GET_STARTED_KITARU = {
       },
       {
         title: "Write your first flow",
-        body: "Run <code>kitaru init</code>, then create a <code>flow.py</code> file with two decorators:",
-        code: `from kitaru import checkpoint, flow
+        body: "Wrap an agent you already have — PydanticAI, the OpenAI or Anthropic SDKs, raw Python — and mark the expensive calls as <code>@checkpoint</code>:",
+        code: `from kitaru import flow, checkpoint
+from kitaru.adapters.pydantic_ai import KitaruAgent
+from pydantic_ai import Agent
+
+# Wrap your existing PydanticAI agent — no rewrite.
+# Use any agent framework or raw Python
+agent = KitaruAgent(
+    Agent("openai:gpt-5.4", system_prompt="You research and summarize topics."),
+)
 
 
 @checkpoint
-def greet() -> str:
-    """A checkpointed step that returns a greeting."""
-    return "Hello World!"
+def research(topic: str) -> str:
+    return agent.run_sync(f"Research: {topic}").output
+
+
+@checkpoint
+def summarize(notes: str) -> str:
+    # Crash here and \`research\` stays cached on replay —
+    # no re-burning tokens on work that already succeeded.
+    return agent.run_sync(f"Summarize: {notes}").output
 
 
 @flow
-def basic_flow():
-    """A simple flow with one checkpoint."""
-    greet()
+def research_flow(topic: str) -> str:
+    return summarize(research(topic))
 
 
 if __name__ == "__main__":
-    basic_flow.run()`,
+    research_flow.run("durable agents")`,
       },
       {
-        title: "Run your flow locally",
-        body: "Kitaru records each checkpoint and lets you replay any run.",
+        title: "Run it, kill it, replay it",
+        body: "Run it. Kill it mid-flight. Run it again — completed checkpoints are restored from cache, only the broken step re-executes.",
         code: "python flow.py",
       },
     ],

--- a/src/lib/getStarted.ts
+++ b/src/lib/getStarted.ts
@@ -233,27 +233,18 @@ export const GET_STARTED_KITARU = {
       {
         title: "Add a human-in-the-loop gate",
         body: "Wrap an agent you already have, checkpoint the expensive calls, and <code>wait</code> for a human before anything ships:",
-        code: `from kitaru import flow, checkpoint, wait
+        code: `from kitaru import flow, wait
 from kitaru.adapters.pydantic_ai import KitaruAgent
 from pydantic_ai import Agent
 
-# Wrap an agent you already have — no rewrite.
+# KitaruAgent checkpoints every model + tool call for you.
 agent = KitaruAgent(Agent("openai:gpt-5.4", system_prompt="You draft customer replies."))
-
-
-@checkpoint
-def draft_reply(ticket: str) -> str:
-    # Persisted. Crash after this and it never re-runs.
-    return agent.run_sync(f"Draft a reply to: {ticket}").output
-
 
 @flow
 def support_flow(ticket: str) -> str:
-    reply = draft_reply(ticket)
-    # Suspends the run, frees the compute, resumes when a human answers — minutes or days later.
-    approved = wait(schema=bool, question=f"Send this?\\n\\n{reply}")
+    reply = agent.run_sync(f"Draft a reply to: {ticket}").output
+    approved = wait(schema=bool, question=f"Send this?\n\n{reply}")
     return reply if approved else "escalated to a human"
-
 
 if __name__ == "__main__":
     print(support_flow.run("my invoice is wrong").wait())`,

--- a/src/lib/getStarted.ts
+++ b/src/lib/getStarted.ts
@@ -2,55 +2,130 @@
  * Get Started page data — centralized marketing copy.
  *
  * Used by src/pages/get-started.astro.
- * Content extracted from Webflow HTML snapshot + SEO baseline.
+ *
+ * The page has two tabs (ZenML / Kitaru) under one /get-started URL with
+ * surface="unified". GET_STARTED_HERO + GET_STARTED_FINAL_CTA + GET_STARTED_SEO
+ * are shared across both tabs. GET_STARTED_ZENML and GET_STARTED_KITARU
+ * hold the per-tab content.
+ *
+ * ZenML copy was extracted from the original Webflow snapshot + SEO baseline.
+ * Kitaru code snippets follow the public docs at https://kitaru.ai/docs
+ * (decorators: @flow + @checkpoint; flows are invoked via `.run()`).
  */
 import type { CtaLink } from "./marketingPageTypes";
 
 // ---------------------------------------------------------------------------
-// SEO
+// SEO (one page, one URL)
 // ---------------------------------------------------------------------------
 export const GET_STARTED_SEO = {
-  title: "Get Started with ZenML - Open Source MLOps Framework",
+  title: "Get Started with ZenML or Kitaru | ZenML",
   description:
-    "Build production-ready ML pipelines with the open-source framework trusted by thousands of ML engineers worldwide.",
-  ogTitle: "Get Started with ZenML",
+    "Set up ZenML for ML pipelines or Kitaru for durable agent workflows. Pick the runtime that matches your work, install, and run locally.",
+  ogTitle: "Get Started with ZenML or Kitaru",
   ogDescription:
-    "Build production-ready ML pipelines with the open-source framework trusted by thousands of ML engineers worldwide.",
+    "Set up ZenML for ML pipelines or Kitaru for durable agent workflows. Pick the runtime that matches your work.",
   ogImage: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/3ae53e01/64b9920cd04b7c4c0340ce50_og-img-0625.jpg`,
 } as const;
 
 // ---------------------------------------------------------------------------
-// Hero
+// Shared hero (cross-product framing)
 // ---------------------------------------------------------------------------
 export const GET_STARTED_HERO = {
   eyebrow: "Open Source",
-  headline: "Get Started with ZenML",
-  deck: "Build production-ready ML pipelines on the open-source framework. Set it up yourself with the docs, or book a demo for a guided walkthrough.",
-  primaryCta: {
-    label: "Book a demo",
-    href: "/book-your-demo",
-  } as CtaLink,
-  secondaryCta: {
-    label: "Read Docs",
-    href: "/docs",
-  } as CtaLink,
+  headline: "Get started.",
+  deck: "Pick the runtime that matches your work. Set it up yourself with the docs, or book a demo for a guided walkthrough.",
 } as const;
 
 // ---------------------------------------------------------------------------
-// Code steps
+// Tab definitions (id, label, subtitle, brand dot)
 // ---------------------------------------------------------------------------
-export const GET_STARTED_STEPS = {
-  headline: "Start in 3 simple steps",
-  items: [
-    {
-      title: "Install ZenML",
-      body: "Get ZenML up and running in minutes. You just need to install it",
-      code: "pip install 'zenml[local]'",
-    },
-    {
-      title: "Write your first pipeline",
-      body: "Create a simple <code>run.py</code> file with a basic workflow:",
-      code: `from zenml import step, pipeline
+export interface GetStartedTab {
+  id: "zenml" | "kitaru";
+  label: string;
+  subtitle: string;
+  /** Tailwind background utility for the 8px brand dot inside the tab pill. */
+  dotClass: string;
+}
+
+export const GET_STARTED_TABS: readonly GetStartedTab[] = [
+  {
+    id: "zenml",
+    label: "ZenML",
+    subtitle: "ML pipelines",
+    dotClass: "bg-zenml-500",
+  },
+  {
+    id: "kitaru",
+    label: "Kitaru",
+    subtitle: "Agent runtime",
+    dotClass: "bg-orange-500",
+  },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
+export interface GetStartedStep {
+  title: string;
+  /** Body copy. May contain inline HTML (e.g. <code>...</code>). */
+  body: string;
+  code: string;
+}
+
+export interface GetStartedSteps {
+  headline: string;
+  items: readonly GetStartedStep[];
+}
+
+export interface GetStartedArchitecture {
+  eyebrow: string;
+  headline: string;
+  body: string;
+  image: { url: string; alt: string };
+  primaryCta: CtaLink;
+  secondaryCta: CtaLink;
+}
+
+export interface GetStartedProjects {
+  eyebrow: string;
+  headline: string;
+  deck: string;
+  cta: CtaLink;
+}
+
+export type GetStartedResourceColor = "teal" | "blue" | "purple" | "gray" | "orange";
+
+export interface GetStartedResource {
+  title: string;
+  body: string;
+  href: string;
+  external: boolean;
+  color: GetStartedResourceColor;
+}
+
+export interface GetStartedResources {
+  eyebrow: string;
+  headline: string;
+  body: string;
+  items: readonly GetStartedResource[];
+}
+
+// ---------------------------------------------------------------------------
+// ZenML tab
+// ---------------------------------------------------------------------------
+export const GET_STARTED_ZENML = {
+  steps: {
+    headline: "Start in 3 simple steps",
+    items: [
+      {
+        title: "Install ZenML",
+        body: "Get ZenML up and running in minutes. You just need to install it",
+        code: "pip install 'zenml[local]'",
+      },
+      {
+        title: "Write your first pipeline",
+        body: "Create a simple <code>run.py</code> file with a basic workflow:",
+        code: `from zenml import step, pipeline
 
 
 @step
@@ -67,88 +142,159 @@ def basic_pipeline():
 
 if __name__ == "__main__":
     basic_pipeline()`,
-    },
-    {
-      title: "Run your pipeline locally",
-      body: "ZenML automatically tracks the execution and stores artifacts.",
-      code: "python run.py",
-    },
-  ],
-} as const;
-
-// ---------------------------------------------------------------------------
-// Architecture section
-// ---------------------------------------------------------------------------
-export const GET_STARTED_ARCHITECTURE = {
-  eyebrow: "ZenML Architecture",
-  headline: "Built on a Robust Client-Server Architecture",
-  body: "ZenML is a metadata layer on top of your existing infrastructure, meaning all data and compute stays on your side.",
-  image: {
-    url: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/e19a8b4e/zenml-architecture.png`,
-    alt: "ZenML system architecture diagram showing connections between five main components: ZenML Client (Development Environment), ZenML Server, Database, MLOps Infrastructure (Cloud, Kubernetes, on-prem), and MLOps Tools (Experiment tracker, model deployer)",
+      },
+      {
+        title: "Run your pipeline locally",
+        body: "ZenML automatically tracks the execution and stores artifacts.",
+        code: "python run.py",
+      },
+    ],
   },
-  primaryCta: { label: "Learn More", href: "/deployments" } as CtaLink,
-  secondaryCta: {
-    label: "Read Docs",
-    href: "/docs",
-  } as CtaLink,
-} as const;
+  architecture: {
+    eyebrow: "ZenML Architecture",
+    headline: "Built on a Robust Client-Server Architecture",
+    body: "ZenML is a metadata layer on top of your existing infrastructure, meaning all data and compute stays on your side.",
+    image: {
+      url: `https://assets.zenml.io/webflow/64a817a2e7e2208272d1ce30/e19a8b4e/zenml-architecture.png`,
+      alt: "ZenML system architecture diagram showing connections between five main components: ZenML Client (Development Environment), ZenML Server, Database, MLOps Infrastructure (Cloud, Kubernetes, on-prem), and MLOps Tools (Experiment tracker, model deployer)",
+    },
+    primaryCta: { label: "Learn More", href: "/deployments" },
+    secondaryCta: { label: "Read Docs", href: "/docs" },
+  },
+  projects: {
+    eyebrow: "Projects",
+    headline: "Start with one of our ready-made projects",
+    deck: "Everything you need to replicate a production-grade use case — demo, video, blog, and code.",
+    cta: { label: "View All Projects", href: "/projects" },
+  },
+  resources: {
+    eyebrow: "Resources",
+    headline: "Your Complete ZenML Learning Toolkit",
+    body: "Dive deeper into ZenML with comprehensive documentation, development tools, hands-on tutorials, and a thriving community of ML engineers ready to help you succeed.",
+    items: [
+      {
+        title: "Official Documentation",
+        body: "Comprehensive guides, tutorials, and API reference to master ZenML",
+        href: "https://docs.zenml.io",
+        external: true,
+        color: "teal",
+      },
+      {
+        title: "VS Code Extension",
+        body: "ZenML Studio enhances your ML workflow with support for pipelines, stacks, server management and DAG visualization.",
+        href: "https://marketplace.visualstudio.com/items?itemName=ZenML.zenml-vscode",
+        external: true,
+        color: "blue",
+      },
+      {
+        title: "Interactive Tutorial",
+        body: "Master ZenML fundamentals through 10 guided pipeline examples with step-by-step tutorials and one-click execution!",
+        href: "https://github.com/zenml-io/vscode-tutorial",
+        external: true,
+        color: "purple",
+      },
+      {
+        title: "Slack Community",
+        body: "Join thousands of ML engineers sharing knowledge and best practices.",
+        href: "/slack",
+        external: false,
+        color: "gray",
+      },
+    ],
+  },
+} as const satisfies {
+  steps: GetStartedSteps;
+  architecture: GetStartedArchitecture;
+  projects: GetStartedProjects;
+  resources: GetStartedResources;
+};
 
 // ---------------------------------------------------------------------------
-// Projects section
+// Kitaru tab
 // ---------------------------------------------------------------------------
-export const GET_STARTED_PROJECTS = {
-  eyebrow: "Projects",
-  headline: "Start with one of our ready-made projects",
-  deck: "Everything you need to replicate a production-grade use case \u2014 demo, video, blog, and code.",
-  cta: { label: "View All Projects", href: "/projects" } as CtaLink,
-} as const;
+export const GET_STARTED_KITARU = {
+  steps: {
+    headline: "Start in 3 simple steps",
+    items: [
+      {
+        title: "Install Kitaru",
+        body: "Get Kitaru up and running in minutes. You just need to install it.",
+        code: "pip install kitaru",
+      },
+      {
+        title: "Write your first flow",
+        body: "Run <code>kitaru init</code>, then create a <code>flow.py</code> file with two decorators:",
+        code: `from kitaru import checkpoint, flow
+
+
+@checkpoint
+def greet() -> str:
+    """A checkpointed step that returns a greeting."""
+    return "Hello World!"
+
+
+@flow
+def basic_flow():
+    """A simple flow with one checkpoint."""
+    greet()
+
+
+if __name__ == "__main__":
+    basic_flow.run()`,
+      },
+      {
+        title: "Run your flow locally",
+        body: "Kitaru records each checkpoint and lets you replay any run.",
+        code: "python flow.py",
+      },
+    ],
+  },
+  resources: {
+    eyebrow: "Resources",
+    headline: "Your Complete Kitaru Learning Toolkit",
+    body: "Docs, examples, and a community building durable agents — start where you are.",
+    items: [
+      {
+        title: "Kitaru Docs",
+        body: "Primitives, APIs, and recipes for building durable agents.",
+        href: "https://kitaru.ai/docs",
+        external: true,
+        color: "orange",
+      },
+      {
+        title: "GitHub Repo",
+        body: "Star, file issues, and read the source on github.com/zenml-io/kitaru.",
+        href: "https://github.com/zenml-io/kitaru",
+        external: true,
+        color: "gray",
+      },
+      {
+        title: "From ZenML to Kitaru",
+        body: "Why we built a separate runtime for agents — and what it does for you.",
+        href: "/blog/from-zenml-to-kitaru",
+        external: false,
+        color: "purple",
+      },
+      {
+        title: "Slack Community",
+        body: "Join engineers shipping durable agents — get help, share patterns.",
+        href: "/slack",
+        external: false,
+        color: "blue",
+      },
+    ],
+  },
+} as const satisfies {
+  steps: GetStartedSteps;
+  resources: GetStartedResources;
+};
 
 // ---------------------------------------------------------------------------
-// Resources grid
-// ---------------------------------------------------------------------------
-export const GET_STARTED_RESOURCES = {
-  eyebrow: "Resources",
-  headline: "Your Complete ZenML Learning Toolkit",
-  body: "Dive deeper into ZenML with comprehensive documentation, development tools, hands-on tutorials, and a thriving community of ML engineers ready to help you succeed.",
-  items: [
-    {
-      title: "Official Documentation",
-      body: "Comprehensive guides, tutorials, and API reference to master ZenML",
-      href: "https://docs.zenml.io",
-      external: true,
-      color: "teal" as const,
-    },
-    {
-      title: "VS Code Extension",
-      body: "ZenML Studio enhances your ML workflow with support for pipelines, stacks, server management and DAG visualization.",
-      href: "https://marketplace.visualstudio.com/items?itemName=ZenML.zenml-vscode",
-      external: true,
-      color: "blue" as const,
-    },
-    {
-      title: "Interactive Tutorial",
-      body: "Master ZenML fundamentals through 10 guided pipeline examples with step-by-step tutorials and one-click execution!",
-      href: "https://github.com/zenml-io/vscode-tutorial",
-      external: true,
-      color: "purple" as const,
-    },
-    {
-      title: "Slack Community",
-      body: "Join thousands of ML engineers sharing knowledge and best practices.",
-      href: "/slack",
-      external: false,
-      color: "gray" as const,
-    },
-  ],
-} as const;
-
-// ---------------------------------------------------------------------------
-// Final CTA
+// Shared final CTA (sits below the tab panels, applies to both products)
 // ---------------------------------------------------------------------------
 export const GET_STARTED_FINAL_CTA = {
   headline: "Ready for the next level?",
-  body: "Go beyond open source with ZenML Pro. Get enterprise features, managed infrastructure, RBAC, enhanced security, dedicated support, and more.",
+  body: "Run ML pipelines or agent flows on a managed control plane. RBAC, audit logs, and dedicated support.",
   primaryCta: {
     label: "Compare OSS vs Pro",
     href: "/open-source-vs-pro",

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -114,10 +114,8 @@ export const PRICING_PLANS: PricingPlan[] = [
   {
     id: "open-source",
     eyebrow: "Open Source",
-    pill: "Self-hosted",
     subtitle: "For individuals and small teams",
     price: "Free",
-    priceSuffix: "self-hosted, forever",
     limitsLine: "Unlimited executions · Unlimited projects",
     includesLabel: "Includes",
     features: [
@@ -173,10 +171,9 @@ export const PRICING_PLANS: PricingPlan[] = [
   {
     id: "enterprise",
     eyebrow: "Enterprise",
-    pill: "SaaS + Self-hosted",
+    pill: "SaaS",
     subtitle: "For organizations at scale",
     price: "Custom",
-    priceSuffix: "annual contract",
     limitsLine: "Unlimited executions · Unlimited projects",
     includesLabel: "Everything in Scale, plus",
     features: [

--- a/src/pages/get-started.astro
+++ b/src/pages/get-started.astro
@@ -1,51 +1,77 @@
 ---
 /**
- * Get Started — ZenML (ML pipelines) onboarding.
+ * Get Started — unified onboarding for ZenML and Kitaru.
  *
- * Route: /get-started
+ * Route: /get-started · surface="unified"
  *
- * Open-source onboarding page: hero, 3-step code walkthrough,
- * architecture diagram, projects showcase, resources grid, and CTA.
- * The Phase-4 ML/Agent chooser was removed — `/get-started` is the
- * ZenML onboarding again; Kitaru's entry point is its own
- * `/product/kitaru` landing. `/get-started/zenml` 301-redirects here.
+ * Single page with two tabs (ZenML / Kitaru). The hero + pill switcher sit
+ * in one gradient band at the top. Each tab panel renders its own onboarding
+ * content (3-step walkthrough, architecture, resources). The final CTA is
+ * shared across both tabs.
+ *
+ * The Kitaru panel wraps its sections in `<div data-app="kitaru">` so brand
+ * tokens flip to Kitaru via `src/styles/kitaru-compat.css`.
+ *
+ * Tab switching: data-active-tab attribute selector swaps panel visibility.
+ * Plausible events: `Get Started: Tab View` (first interaction),
+ * `Get Started: Tab Switch` (subsequent).
+ *
+ * `/get-started/zenml` 301-redirects here (see public/_redirects).
  */
 import { getCollection } from "astro:content";
 import { createHighlighter } from "shiki";
 import Button from "../components/Button.astro";
+import Architecture from "../components/kitaru/Architecture.astro";
 import FeaturesHubCTA from "../components/sections/FeaturesHubCTA.astro";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import {
-  GET_STARTED_ARCHITECTURE,
   GET_STARTED_FINAL_CTA,
   GET_STARTED_HERO,
-  GET_STARTED_PROJECTS,
-  GET_STARTED_RESOURCES,
+  GET_STARTED_KITARU,
   GET_STARTED_SEO,
-  GET_STARTED_STEPS,
+  GET_STARTED_TABS,
+  GET_STARTED_ZENML,
+  type GetStartedStep,
 } from "../lib/getStarted";
+import "../styles/kitaru-compat.css";
+import kitaruDark from "../styles/kitaru-dark.json";
 import zenmlDark from "../styles/zenml-dark.json";
 
 type HighlighterTheme = NonNullable<
   Parameters<typeof createHighlighter>[0]["themes"]
 >[number];
 
-// Highlight code steps at build time with dark theme
+// Each tab's code blocks render with the matching brand's Shiki theme:
+// ZenML steps use `zenml-dark` (cool purples), Kitaru steps use
+// `kitaru-dark` (warm oranges) so the in-product syntax colors line up
+// with the brand-token swap on the rest of the panel.
 const highlighter = await createHighlighter({
-  themes: [zenmlDark as HighlighterTheme],
+  themes: [zenmlDark as HighlighterTheme, kitaruDark as HighlighterTheme],
   langs: ["python", "bash"],
 });
 
-const highlightedSteps = GET_STARTED_STEPS.items.map((step) => {
-  const lang = step.code.includes("\n") ? "python" : "bash";
-  const html = highlighter.codeToHtml(step.code, {
-    lang,
-    theme: "zenml-dark",
+const highlightSteps = (
+  items: readonly GetStartedStep[],
+  theme: "zenml-dark" | "kitaru-dark",
+) =>
+  items.map((step) => {
+    const lang = step.code.includes("\n") ? "python" : "bash";
+    return {
+      ...step,
+      highlightedHtml: highlighter.codeToHtml(step.code, {
+        lang,
+        theme,
+      }),
+    };
   });
-  return { ...step, highlightedHtml: html };
-});
 
-// Pull projects from the CMS collection if it exists
+const zenmlSteps = highlightSteps(GET_STARTED_ZENML.steps.items, "zenml-dark");
+const kitaruSteps = highlightSteps(
+  GET_STARTED_KITARU.steps.items,
+  "kitaru-dark",
+);
+
+// Pull ZenML projects from the CMS collection if it exists
 let projects: {
   data: { title: string; description?: string };
   id: string;
@@ -68,7 +94,10 @@ const resourceColors = {
   blue: "bg-blue-50 text-blue-600",
   purple: "bg-zenml-50 text-zenml-500",
   gray: "bg-gray-100 text-gray-600",
+  orange: "bg-orange-50 text-orange-500",
 } as const;
+
+const defaultTab: "zenml" | "kitaru" = "zenml";
 ---
 
 <BaseLayout
@@ -77,173 +106,269 @@ const resourceColors = {
   ogTitle={GET_STARTED_SEO.ogTitle}
   ogDescription={GET_STARTED_SEO.ogDescription}
   ogImage={GET_STARTED_SEO.ogImage}
-  surface="ml"
+  surface="unified"
 >
   <main>
-    {/* Hero */}
-    <section class="bg-linear-to-t from-zenml-50 to-white border-b border-gray-200 pt-16 pb-12 sm:pt-24 sm:pb-16">
-      <div class="mx-auto max-w-4xl px-4 text-center sm:px-6 lg:px-8">
-        <p class="text-sm font-semibold uppercase tracking-wider text-zenml-500">
-          {GET_STARTED_HERO.eyebrow}
-        </p>
-        <h1 class="mt-2 text-3xl font-bold text-gray-900 sm:text-4xl lg:text-5xl">
-          {GET_STARTED_HERO.headline}
-        </h1>
-        <p class="mt-4 text-lg text-gray-600 leading-relaxed">
-          {GET_STARTED_HERO.deck}
-        </p>
-        <div class="mt-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
-          <Button
-            href={GET_STARTED_HERO.primaryCta.href}
-            variant="secondary"
-            size="lg"
-            target="_blank"
-            rel="noopener noreferrer"
+    <div id="get-started" data-active-tab={defaultTab}>
+      {/* Hero + pill switcher in one gradient band */}
+      <section class="bg-linear-to-t from-zenml-50 to-white pt-16 pb-10 sm:pt-24 sm:pb-12">
+        <div class="mx-auto max-w-4xl px-4 text-center sm:px-6 lg:px-8">
+          <p class="text-sm font-semibold uppercase tracking-wider text-zenml-500">
+            {GET_STARTED_HERO.eyebrow}
+          </p>
+          <h1 class="mt-2 text-3xl font-bold text-gray-900 sm:text-4xl lg:text-5xl">
+            {GET_STARTED_HERO.headline}
+          </h1>
+          <p class="mt-4 text-lg text-gray-600 leading-relaxed">
+            {GET_STARTED_HERO.deck}
+          </p>
+        </div>
+        <div class="mt-8 flex justify-center px-4">
+          <div
+            role="tablist"
+            aria-label="Onboarding"
+            class="inline-flex items-center gap-1 rounded-xl border border-gray-200 bg-white p-1.5 shadow-[0_1px_2px_rgba(15,15,18,0.04)]"
           >
-            {GET_STARTED_HERO.primaryCta.label}
-          </Button>
-          <Button
-            href={GET_STARTED_HERO.secondaryCta.href}
-            size="lg"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {GET_STARTED_HERO.secondaryCta.label}
-          </Button>
-        </div>
-      </div>
-    </section>
-
-    {/* Code steps */}
-    <section class="bg-gray-900 py-16 sm:py-20">
-      <div class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
-        <h2 class="text-2xl font-bold text-white sm:text-3xl">
-          {GET_STARTED_STEPS.headline}
-        </h2>
-        <div class="mt-10 space-y-10">
-          {highlightedSteps.map((step) => (
-            <div>
-              <h3 class="text-lg font-semibold text-white">{step.title}</h3>
-              <p class="mt-1 text-sm text-gray-300" set:html={step.body} />
-              <div class="mt-3 dark-code-block" set:html={step.highlightedHtml} />
-            </div>
-          ))}
-        </div>
-      </div>
-    </section>
-
-    {/* Architecture */}
-    <section class="bg-gray-900 py-16 sm:py-20">
-      <div class="mx-auto max-w-5xl px-4 text-center sm:px-6 lg:px-8">
-        <p class="text-sm font-semibold uppercase tracking-wider text-zenml-400">
-          {GET_STARTED_ARCHITECTURE.eyebrow}
-        </p>
-        <h2 class="mt-2 text-2xl font-bold text-white sm:text-3xl">
-          {GET_STARTED_ARCHITECTURE.headline}
-        </h2>
-        <p class="mt-3 text-lg text-gray-300">
-          {GET_STARTED_ARCHITECTURE.body}
-        </p>
-        <div class="mt-8">
-          <img
-            src={GET_STARTED_ARCHITECTURE.image.url}
-            alt={GET_STARTED_ARCHITECTURE.image.alt}
-            class="w-full max-w-[900px] mx-auto"
-            loading="lazy"
-          />
-        </div>
-        <div class="mt-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
-          <Button href={GET_STARTED_ARCHITECTURE.primaryCta.href} variant="secondary" size="lg">
-            {GET_STARTED_ARCHITECTURE.primaryCta.label}
-          </Button>
-          <Button
-            href={GET_STARTED_ARCHITECTURE.secondaryCta.href}
-            size="lg"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {GET_STARTED_ARCHITECTURE.secondaryCta.label}
-          </Button>
-        </div>
-      </div>
-    </section>
-
-    {/* Projects */}
-    <section class="bg-white py-16 sm:py-20">
-      <div class="mx-auto max-w-5xl px-4 text-center sm:px-6 lg:px-8">
-        <p class="text-sm font-semibold uppercase tracking-wider text-zenml-500">
-          {GET_STARTED_PROJECTS.eyebrow}
-        </p>
-        <h2 class="mt-2 text-2xl font-bold text-gray-900 sm:text-3xl">
-          {GET_STARTED_PROJECTS.headline}
-        </h2>
-        <p class="mt-3 text-lg text-gray-600">{GET_STARTED_PROJECTS.deck}</p>
-        {projects.length > 0 ? (
-          <div class="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            {projects.map((project) => (
-              <a
-                href={`/projects/${project.id}`}
-                class="block rounded-lg border border-gray-200 p-4 text-left hover:shadow-md transition"
+            {GET_STARTED_TABS.map((tab) => (
+              <button
+                type="button"
+                role="tab"
+                id={`getstarted-tab-${tab.id}`}
+                data-tab-trigger={tab.id}
+                aria-controls={`getstarted-panel-${tab.id}`}
+                aria-selected={tab.id === defaultTab ? "true" : "false"}
+                tabindex={tab.id === defaultTab ? 0 : -1}
+                class="group inline-flex cursor-pointer items-center gap-2.5 rounded-lg px-5 py-3 text-[15px] font-semibold text-gray-700 transition-colors aria-selected:bg-gray-900 aria-selected:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-zenml-500"
               >
-                <h3 class="font-semibold text-gray-900">{project.data.title}</h3>
-                {project.data.description && (
-                  <p class="mt-1 text-sm text-gray-600 line-clamp-2">{project.data.description}</p>
-                )}
-              </a>
+                <span
+                  class={`inline-block size-2 shrink-0 rounded-full ${tab.dotClass}`}
+                  aria-hidden="true"
+                ></span>
+                <span>{tab.label}</span>
+                <span class="text-[13px] font-medium text-gray-400 group-aria-selected:text-gray-400">
+                  · {tab.subtitle}
+                </span>
+              </button>
             ))}
           </div>
-        ) : (
-          <p class="mt-6 text-sm text-gray-500">Projects coming soon.</p>
-        )}
-        <div class="mt-8">
-          <Button href={GET_STARTED_PROJECTS.cta.href} variant="secondary" size="lg">
-            {GET_STARTED_PROJECTS.cta.label}
-          </Button>
         </div>
-      </div>
-    </section>
+      </section>
 
-    {/* Resources */}
-    <section class="bg-gray-50 py-16 sm:py-20">
-      <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
-        <div class="max-w-3xl">
-          <p class="text-sm font-semibold uppercase tracking-wider text-zenml-500">
-            {GET_STARTED_RESOURCES.eyebrow}
-          </p>
-          <h2 class="mt-2 text-2xl font-bold text-gray-900 sm:text-3xl">
-            {GET_STARTED_RESOURCES.headline}
-          </h2>
-          <p class="mt-3 text-lg text-gray-600 leading-relaxed">
-            {GET_STARTED_RESOURCES.body}
-          </p>
-        </div>
-        <div class="mt-10 grid gap-6 sm:grid-cols-2">
-          {GET_STARTED_RESOURCES.items.map((resource) => (
-            <a
-              href={resource.href}
-              target={resource.external ? "_blank" : undefined}
-              rel={resource.external ? "noopener noreferrer" : undefined}
-              class="group rounded-md border border-gray-200 bg-white p-6 transition hover:shadow-md"
-            >
-              <div class:list={[
-                "inline-flex h-10 w-10 items-center justify-center rounded-lg",
-                resourceColors[resource.color],
-              ]}>
-                <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
-                </svg>
+      {/* ZenML tab panel */}
+      <div
+        id="getstarted-panel-zenml"
+        role="tabpanel"
+        data-tab-panel="zenml"
+        aria-labelledby="getstarted-tab-zenml"
+      >
+        {/* Steps */}
+        <section class="bg-gray-900 py-16 sm:py-20">
+          <div class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
+            <h2 class="text-2xl font-bold text-white sm:text-3xl">
+              {GET_STARTED_ZENML.steps.headline}
+            </h2>
+            <div class="mt-10 space-y-10">
+              {zenmlSteps.map((step) => (
+                <div>
+                  <h3 class="text-lg font-semibold text-white">{step.title}</h3>
+                  <p class="mt-1 text-sm text-gray-300" set:html={step.body} />
+                  <div class="mt-3 dark-code-block" set:html={step.highlightedHtml} />
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Architecture */}
+        <section class="bg-gray-900 py-16 sm:py-20">
+          <div class="mx-auto max-w-5xl px-4 text-center sm:px-6 lg:px-8">
+            <p class="text-sm font-semibold uppercase tracking-wider text-zenml-400">
+              {GET_STARTED_ZENML.architecture.eyebrow}
+            </p>
+            <h2 class="mt-2 text-2xl font-bold text-white sm:text-3xl">
+              {GET_STARTED_ZENML.architecture.headline}
+            </h2>
+            <p class="mt-3 text-lg text-gray-300">
+              {GET_STARTED_ZENML.architecture.body}
+            </p>
+            <div class="mt-8">
+              <img
+                src={GET_STARTED_ZENML.architecture.image.url}
+                alt={GET_STARTED_ZENML.architecture.image.alt}
+                class="w-full max-w-[900px] mx-auto"
+                loading="lazy"
+              />
+            </div>
+            <div class="mt-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+              <Button
+                href={GET_STARTED_ZENML.architecture.primaryCta.href}
+                variant="secondary"
+                size="lg"
+              >
+                {GET_STARTED_ZENML.architecture.primaryCta.label}
+              </Button>
+              <Button
+                href={GET_STARTED_ZENML.architecture.secondaryCta.href}
+                size="lg"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {GET_STARTED_ZENML.architecture.secondaryCta.label}
+              </Button>
+            </div>
+          </div>
+        </section>
+
+        {/* Projects */}
+        <section class="bg-white py-16 sm:py-20">
+          <div class="mx-auto max-w-5xl px-4 text-center sm:px-6 lg:px-8">
+            <p class="text-sm font-semibold uppercase tracking-wider text-zenml-500">
+              {GET_STARTED_ZENML.projects.eyebrow}
+            </p>
+            <h2 class="mt-2 text-2xl font-bold text-gray-900 sm:text-3xl">
+              {GET_STARTED_ZENML.projects.headline}
+            </h2>
+            <p class="mt-3 text-lg text-gray-600">{GET_STARTED_ZENML.projects.deck}</p>
+            {projects.length > 0 ? (
+              <div class="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                {projects.map((project) => (
+                  <a
+                    href={`/projects/${project.id}`}
+                    class="block rounded-lg border border-gray-200 p-4 text-left hover:shadow-md transition"
+                  >
+                    <h3 class="font-semibold text-gray-900">{project.data.title}</h3>
+                    {project.data.description && (
+                      <p class="mt-1 text-sm text-gray-600 line-clamp-2">{project.data.description}</p>
+                    )}
+                  </a>
+                ))}
               </div>
-              <h3 class="mt-4 text-lg font-semibold text-gray-900 group-hover:text-zenml-500">
-                {resource.title}
-              </h3>
-              <p class="mt-2 text-sm text-gray-600 leading-relaxed">{resource.body}</p>
-            </a>
-          ))}
+            ) : (
+              <p class="mt-6 text-sm text-gray-500">Projects coming soon.</p>
+            )}
+            <div class="mt-8">
+              <Button href={GET_STARTED_ZENML.projects.cta.href} variant="secondary" size="lg">
+                {GET_STARTED_ZENML.projects.cta.label}
+              </Button>
+            </div>
+          </div>
+        </section>
+
+        {/* Resources */}
+        <section class="bg-gray-50 py-16 sm:py-20">
+          <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl">
+              <p class="text-sm font-semibold uppercase tracking-wider text-zenml-500">
+                {GET_STARTED_ZENML.resources.eyebrow}
+              </p>
+              <h2 class="mt-2 text-2xl font-bold text-gray-900 sm:text-3xl">
+                {GET_STARTED_ZENML.resources.headline}
+              </h2>
+              <p class="mt-3 text-lg text-gray-600 leading-relaxed">
+                {GET_STARTED_ZENML.resources.body}
+              </p>
+            </div>
+            <div class="mt-10 grid gap-6 sm:grid-cols-2">
+              {GET_STARTED_ZENML.resources.items.map((resource) => (
+                <a
+                  href={resource.href}
+                  target={resource.external ? "_blank" : undefined}
+                  rel={resource.external ? "noopener noreferrer" : undefined}
+                  class="group rounded-md border border-gray-200 bg-white p-6 transition hover:shadow-md"
+                >
+                  <div class:list={[
+                    "inline-flex h-10 w-10 items-center justify-center rounded-lg",
+                    resourceColors[resource.color],
+                  ]}>
+                    <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+                    </svg>
+                  </div>
+                  <h3 class="mt-4 text-lg font-semibold text-gray-900 group-hover:text-zenml-500">
+                    {resource.title}
+                  </h3>
+                  <p class="mt-2 text-sm text-gray-600 leading-relaxed">{resource.body}</p>
+                </a>
+              ))}
+            </div>
+          </div>
+        </section>
+      </div>
+
+      {/* Kitaru tab panel — scoped to Kitaru brand tokens */}
+      <div
+        id="getstarted-panel-kitaru"
+        role="tabpanel"
+        data-tab-panel="kitaru"
+        aria-labelledby="getstarted-tab-kitaru"
+      >
+        <div data-app="kitaru">
+          {/* Steps — warm-dark section bg sits one step darker than the
+              kitaru-dark Shiki theme so the code blocks lift off the surface. */}
+          <section class="bg-[#14110E] py-16 sm:py-20">
+            <div class="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
+              <h2 class="text-2xl font-bold text-white sm:text-3xl">
+                {GET_STARTED_KITARU.steps.headline}
+              </h2>
+              <div class="mt-10 space-y-10">
+                {kitaruSteps.map((step) => (
+                  <div>
+                    <h3 class="text-lg font-semibold text-white">{step.title}</h3>
+                    <p class="mt-1 text-sm text-gray-300" set:html={step.body} />
+                    <div class="mt-3 dark-code-block" set:html={step.highlightedHtml} />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+
+          {/* Architecture — the canonical Kitaru architecture diagram */}
+          <Architecture />
+
+          {/* Resources */}
+          <section class="bg-gray-50 py-16 sm:py-20">
+            <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+              <div class="max-w-3xl">
+                <p class="text-sm font-semibold uppercase tracking-wider text-orange-500">
+                  {GET_STARTED_KITARU.resources.eyebrow}
+                </p>
+                <h2 class="mt-2 text-2xl font-bold text-gray-900 sm:text-3xl">
+                  {GET_STARTED_KITARU.resources.headline}
+                </h2>
+                <p class="mt-3 text-lg text-gray-600 leading-relaxed">
+                  {GET_STARTED_KITARU.resources.body}
+                </p>
+              </div>
+              <div class="mt-10 grid gap-6 sm:grid-cols-2">
+                {GET_STARTED_KITARU.resources.items.map((resource) => (
+                  <a
+                    href={resource.href}
+                    target={resource.external ? "_blank" : undefined}
+                    rel={resource.external ? "noopener noreferrer" : undefined}
+                    class="group rounded-md border border-gray-200 bg-white p-6 transition hover:shadow-md"
+                  >
+                    <div class:list={[
+                      "inline-flex h-10 w-10 items-center justify-center rounded-lg",
+                      resourceColors[resource.color],
+                    ]}>
+                      <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+                      </svg>
+                    </div>
+                    <h3 class="mt-4 text-lg font-semibold text-gray-900 group-hover:text-orange-500">
+                      {resource.title}
+                    </h3>
+                    <p class="mt-2 text-sm text-gray-600 leading-relaxed">{resource.body}</p>
+                  </a>
+                ))}
+              </div>
+            </div>
+          </section>
         </div>
       </div>
-    </section>
+    </div>
 
-    {/* Final CTA */}
+    {/* Final CTA — sits outside the tab root; shared across both tabs */}
     <FeaturesHubCTA
       headline={GET_STARTED_FINAL_CTA.headline}
       body={GET_STARTED_FINAL_CTA.body}
@@ -252,3 +377,110 @@ const resourceColors = {
     />
   </main>
 </BaseLayout>
+
+<style>
+  /* Tab panel visibility — toggled by data-active-tab on #get-started. */
+  #get-started > [data-tab-panel] {
+    display: none;
+  }
+  #get-started[data-active-tab="zenml"] > [data-tab-panel="zenml"],
+  #get-started[data-active-tab="kitaru"] > [data-tab-panel="kitaru"] {
+    display: block;
+  }
+
+  /* Fade-in transition on the newly-shown panel. Honours reduced motion. */
+  @keyframes gs-panel-in {
+    from {
+      opacity: 0;
+      transform: translateY(6px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  @media (prefers-reduced-motion: no-preference) {
+    #get-started > [data-tab-panel] {
+      animation: gs-panel-in 280ms cubic-bezier(0.22, 1, 0.36, 1);
+    }
+  }
+</style>
+
+<script>
+  // Scroll-reveal observer drives [data-reveal] fade-ins inside the embedded
+  // Kitaru Architecture component. The observer is a no-op on elements that
+  // don't carry the attribute, so it's safe to load page-wide.
+  import "../scripts/kitaru/scroll-reveal";
+
+  const root = document.getElementById("get-started");
+  if (root) {
+    const tabTriggers = Array.from(
+      root.querySelectorAll<HTMLButtonElement>("[data-tab-trigger]"),
+    );
+
+    // Analytics — single mutation point so click + keyboard route through the
+    // same emit logic. `surface` is auto-merged by PlausibleBridge.
+    let hasInteracted = false;
+    const track = (name: string, props?: Record<string, string>) => {
+      (window as any).__zenmlPlausibleTrack?.(name, props);
+    };
+
+    const applyTab = (tabId: string, focus = false) => {
+      const prev = root.dataset.activeTab;
+      if (prev === tabId) {
+        if (focus) {
+          tabTriggers
+            .find((b) => b.dataset.tabTrigger === tabId)
+            ?.focus();
+        }
+        return;
+      }
+
+      root.dataset.activeTab = tabId;
+
+      tabTriggers.forEach((btn) => {
+        const isActive = btn.dataset.tabTrigger === tabId;
+        btn.setAttribute("aria-selected", isActive ? "true" : "false");
+        btn.tabIndex = isActive ? 0 : -1;
+        if (isActive && focus) btn.focus();
+      });
+
+      // The newly-active panel may contain [data-reveal] elements (e.g. the
+      // embedded Kitaru Architecture) that the IntersectionObserver couldn't
+      // see while the panel was display:none. Reveal them immediately on
+      // switch so the panel renders fully instead of as a void below the fold.
+      const newPanel = root.querySelector<HTMLElement>(
+        `[data-tab-panel="${tabId}"]`,
+      );
+      newPanel?.querySelectorAll<HTMLElement>("[data-reveal]:not(.revealed)").forEach(
+        (el) => el.classList.add("revealed"),
+      );
+
+      if (!hasInteracted) {
+        hasInteracted = true;
+        track("Get Started: Tab View", { first_tab: tabId });
+      } else if (prev) {
+        track("Get Started: Tab Switch", { from: prev, to: tabId });
+      }
+    };
+
+    tabTriggers.forEach((btn, idx) => {
+      btn.addEventListener("click", () => {
+        const tabId = btn.dataset.tabTrigger;
+        if (tabId) applyTab(tabId);
+      });
+      btn.addEventListener("keydown", (e: KeyboardEvent) => {
+        let nextIdx: number | null = null;
+        if (e.key === "ArrowRight") nextIdx = (idx + 1) % tabTriggers.length;
+        else if (e.key === "ArrowLeft")
+          nextIdx = (idx - 1 + tabTriggers.length) % tabTriggers.length;
+        else if (e.key === "Home") nextIdx = 0;
+        else if (e.key === "End") nextIdx = tabTriggers.length - 1;
+        if (nextIdx === null) return;
+        e.preventDefault();
+        const target = tabTriggers[nextIdx]?.dataset.tabTrigger;
+        if (target) applyTab(target, true);
+      });
+    });
+  }
+</script>

--- a/src/pages/product/kitaru.astro
+++ b/src/pages/product/kitaru.astro
@@ -35,7 +35,7 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import "../../styles/kitaru-compat.css";
 
 const seo = {
-  title: "Kitaru — Durable runtime for AI agents | ZenML",
+  title: "Kitaru — Open-source runtime for long-running Python agents | ZenML",
   description:
     "Open-source runtime for long-running Python agents. Add checkpoints, replay, wait/resume, isolated execution, artifacts, and versioned deployments on your own cloud. Built by the ZenML team.",
 };

--- a/src/styles/kitaru-dark.json
+++ b/src/styles/kitaru-dark.json
@@ -1,0 +1,185 @@
+{
+  "name": "kitaru-dark",
+  "type": "dark",
+  "colors": {
+    "editor.background": "#1E1B16",
+    "editor.foreground": "#E9E4DE"
+  },
+  "tokenColors": [
+    {
+      "name": "Comments",
+      "scope": ["comment", "punctuation.definition.comment"],
+      "settings": {
+        "foreground": "#9C938C",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Strings",
+      "scope": ["string", "string.quoted", "string.template"],
+      "settings": {
+        "foreground": "#6FB789"
+      }
+    },
+    {
+      "name": "String Escape",
+      "scope": ["constant.character.escape"],
+      "settings": {
+        "foreground": "#6FB789"
+      }
+    },
+    {
+      "name": "F-string expressions",
+      "scope": [
+        "meta.fstring",
+        "punctuation.definition.template-expression"
+      ],
+      "settings": {
+        "foreground": "#D38151"
+      }
+    },
+    {
+      "name": "Numbers",
+      "scope": ["constant.numeric"],
+      "settings": {
+        "foreground": "#D38151"
+      }
+    },
+    {
+      "name": "Built-in Constants (True, False, None)",
+      "scope": ["constant.language"],
+      "settings": {
+        "foreground": "#6FB789"
+      }
+    },
+    {
+      "name": "Keywords & Storage",
+      "scope": [
+        "keyword",
+        "storage.type",
+        "storage.modifier",
+        "keyword.control",
+        "keyword.operator.new"
+      ],
+      "settings": {
+        "foreground": "#C89F70"
+      }
+    },
+    {
+      "name": "Functions & Methods",
+      "scope": [
+        "entity.name.function",
+        "meta.function-call",
+        "support.function"
+      ],
+      "settings": {
+        "foreground": "#D38151"
+      }
+    },
+    {
+      "name": "Classes & Types",
+      "scope": [
+        "entity.name.type",
+        "entity.name.class",
+        "support.type",
+        "support.class",
+        "entity.other.inherited-class"
+      ],
+      "settings": {
+        "foreground": "#C89F70"
+      }
+    },
+    {
+      "name": "Decorators",
+      "scope": [
+        "meta.decorator",
+        "punctuation.definition.decorator",
+        "entity.name.function.decorator"
+      ],
+      "settings": {
+        "foreground": "#D38151",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Operators & Punctuation",
+      "scope": [
+        "keyword.operator",
+        "punctuation",
+        "punctuation.definition.parameters",
+        "punctuation.separator",
+        "punctuation.section"
+      ],
+      "settings": {
+        "foreground": "#AEA298"
+      }
+    },
+    {
+      "name": "Variables & Parameters",
+      "scope": [
+        "variable",
+        "variable.parameter",
+        "variable.other",
+        "meta.function.parameters"
+      ],
+      "settings": {
+        "foreground": "#E9E4DE"
+      }
+    },
+    {
+      "name": "Properties & Attributes",
+      "scope": [
+        "variable.other.property",
+        "variable.other.object.property",
+        "entity.other.attribute-name"
+      ],
+      "settings": {
+        "foreground": "#E9E4DE"
+      }
+    },
+    {
+      "name": "Built-in & Self",
+      "scope": [
+        "variable.language",
+        "variable.language.self",
+        "variable.language.this"
+      ],
+      "settings": {
+        "foreground": "#6FB789",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Imports & Modules",
+      "scope": [
+        "keyword.control.import",
+        "keyword.control.from",
+        "keyword.other.import"
+      ],
+      "settings": {
+        "foreground": "#C89F70"
+      }
+    },
+    {
+      "name": "Module Names",
+      "scope": [
+        "entity.name.import",
+        "entity.name.module"
+      ],
+      "settings": {
+        "foreground": "#6FB789"
+      }
+    },
+    {
+      "name": "Type Annotations",
+      "scope": [
+        "meta.function.return-type",
+        "punctuation.definition.type",
+        "support.type.python"
+      ],
+      "settings": {
+        "foreground": "#6FB789"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #80. `/get-started` becomes a single `surface="unified"` page with two tabs (ZenML default, Kitaru) under one URL. The hero + pill switcher sit in one gradient band; each tab's panel renders its own onboarding (3-step walkthrough, architecture, resources). The final CTA is shared.

- **Pattern chosen:** Option B from the ticket — tabbed inline on one URL. Mirrors the homepage `TwoWorkspaces` switcher pattern but at the onboarding level.
- **Brand isolation:** Kitaru panel wraps in `<div data-app="kitaru">` so `kitaru-compat.css` tokens take effect. Code blocks use the new `kitaru-dark` Shiki theme; section bg is a slightly darker warm tone so the code blocks lift visually.
- **Data refactor:** `src/lib/getStarted.ts` split into `GET_STARTED_ZENML` / `GET_STARTED_KITARU` namespaces plus shared `GET_STARTED_HERO` / `FINAL_CTA` / `SEO`.
- **Kitaru code accuracy:** snippets follow the public docs at https://kitaru.ai/docs (`@flow` + `@checkpoint`, flows invoked via `.run()`).
- **Routing:** existing `/get-started/zenml` → `/get-started` redirect in `public/_redirects` is unchanged (still correct under the one-URL design).

## New Plausible events

Please register these as goals in the Plausible dashboard:

| Event | Props | When |
|-------|-------|------|
| `Get Started: Tab View` | `first_tab` | First tab interaction in a session |
| `Get Started: Tab Switch` | `from`, `to` | Subsequent tab changes |

Surface (`unified`) is auto-merged by `PlausibleBridge`.

## Test plan

- [x] `pnpm check:surface` passes (`surface="unified"`)
- [x] `pnpm astro build` clean
- [x] Dev verification: ZenML default on cold load, Kitaru tab switch swaps panel content, both Plausible events fire with correct props (verified via spy in DevTools)
- [x] Keyboard nav: ArrowLeft/Right + Home/End rotate focus across tabs
- [x] Embedded Kitaru `<Architecture />` data-reveal items force-revealed on tab switch (avoids the IntersectionObserver-misses-display-none case)
- [x] Zero console errors
- [ ] Production smoke: `/get-started/zenml` still 301s on the Cloudflare edge

## Out of scope

- Nav surgery (#65 covers that)
- New Kitaru product pages beyond `/product/kitaru`
- Adding a Kitaru-side `projects` collection (the Kitaru panel intentionally has 3 sections vs ZenML's 4)
- URL hash-routing for tab state

🤖 Generated with [Claude Code](https://claude.com/claude-code)