### PR TITLE
Two-tier nav + per-product compare hubs (closes #65, closes #66)

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -1,240 +1,72 @@
 ---
+import type { Surface } from "../lib/analytics";
 import {
   FALLBACK_STARS,
   formatStars,
   GITHUB_REPO_URL,
 } from "../lib/githubStars";
 import {
+  getActiveContext,
+  getSubnavForSurface,
   isActivePath,
   NAV_CTAS,
-  NAV_DROPDOWNS,
-  NAV_LINKS,
+  NAV_PRIMARY,
+  PRODUCT_CONTEXTS,
+  productAccent,
 } from "../lib/navigation";
 import Button from "./Button.astro";
-/**
- * Navigation — responsive navbar matching the zenml.io Webflow site.
- * Desktop: hover-driven dropdown panels with two-column layout.
- * Mobile: hamburger toggle with accordion sections.
- */
 import ZenmlLogo from "./brand/ZenmlLogo.astro";
+
+/**
+ * Navigation — two-tier (#65).
+ *
+ * Primary tier on every page (6 direct links + GitHub star pill + CTAs).
+ * Secondary subnav strip below the primary tier on product pages only
+ * (surface="ml" or "agent"). Hidden on surface="unified".
+ *
+ * Mobile: ElevenLabs-style product-context switcher inside the drawer.
+ * One active product context at a time; the "Menu ▾" chip swaps between
+ * ZenML / Kitaru / ZenML Pro. On unified pages, omit the chip and subnav
+ * and show only the flat primary list.
+ */
 
 interface Props {
   currentPath?: string;
+  surface: Surface;
 }
 
-const { currentPath = Astro.url.pathname } = Astro.props;
+const { currentPath = Astro.url.pathname, surface } = Astro.props;
 const headerStarsFallback = formatStars(FALLBACK_STARS);
+
+// A page renders the subnav whenever it's on a product surface (ml or agent).
+// `subnav`, `activeContext`, and `accent` are all non-null together — the
+// JSX guards on `accent` to narrow all three for the rendering block.
+const subnav = getSubnavForSurface(surface);
+const activeContext = getActiveContext(surface);
+const accent = activeContext ? productAccent(activeContext.productSurface) : null;
+
+// CSS brand-token scope override for Kitaru pages. The site-wide default is
+// data-app="zenml" set by BaseLayout; agent pages need to flip the scope.
+const brandScope = surface === "agent" ? "kitaru" : undefined;
+
+// Mobile primary cross-product list — on product surfaces, the three product
+// anchors are already in the context chip, so drop them to avoid duplication.
+const mobilePrimaryLinks = subnav
+  ? NAV_PRIMARY.filter((link) => !link.productSurface)
+  : NAV_PRIMARY;
 ---
 
 <header class="sticky top-0 z-50 w-full bg-white/95 backdrop-blur-sm border-b border-gray-200/60">
+  {/* ─── Primary tier ─────────────────────────────────────────────────── */}
   <div class="mx-auto max-w-[var(--container-lg)] px-4 sm:px-6 lg:px-8">
     <div class="flex h-[72px] items-center">
-      {/* Logo */}
       <a href="/" class="flex shrink-0 items-center gap-2 text-foreground" aria-label="ZenML">
         <ZenmlLogo class="h-7 w-auto" />
       </a>
 
-      {/* Desktop Nav */}
+      {/* Desktop primary links */}
       <nav class="hidden lg:flex lg:items-center lg:gap-1 lg:ml-12 h-full" role="navigation" aria-label="Main navigation">
-        {/* Dropdown menus */}
-        {NAV_DROPDOWNS.map((dropdown) => dropdown.compact ? (
-          <div class="group relative flex h-full items-center" data-compact-dropdown>
-            <button
-              class="flex items-center gap-1 rounded-md px-3 py-2 text-sm font-semibold text-gray-900 transition-colors hover:bg-gray-50"
-              aria-expanded="false"
-              aria-haspopup="true"
-            >
-              {dropdown.label}
-              <svg class="h-4 w-4 text-gray-400 transition-transform group-hover:rotate-180" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M5 7.5L10 12.5L15 7.5" />
-              </svg>
-            </button>
-            {/* Compact dropdown — narrow box anchored under the button */}
-            <div data-dropdown-panel class="pointer-events-none invisible absolute left-0 top-full z-50 w-[320px] pt-2 opacity-0 transition-[opacity,visibility] duration-200 group-hover:pointer-events-auto group-hover:visible group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:visible group-focus-within:opacity-100">
-              <div class="rounded-lg bg-white shadow-large border border-gray-100 p-2">
-                {dropdown.sections[0].links.map((link) => (
-                  <a
-                    href={link.href}
-                    class="group/link flex items-center gap-3 rounded-md p-2 transition-colors hover:bg-gray-50"
-                    target={link.external ? "_blank" : undefined}
-                    rel={link.external ? "noopener noreferrer" : undefined}
-                  >
-                    <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-zenml-25 text-zenml-500">
-                      <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <Fragment set:html={link.icon || '<path d="M13 2L4.09 12.69a.5.5 0 00.41.81H12l-1 10 8.91-10.69a.5.5 0 00-.41-.81H12l1-10z"/>'} />
-                      </svg>
-                    </div>
-                    <div class="min-w-0">
-                      <div class="text-sm font-medium text-gray-900 group-hover/link:text-zenml-500">
-                        {link.label}
-                      </div>
-                      {link.description && (
-                        <div class="mt-0.5 text-xs text-gray-500 leading-snug">
-                          {link.description}
-                        </div>
-                      )}
-                    </div>
-                  </a>
-                ))}
-              </div>
-            </div>
-          </div>
-        ) : (
-          <div class="group flex h-full items-center">
-            <button
-              class="flex items-center gap-1 rounded-md px-3 py-2 text-sm font-semibold text-gray-900 transition-colors hover:bg-gray-50"
-              aria-expanded="false"
-              aria-haspopup="true"
-            >
-              {dropdown.label}
-              <svg class="h-4 w-4 text-gray-400 transition-transform group-hover:rotate-180" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M5 7.5L10 12.5L15 7.5" />
-              </svg>
-            </button>
-            {/* Dropdown panel — positioned relative to the <header> (sticky = containing block) */}
-            <div class="pointer-events-none invisible absolute inset-x-0 top-full z-50 opacity-0 transition-[opacity,visibility] duration-200 group-hover:pointer-events-auto group-hover:visible group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:visible group-focus-within:opacity-100">
-              <div class="bg-white shadow-large border-t border-b border-gray-100">
-              <div class="mx-auto max-w-[var(--container-lg)] px-4 sm:px-6 lg:px-8">
-                <div class="flex">
-                  {/* Link columns — all equal width */}
-                  {dropdown.sections.slice(0, 2).map((section) => (
-                    <div class="flex-1 p-5">
-                      <div class="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-400">
-                        {section.heading}
-                      </div>
-                      <div class="space-y-1">
-                        {section.links.map((link) => (
-                          <a
-                            href={link.href}
-                            class="group/link flex items-center gap-3 rounded-md p-2 transition-colors hover:bg-gray-50"
-                            target={link.external ? "_blank" : undefined}
-                            rel={link.external ? "noopener noreferrer" : undefined}
-                          >
-                            <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-zenml-25 text-zenml-500">
-                              <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                <Fragment set:html={link.icon || '<path d="M13 2L4.09 12.69a.5.5 0 00.41.81H12l-1 10 8.91-10.69a.5.5 0 00-.41-.81H12l1-10z"/>'} />
-                              </svg>
-                            </div>
-                            <div>
-                              <div class="text-sm font-medium text-gray-900 group-hover/link:text-zenml-500">
-                                {link.label}
-                              </div>
-                              {link.description && (
-                                <div class="mt-0.5 text-xs text-gray-500 leading-snug">
-                                  {link.description}
-                                </div>
-                              )}
-                            </div>
-                          </a>
-                        ))}
-                      </div>
-                    </div>
-                  ))}
-                  {/* Third column: featured/organization section */}
-                  {(dropdown.sections.length > 2 || dropdown.featured) && (
-                    <div class="flex-1 border-l border-gray-100 bg-gray-50/80 p-5">
-                      {dropdown.sections.length > 2 && (
-                        <div class="mb-4">
-                          <div class="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-400">
-                            {dropdown.sections[2].heading}
-                          </div>
-                          <div class="space-y-1">
-                            {dropdown.sections[2].links.map((link) => (
-                              <a
-                                href={link.href}
-                                class="group/link flex items-center gap-3 rounded-md p-2 transition-colors hover:bg-gray-100"
-                              >
-                                {link.icon && (
-                                  <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-zenml-25 text-zenml-500">
-                                    <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                      <Fragment set:html={link.icon} />
-                                    </svg>
-                                  </div>
-                                )}
-                                <div>
-                                  <div class="text-sm font-medium text-gray-900 group-hover/link:text-zenml-500">
-                                    {link.label}
-                                  </div>
-                                  {link.description && (
-                                    <div class="mt-0.5 text-xs text-gray-500 leading-snug">
-                                      {link.description}
-                                    </div>
-                                  )}
-                                </div>
-                              </a>
-                            ))}
-                          </div>
-                        </div>
-                      )}
-                      {dropdown.featured && (
-                        <div>
-                          <div class="mb-3 flex items-center justify-between">
-                            <div class="text-xs font-semibold uppercase tracking-wider text-gray-400">
-                              {dropdown.featured.heading}
-                            </div>
-                            {dropdown.featured.ctaHref && (
-                              <a
-                                href={dropdown.featured.ctaHref}
-                                class="inline-flex items-center gap-0.5 text-[11px] font-medium text-zenml-500 hover:text-zenml-600 transition-colors"
-                              >
-                                {dropdown.featured.ctaLabel}
-                                <svg class="h-3 w-3" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round">
-                                  <path d="M4.167 10h11.666M10.5 4.167L15.833 10 10.5 15.833" />
-                                </svg>
-                              </a>
-                            )}
-                          </div>
-                          {dropdown.featured.caseStudies?.map((cs) => (
-                            <a
-                              href={cs.href}
-                              class="group/link mb-2 flex items-center gap-3 rounded-md p-2 transition-colors hover:bg-gray-100"
-                            >
-                              {cs.logoUrl && (
-                                <div class="flex h-10 w-16 shrink-0 items-center justify-center rounded-md bg-white border border-gray-100 p-1.5">
-                                  <img src={cs.logoUrl} alt={cs.label} class="h-full w-full object-contain" loading="lazy" />
-                                </div>
-                              )}
-                              <div>
-                                <div class="text-sm font-medium text-gray-900 group-hover/link:text-zenml-500">{cs.label}</div>
-                                <div class="text-xs text-gray-500">{cs.subtitle}</div>
-                              </div>
-                            </a>
-                          ))}
-                          {dropdown.featured.links?.map((link) => (
-                            <a
-                              href={link.href}
-                              class="group/link mb-2 flex items-center gap-3 rounded-md p-2 transition-colors hover:bg-gray-100"
-                              target={link.external ? "_blank" : undefined}
-                              rel={link.external ? "noopener noreferrer" : undefined}
-                            >
-                              {link.icon && (
-                                <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-zenml-25 text-zenml-500">
-                                  <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                    <Fragment set:html={link.icon} />
-                                  </svg>
-                                </div>
-                              )}
-                              <div>
-                                <div class="text-sm font-medium text-gray-900 group-hover/link:text-zenml-500">{link.label}</div>
-                                {link.description && (
-                                  <div class="mt-0.5 text-xs text-gray-500 leading-snug">{link.description}</div>
-                                )}
-                              </div>
-                            </a>
-                          ))}
-                        </div>
-                      )}
-                    </div>
-                  )}
-                </div>
-              </div>
-              </div>
-            </div>
-          </div>
-        ))}
-
-        {/* Direct links */}
-        {NAV_LINKS.map((link) => (
+        {NAV_PRIMARY.map((link) => (
           <a
             href={link.href}
             class:list={[
@@ -282,7 +114,7 @@ const headerStarsFallback = formatStars(FALLBACK_STARS);
       {/* Mobile menu button */}
       <button
         type="button"
-        class="ml-auto lg:hidden rounded-md p-2 text-gray-700 hover:bg-gray-50"
+        class="ml-auto lg:hidden rounded-md p-2 text-gray-700 hover:bg-gray-50 cursor-pointer"
         aria-label="Toggle menu"
         data-mobile-toggle
       >
@@ -299,57 +131,137 @@ const headerStarsFallback = formatStars(FALLBACK_STARS);
     </div>
   </div>
 
-  {/* Mobile menu */}
+  {/* ─── Secondary subnav (desktop) ───────────────────────────────────── */}
+  {subnav && activeContext && accent && (
+    <div
+      class="hidden lg:block border-t border-gray-200/60 bg-white"
+      data-app={brandScope}
+    >
+      <div class="mx-auto max-w-[var(--container-lg)] px-4 sm:px-6 lg:px-8">
+        <nav class="flex h-[44px] items-center gap-6" aria-label="Product navigation">
+          <a
+            href={activeContext.href}
+            class="flex items-center gap-2 pr-4 border-r border-gray-200/60 text-gray-900 hover:opacity-70 transition-opacity"
+          >
+            <span
+              class:list={["inline-block h-2 w-2 rounded-full", accent.dot]}
+              aria-hidden="true"
+            ></span>
+            <span class="text-sm font-semibold">{activeContext.label}</span>
+          </a>
+          {subnav.map((item) => {
+            const isActive = isActivePath(currentPath, item.href);
+            return (
+              <a
+                href={item.href}
+                target={item.external ? "_blank" : undefined}
+                rel={item.external ? "noopener noreferrer" : undefined}
+                class:list={[
+                  "inline-flex h-full items-center border-b-2 text-sm font-medium transition-colors",
+                  isActive
+                    ? `${accent.text} ${accent.border}`
+                    : "border-transparent text-gray-600 hover:text-gray-900",
+                ]}
+              >
+                {item.label}
+                {item.external && (
+                  <svg class="ml-1 h-3 w-3 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M7 13l6-6M7 7h6v6" />
+                  </svg>
+                )}
+              </a>
+            );
+          })}
+        </nav>
+      </div>
+    </div>
+  )}
+
+  {/* ─── Mobile drawer ────────────────────────────────────────────────── */}
   <div class="hidden lg:hidden" data-mobile-menu>
-    <div class="border-t border-gray-200 bg-white px-4 pb-6 pt-4">
-      <nav class="space-y-1" role="navigation" aria-label="Mobile navigation">
-        {/* Mobile dropdown sections (as accordions) */}
-        {NAV_DROPDOWNS.map((dropdown) => (
-          <details class="group/accordion">
-            <summary class="flex cursor-pointer items-center justify-between rounded-md px-3 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 list-none [&::-webkit-details-marker]:hidden">
-              {dropdown.label}
-              <svg class="h-4 w-4 text-gray-400 transition-transform group-open/accordion:rotate-180" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round">
+    <div class="border-t border-gray-200 bg-white px-4 pb-6 pt-2">
+      {/* Context chip row (product surfaces only) */}
+      {activeContext && accent && (
+        <div class="relative" data-mobile-context>
+          <div class="flex items-center justify-between border-b border-gray-200 py-3">
+            <div class="flex items-center gap-2">
+              <span
+                class:list={["inline-block h-2.5 w-2.5 rounded-full", accent.dot]}
+                aria-hidden="true"
+              ></span>
+              <span class="text-sm font-semibold text-gray-900">{activeContext.label}</span>
+            </div>
+            <button
+              type="button"
+              class="inline-flex items-center gap-1 rounded-md px-2 py-1 text-sm font-medium text-gray-500 hover:bg-gray-50 cursor-pointer"
+              aria-haspopup="listbox"
+              aria-expanded="false"
+              data-context-toggle
+            >
+              Menu
+              <svg class="h-4 w-4 transition-transform" data-context-chevron viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <path d="M5 7.5L10 12.5L15 7.5" />
               </svg>
-            </summary>
-            <div class="ml-4 mt-1 space-y-3 border-l border-gray-200 pl-4 pb-2">
-              {dropdown.sections.map((section) => (
-                <div>
-                  <div class="mb-1.5 text-xs font-semibold uppercase tracking-wider text-gray-400">
-                    {section.heading}
-                  </div>
-                  {section.links.map((link) => (
-                    <a
-                      href={link.href}
-                      class="block rounded-md px-2 py-1.5 text-sm text-gray-600 hover:bg-gray-50 hover:text-gray-900"
-                      target={link.external ? "_blank" : undefined}
-                      rel={link.external ? "noopener noreferrer" : undefined}
-                    >
-                      {link.label}
-                    </a>
-                  ))}
-                </div>
-              ))}
-              {dropdown.featured?.links?.map((link) => (
+            </button>
+          </div>
+          <div class="hidden border-b border-gray-200 py-2" data-context-picker role="listbox">
+            {PRODUCT_CONTEXTS.map((ctx) => {
+              const isActive = ctx.productSurface === activeContext.productSurface;
+              return (
                 <a
-                  href={link.href}
-                  class="block rounded-md px-2 py-1.5 text-sm text-gray-600 hover:bg-gray-50 hover:text-gray-900"
-                  target={link.external ? "_blank" : undefined}
-                  rel={link.external ? "noopener noreferrer" : undefined}
+                  href={ctx.href}
+                  role="option"
+                  aria-selected={isActive}
+                  class:list={[
+                    "flex items-center gap-2 rounded-md px-2 py-2 text-sm hover:bg-gray-50",
+                    isActive ? "font-semibold text-gray-900" : "text-gray-600",
+                  ]}
                 >
-                  {link.label}
+                  <span
+                    class:list={["inline-block h-2 w-2 rounded-full", productAccent(ctx.productSurface).dot]}
+                    aria-hidden="true"
+                  ></span>
+                  {ctx.label}
                 </a>
-              ))}
-            </div>
-          </details>
-        ))}
+              );
+            })}
+          </div>
+        </div>
+      )}
 
-        {/* Mobile direct links */}
-        {NAV_LINKS.map((link) => (
+      <nav class="space-y-1 pt-3" role="navigation" aria-label="Mobile navigation">
+        {/* Product subnav (when on a product surface) */}
+        {subnav && accent && (
+          <div class="pb-3" data-app={brandScope}>
+            {subnav.map((item) => {
+              const isActive = isActivePath(currentPath, item.href);
+              return (
+                <a
+                  href={item.href}
+                  target={item.external ? "_blank" : undefined}
+                  rel={item.external ? "noopener noreferrer" : undefined}
+                  class:list={[
+                    "block rounded-md px-3 py-2 text-sm font-medium",
+                    isActive ? accent.text : "text-gray-700 hover:bg-gray-50",
+                  ]}
+                >
+                  {item.label}
+                </a>
+              );
+            })}
+          </div>
+        )}
+
+        {subnav && (
+          <div class="my-2 border-t border-gray-200" aria-hidden="true"></div>
+        )}
+
+        {/* Primary cross-product links — see `mobilePrimaryLinks` above. */}
+        {mobilePrimaryLinks.map((link) => (
           <a
             href={link.href}
             class:list={[
-              "block rounded-md px-3 py-2.5 text-sm font-medium hover:bg-gray-50",
+              "block rounded-md px-3 py-2 text-sm font-medium hover:bg-gray-50",
               isActivePath(currentPath, link.href)
                 ? "text-zenml-500"
                 : "text-gray-700",
@@ -359,7 +271,7 @@ const headerStarsFallback = formatStars(FALLBACK_STARS);
           </a>
         ))}
 
-        {/* Mobile CTAs */}
+        {/* CTAs */}
         <div class="mt-4 flex flex-col gap-2 pt-4 border-t border-gray-200">
           <Button href={NAV_CTAS[0].href} variant="secondary" size="md" class="w-full justify-center">
             {NAV_CTAS[0].label}
@@ -373,18 +285,8 @@ const headerStarsFallback = formatStars(FALLBACK_STARS);
   </div>
 </header>
 
-<style>
-  /* Force-hide a compact dropdown panel when its sibling is the active hover
-   * target. Overrides Tailwind's group-hover/group-focus-within visibility. */
-  [data-dropdown-panel].force-hidden {
-    visibility: hidden !important;
-    opacity: 0 !important;
-    pointer-events: none !important;
-  }
-</style>
-
 <script>
-  // Mobile menu toggle — minimal JS (no framework needed)
+  // Mobile drawer toggle.
   const toggle = document.querySelector("[data-mobile-toggle]");
   const menu = document.querySelector("[data-mobile-menu]");
   const openIcon = toggle?.querySelector('[data-icon="open"]');
@@ -399,32 +301,15 @@ const headerStarsFallback = formatStars(FALLBACK_STARS);
     closeIcon?.classList.toggle("block", !isOpen);
   });
 
-  // Compact dropdowns: enforce single-open-at-a-time. Adjacent panels are
-  // 320px wide and overlap horizontally, so CSS group-hover alone leaves
-  // the previously-opened panel stuck visible when the cursor crosses it.
-  const compactDropdowns = document.querySelectorAll(
-    "[data-compact-dropdown]"
-  ) as NodeListOf<HTMLElement>;
-  const navHeader = document.querySelector("header");
+  // Mobile context picker (the ElevenLabs-style "Menu ▾" chip).
+  const contextToggle = document.querySelector("[data-context-toggle]");
+  const contextPicker = document.querySelector("[data-context-picker]");
+  const contextChevron = document.querySelector("[data-context-chevron]");
 
-  function closeOthers(active: Element) {
-    compactDropdowns.forEach((d) => {
-      if (d === active) return;
-      d.querySelector("[data-dropdown-panel]")?.classList.add("force-hidden");
-    });
-  }
-  function resetAll() {
-    document
-      .querySelectorAll("[data-dropdown-panel].force-hidden")
-      .forEach((p) => p.classList.remove("force-hidden"));
-  }
-
-  compactDropdowns.forEach((d) => {
-    d.addEventListener("mouseenter", () => {
-      d.querySelector("[data-dropdown-panel]")?.classList.remove("force-hidden");
-      closeOthers(d);
-    });
+  contextToggle?.addEventListener("click", () => {
+    const isOpen = !contextPicker?.classList.contains("hidden");
+    contextPicker?.classList.toggle("hidden", isOpen);
+    contextChevron?.classList.toggle("rotate-180", !isOpen);
+    contextToggle.setAttribute("aria-expanded", String(!isOpen));
   });
-
-  navHeader?.addEventListener("mouseleave", resetAll);
 </script>

--- a/src/components/blog/CategoryBar.astro
+++ b/src/components/blog/CategoryBar.astro
@@ -29,7 +29,7 @@ const {
 const topCategories = categories.slice(0, 8);
 ---
 
-<div class="sticky top-[72px] z-40 border-b border-gray-100 bg-white/95 backdrop-blur-sm">
+<div class="sticky top-[var(--nav-height)] z-40 border-b border-gray-100 bg-white/95 backdrop-blur-sm">
   <div class="mx-auto flex h-11 max-w-[1440px] items-center gap-3 px-4 sm:px-6 lg:px-8">
     {breadcrumbTitle ? (
       /* Breadcrumb mode: Blog / Post Title */

--- a/src/components/integrations/IntegrationDetailSidebar.astro
+++ b/src/components/integrations/IntegrationDetailSidebar.astro
@@ -37,7 +37,7 @@ const {
 ---
 
 <aside class="w-full shrink-0 lg:w-64">
-  <div class="sticky top-24 space-y-8">
+  <div class="sticky top-[calc(var(--nav-height)+1rem)] space-y-8">
     {/* Category */}
     {type && (
       <div>

--- a/src/components/sections/compare/CompareCodeComparison.astro
+++ b/src/components/sections/compare/CompareCodeComparison.astro
@@ -46,7 +46,7 @@ const {
 
     <div class="grid gap-8 lg:grid-cols-2">
       {/* ZenML column — sticky on desktop so short code stays visible */}
-      <div class="fade-in-element lg:sticky lg:top-20 lg:self-start">
+      <div class="fade-in-element lg:sticky lg:top-[calc(var(--nav-height)+0.5rem)] lg:self-start">
         <div class="flex items-center gap-4 py-4">
           <img src={zenmlIconUrl} alt="ZenML" width="28" height="28" class="rounded" />
           <span class="text-xl font-semibold text-white">ZenML</span>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -113,7 +113,7 @@ const seo = resolveSeo(seoProps, Astro.url.pathname);
   </head>
   <body class:list={["min-h-screen bg-white text-gray-900 antialiased", bodyClass]}>
     <slot name="before-nav" />
-    <Navigation currentPath={Astro.url.pathname} />
+    <Navigation currentPath={Astro.url.pathname} surface={surface} />
     <slot />
     <Footer />
 

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -100,7 +100,7 @@ const {
   prev,
   next,
   relatedPosts = [],
-  surface = "ml",
+  surface = "unified",
   ...seoProps
 } = Astro.props;
 
@@ -152,7 +152,7 @@ const articleJsonLd = {
   <CategoryBar breadcrumbTitle={displayTitle} />
 
   {/* Reading progress bar */}
-  <div class="sticky top-[116px] z-30 h-0.5" id="progress-container">
+  <div class="sticky top-[calc(var(--nav-height)+44px)] z-30 h-0.5" id="progress-container">
     <div class="h-full w-0 bg-primary-600 transition-[width] duration-150" id="progress-bar"></div>
   </div>
 
@@ -342,7 +342,7 @@ const articleJsonLd = {
     {/* Desktop Table of contents sidebar */}
     {showTOC && (
       <aside class="hidden xl:block">
-        <div class="sticky top-32 max-h-[calc(100vh-9rem)] overflow-y-auto">
+        <div class="sticky top-[calc(var(--nav-height)+44px+1rem)] max-h-[calc(100vh-var(--nav-height)-44px-2rem)] overflow-y-auto">
           <BlogTOC headings={tocHeadings} />
 
           {/* Sidebar CTA */}

--- a/src/lib/footer.ts
+++ b/src/lib/footer.ts
@@ -47,7 +47,8 @@ export const FOOTER_COLUMNS: FooterColumn[] = [
   {
     title: "Compare & deploy",
     links: [
-      { label: "All comparisons", href: "/compare" },
+      { label: "Compare ZenML", href: "/compare/zenml" },
+      { label: "Compare Kitaru", href: "/compare/kitaru" },
       { label: "Open Source vs Pro", href: "/open-source-vs-pro" },
       { label: "Deployment scenarios", href: "/deployments" },
       { label: "Integrations", href: "/integrations" },

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,171 +1,89 @@
 /**
- * Navigation data — post-Kitaru-merge structure.
+ * Two-tier navigation data — issue #65.
  *
- * See MERGE_PLAN.md for the IA decisions. Top nav:
- *   Product ▾    Docs ▾    Compare    Pricing    Blog    Case Studies ▾
+ * Primary tier (brand-neutral, on every page):
+ *   ZenML  Kitaru  ZenML Pro  Pricing  Case Studies  Blog
  *
- * Note: dropdowns render before direct links, so the visual order is
- *   Product ▾ Docs ▾ Case Studies ▾ | Compare Pricing Blog
- * — which is standard practice (dropdowns clustered left).
+ * Secondary tier (product subnav, appears only on product-context pages):
+ *   ZenML  (surface=ml)   : Overview · Features · Integrations · Compare · OSS vs Pro · Docs
+ *   Kitaru (surface=agent): Overview · Compare · Docs
+ *
+ * On surface=unified pages (homepage, /pricing, /compare, /blog, etc.) the
+ * subnav is hidden — see Navigation.astro for the render rules.
  */
+import type { Surface } from "./analytics";
 
+/**
+ * `productSurface` marks an entry as one of the three product anchors
+ * (ZenML / Kitaru / ZenML Pro). The mobile drawer uses this to avoid
+ * showing those entries twice (they're already in the context chip) and
+ * the desktop subnav uses it to label the current product context.
+ */
 export interface NavLink {
   label: string;
   href: string;
-  description?: string;
   external?: boolean;
-  /** SVG path(s) for the dropdown icon (Untitled UI style, 24x24 viewBox) */
-  icon?: string;
+  productSurface?: ProductSurface;
 }
 
-export interface NavSection {
-  heading: string;
-  links: NavLink[];
-}
-
-export interface NavCaseStudy {
-  label: string;
-  href: string;
-  subtitle: string;
-  /** Company logo URL (displayed as image in dropdown) */
-  logoUrl?: string;
-}
-
-export interface NavDropdown {
-  label: string;
-  /** Left side: one or two columns of link groups */
-  sections: NavSection[];
-  /** Right side: featured content (case studies, community, etc.) */
-  featured?: {
-    heading: string;
-    caseStudies?: NavCaseStudy[];
-    links?: NavLink[];
-    ctaLabel?: string;
-    ctaHref?: string;
-  };
-  /** Compact mode: narrow box anchored to button, not full-page panel.
-   *  Use when dropdown only has a single section with a few items. */
-  compact?: boolean;
-}
+export type ProductSurface = "ml" | "agent" | "pro";
 
 // ---------------------------------------------------------------------------
-// Reusable icons (Untitled UI style, 24x24 viewBox)
+// Primary tier (always shown)
 // ---------------------------------------------------------------------------
 
-const ICON_LIGHTNING =
-  '<path d="M9 3.5V2M5.06066 5.06066L4 4M5.06066 13L4 14.0607M13 5.06066L14.0607 4M3.5 9H2M15.8645 16.1896L13.3727 20.817C13.0881 21.3457 12.9457 21.61 12.7745 21.6769C12.6259 21.7349 12.4585 21.7185 12.324 21.6328C12.1689 21.534 12.0806 21.2471 11.9038 20.6733L8.44519 9.44525C8.3008 8.97651 8.2286 8.74213 8.28669 8.58383C8.33729 8.44595 8.44595 8.33729 8.58383 8.2867C8.74213 8.22861 8.9765 8.3008 9.44525 8.44519L20.6732 11.9038C21.247 12.0806 21.5339 12.169 21.6327 12.324C21.7185 12.4586 21.7348 12.6259 21.6768 12.7745C21.61 12.9458 21.3456 13.0881 20.817 13.3728L16.1896 15.8645C16.111 15.9068 16.0717 15.9279 16.0374 15.9551C16.0068 15.9792 15.9792 16.0068 15.9551 16.0374C15.9279 16.0717 15.9068 16.111 15.8645 16.1896Z"/>';
-
-const ICON_AGENT =
-  '<path d="M12 2v2m0 16v2M5.05 5.05l1.41 1.41m11.08 11.08l1.41 1.41M2 12h2m16 0h2M5.05 18.95l1.41-1.41M17.54 6.46l1.41-1.41M9 12a3 3 0 116 0 3 3 0 01-6 0z"/><path d="M8 8h8v8H8z" fill="none"/>';
-
-const ICON_PRO_GEAR =
-  '<path d="M12 15C13.6569 15 15 13.6569 15 12C15 10.3431 13.6569 9 12 9C10.3431 9 9 10.3431 9 12C9 13.6569 10.3431 15 12 15Z"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 01-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 008.91 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 8.91a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/>';
-
-const ICON_BOOK =
-  '<path d="M14 2.26953V6.40007C14 6.96012 14 7.24015 14.109 7.45406C14.2049 7.64222 14.3578 7.7952 14.546 7.89108C14.7599 8.00007 15.0399 8.00007 15.6 8.00007H19.7305M16 13H8M16 17H8M10 9H8M14 2H8.8C7.11984 2 6.27976 2 5.63803 2.32698C5.07354 2.6146 4.6146 3.07354 4.32698 3.63803C4 4.27976 4 5.11984 4 6.8V17.2C4 18.8802 4 19.7202 4.32698 20.362C4.6146 20.9265 5.07354 21.3854 5.63803 21.673C6.27976 22 7.11984 22 8.8 22H15.2C16.8802 22 17.7202 22 18.362 21.673C18.9265 21.3854 19.3854 20.9265 19.673 20.362C20 19.7202 20 18.8802 20 17.2V8L14 2Z"/>';
-
-const ICON_BUILDING =
-  '<path d="M15 21V15.6C15 15.0399 15 14.7599 14.891 14.546C14.7951 14.3578 14.6422 14.2049 14.454 14.109C14.2401 14 13.9601 14 13.4 14H10.6C10.0399 14 9.75992 14 9.54601 14.109C9.35785 14.2049 9.20487 14.3578 9.10899 14.546C9 14.7599 9 15.0399 9 15.6V21M19 21V6.2C19 5.0799 19 4.51984 18.782 4.09202C18.5903 3.71569 18.2843 3.40973 17.908 3.21799C17.4802 3 16.9201 3 15.8 3H8.2C7.07989 3 6.51984 3 6.09202 3.21799C5.71569 3.40973 5.40973 3.71569 5.21799 4.09202C5 4.51984 5 5.0799 5 6.2V21M21 21H3"/>';
-
-const ICON_DATABASE =
-  '<path d="M21 5C21 6.65685 16.9706 8 12 8C7.02944 8 3 6.65685 3 5M21 5C21 3.34315 16.9706 2 12 2C7.02944 2 3 3.34315 3 5M21 5V19C21 20.66 17 22 12 22C7 22 3 20.66 3 19V5M21 9.72021C21 11.3802 17 12.7202 12 12.7202C7 12.7202 3 11.3802 3 9.72021M21 14.44C21 16.1 17 17.44 12 17.44C7 17.44 3 16.1 3 14.44"/>';
-
-// ---------------------------------------------------------------------------
-// Dropdown Menus
-// ---------------------------------------------------------------------------
-
-export const NAV_DROPDOWNS: NavDropdown[] = [
-  {
-    label: "Product",
-    compact: true,
-    sections: [
-      {
-        heading: "Products",
-        links: [
-          {
-            label: "ZenML",
-            href: "/product/zenml",
-            description: "Pipelines for ML workflows",
-            icon: ICON_LIGHTNING,
-          },
-          {
-            label: "Kitaru",
-            href: "/product/kitaru",
-            description: "Durable runtime for AI agents",
-            icon: ICON_AGENT,
-          },
-          {
-            label: "ZenML Pro",
-            href: "/pro",
-            description: "Managed control plane for ML + Agent workspaces",
-            icon: ICON_PRO_GEAR,
-          },
-        ],
-      },
-    ],
-  },
-  {
-    label: "Docs",
-    compact: true,
-    sections: [
-      {
-        heading: "Documentation",
-        links: [
-          {
-            label: "ZenML docs",
-            href: "https://docs.zenml.io",
-            description: "Pipelines, components, integrations",
-            external: true,
-            icon: ICON_BOOK,
-          },
-          {
-            label: "Kitaru docs",
-            href: "https://kitaru.ai/docs",
-            description: "Agent runtime primitives and APIs",
-            external: true,
-            icon: ICON_BOOK,
-          },
-        ],
-      },
-    ],
-  },
-  {
-    label: "Case Studies",
-    compact: true,
-    sections: [
-      {
-        heading: "Case studies",
-        links: [
-          {
-            label: "Customer stories",
-            href: "/case-studies",
-            description: "How teams ship ML and agents with ZenML",
-            icon: ICON_BUILDING,
-          },
-          {
-            label: "LLMOps Database",
-            href: "/llmops-database",
-            description: "1,453 LLMOps case studies, searchable",
-            icon: ICON_DATABASE,
-          },
-        ],
-      },
-    ],
-  },
-];
-
-// ---------------------------------------------------------------------------
-// Direct Links (no dropdown)
-// ---------------------------------------------------------------------------
-
-export const NAV_LINKS: NavLink[] = [
-  { label: "Compare", href: "/compare" },
+export const NAV_PRIMARY: NavLink[] = [
+  { label: "ZenML", href: "/product/zenml", productSurface: "ml" },
+  { label: "Kitaru", href: "/product/kitaru", productSurface: "agent" },
+  { label: "ZenML Pro", href: "/pro", productSurface: "pro" },
   { label: "Pricing", href: "/pricing" },
+  { label: "Case Studies", href: "/case-studies" },
   { label: "Blog", href: "/blog" },
 ];
 
+/** Product anchors — derived view of NAV_PRIMARY, used by the mobile context
+ * switcher. Single source of truth: edit NAV_PRIMARY only. */
+export const PRODUCT_CONTEXTS = NAV_PRIMARY.filter(
+  (link): link is NavLink & { productSurface: ProductSurface } =>
+    link.productSurface !== undefined,
+);
+
+/** Resolve the active product context for a given surface, if any. */
+export function getActiveContext(surface: Surface): (typeof PRODUCT_CONTEXTS)[number] | null {
+  return (
+    PRODUCT_CONTEXTS.find((c) => c.productSurface === surface) ?? null
+  );
+}
+
 // ---------------------------------------------------------------------------
-// CTA Buttons
+// Secondary tier (product subnav)
+// ---------------------------------------------------------------------------
+
+export const NAV_SUBNAVS: Record<"ml" | "agent", NavLink[]> = {
+  ml: [
+    { label: "Overview", href: "/product/zenml" },
+    { label: "Features", href: "/features" },
+    { label: "Integrations", href: "/integrations" },
+    { label: "Compare", href: "/compare/zenml" },
+    { label: "OSS vs Pro", href: "/open-source-vs-pro" },
+    { label: "Docs", href: "https://docs.zenml.io", external: true },
+  ],
+  agent: [
+    { label: "Overview", href: "/product/kitaru" },
+    { label: "Compare", href: "/compare/kitaru" },
+    { label: "Docs", href: "https://kitaru.ai/docs", external: true },
+  ],
+};
+
+/** Return the subnav items for a given surface, or null when no subnav renders. */
+export function getSubnavForSurface(surface: Surface): NavLink[] | null {
+  if (surface === "ml") return NAV_SUBNAVS.ml;
+  if (surface === "agent") return NAV_SUBNAVS.agent;
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// CTA buttons (right cluster on desktop, bottom on mobile)
 // ---------------------------------------------------------------------------
 
 export const NAV_CTAS: NavLink[] = [
@@ -177,12 +95,28 @@ export const NAV_CTAS: NavLink[] = [
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Check if a nav link matches the current path (exact or section prefix) */
+/** Check if a nav link matches the current path (exact or section prefix). */
 export function isActivePath(currentPath: string, href: string): boolean {
   if (href === "/") return currentPath === "/";
-  // Exact match
   if (currentPath === href) return true;
-  // Section match: /blog/some-post matches /blog
   if (currentPath.startsWith(`${href}/`)) return true;
   return false;
+}
+
+/** Tailwind classes for a product's brand accent — dot fill, text color, and
+ * border color. Single source of truth for the sage-zenml / warm-orange /
+ * purple-pro mapping used by the subnav title, mobile chip, picker entries,
+ * and subnav active-state styling. */
+export function productAccent(surface: ProductSurface): {
+  dot: string;
+  text: string;
+  border: string;
+} {
+  if (surface === "agent") {
+    return { dot: "bg-orange-500", text: "text-orange-500", border: "border-orange-500" };
+  }
+  if (surface === "pro") {
+    return { dot: "bg-purple-500", text: "text-purple-500", border: "border-purple-500" };
+  }
+  return { dot: "bg-zenml-500", text: "text-zenml-500", border: "border-zenml-500" };
 }

--- a/src/pages/author/[slug].astro
+++ b/src/pages/author/[slug].astro
@@ -52,7 +52,7 @@ for (const post of allPosts) {
 <BaseLayout
   title={`${author.data.name} - ZenML Blog`}
   description={author.data.bio || `Blog posts by ${author.data.name} on the ZenML blog.`}
-  surface="ml"
+  surface="unified"
 >
   <CategoryBar backLink categories={categories} />
 

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -66,7 +66,7 @@ for (const post of gridPosts) {
 <BaseLayout
   title="Blog - ZenML"
   description="Insights on MLOps, LLMOps, and production machine learning from the ZenML team."
-  surface="ml"
+  surface="unified"
 >
   {/* Section header: sticky CategoryBar at top */}
   <CategoryBar categories={categories} />

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -74,7 +74,7 @@ for (const post of posts) {
 <BaseLayout
   title={`Blog - Page ${currentPage} - ZenML`}
   description="Insights on MLOps, LLMOps, and production machine learning from the ZenML team."
-  surface="ml"
+  surface="unified"
 >
   {/* Section header: sticky CategoryBar at top */}
   <CategoryBar categories={categories} />

--- a/src/pages/case-studies/index.astro
+++ b/src/pages/case-studies/index.astro
@@ -31,7 +31,7 @@ const caseStudies = allCaseStudies.sort(
   title="ZenML Case Studies - Real Teams, Real AI Workflows"
   description="See how teams are using ZenML to unify their AI platforms—from batch evaluations to real-time serving, traditional ML to GenAI workflows."
   ogTitle="ZenML Case Studies"
-  surface="ml"
+  surface="unified"
 >
   <main>
     {/* Hero */}

--- a/src/pages/case-study/[slug].astro
+++ b/src/pages/case-study/[slug].astro
@@ -42,7 +42,7 @@ const ogImage = data.seo?.ogImage;
   ogTitle={data.seo?.ogTitle}
   ogDescription={data.seo?.ogDescription}
   canonical={data.seo?.canonical}
-  surface="ml"
+  surface="unified"
 >
   <main>
     {/* Breadcrumb */}

--- a/src/pages/category/[slug].astro
+++ b/src/pages/category/[slug].astro
@@ -63,7 +63,7 @@ for (const post of allPosts) {
 <BaseLayout
   title={`${category.data.name} - ZenML Blog`}
   description={`Blog posts about ${category.data.name} from the ZenML team.`}
-  surface="ml"
+  surface="unified"
 >
   {/* Section header: sticky CategoryBar with back link */}
   <CategoryBar categories={categories} activeCategory={category.data.slug} backLink />

--- a/src/pages/compare/index.astro
+++ b/src/pages/compare/index.astro
@@ -1,151 +1,87 @@
 ---
-/**
- * Compare hub page — Phase 3.
- *
- * Two visually-distinct sections:
- *   - MLOps comparisons (ZenML vs X) — sage-green tinted
- *   - Agent comparisons (Kitaru vs X) — warm-orange tinted
- *
- * Clicking an MLOps card → /compare/zenml-vs-X (existing ZenML template).
- * Clicking an Agent card → /compare/kitaru-vs-X (Kitaru template,
- * theme flipped to data-app="kitaru").
- */
 import { getCollection } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 
-const mlopsItems = (
+const mlopsCount = (
   await getCollection("compare", ({ data }) => !data.draft)
-).sort((a, b) => a.data.title.localeCompare(b.data.title));
+).length;
 
-const agentItems = (
+const agentsCount = (
   await getCollection("compare-kitaru", ({ data }) => !data.draft)
-).sort((a, b) => a.data.order - b.data.order);
+).length;
 ---
 
 <BaseLayout
   title="Compare — ZenML and Kitaru vs. alternatives"
-  description="Side-by-side comparisons of ZenML (MLOps) and Kitaru (agent runtime) against other tools and platforms."
+  description="Side-by-side comparisons of ZenML (ML platforms) and Kitaru (agent runtimes) against the tools you might be considering."
   surface="unified"
 >
-  <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
-    <header class="mb-12 max-w-3xl">
-      <p class="text-sm font-semibold uppercase tracking-wider text-zenml-600">
+  <div class="mx-auto max-w-[1440px] px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
+    <header class="mx-auto max-w-3xl text-center">
+      <p class="text-sm font-semibold uppercase tracking-wider text-gray-500">
         Compare
       </p>
       <h1 class="mt-2 text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
         Pick the right tool for the job.
       </h1>
       <p class="mt-4 text-lg text-gray-600">
-        ZenML for ML pipelines, Kitaru for AI agents. See how each holds
-        up against the other tools you might be considering.
+        ZenML for ML pipelines, Kitaru for AI agents. Choose a product to see
+        how it stacks up against the alternatives.
       </p>
     </header>
-  </div>
 
-  {/* ════════════════════════════════════════════════════════════════════
-       MLOps — ZenML comparisons (sage green tint)
-       ════════════════════════════════════════════════════════════════════ */}
-  <section class="border-y border-zenml-100 bg-zenml-25/50">
-    <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
-      <div class="mb-10 flex items-center gap-4">
-        <span class="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-zenml-500/15 text-zenml-700">
-          <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <div class="mx-auto mt-16 grid max-w-5xl gap-6 sm:grid-cols-2">
+      <a
+        href="/compare/zenml"
+        class="group flex flex-col rounded-md border border-zenml-100 bg-linear-to-b from-zenml-50 to-white p-8 transition-all hover:border-zenml-300 hover:shadow-medium"
+        data-analytics="compare-gateway-zenml"
+      >
+        <span class="inline-flex h-12 w-12 items-center justify-center rounded-md bg-zenml-500/15 text-zenml-700">
+          <svg class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <path d="M9 3.5V2M5.06066 5.06066L4 4M5.06066 13L4 14.0607M13 5.06066L14.0607 4M3.5 9H2M15.8645 16.1896L13.3727 20.817C13.0881 21.3457 12.9457 21.61 12.7745 21.6769C12.6259 21.7349 12.4585 21.7185 12.324 21.6328C12.1689 21.534 12.0806 21.2471 11.9038 20.6733L8.44519 9.44525C8.3008 8.97651 8.2286 8.74213 8.28669 8.58383C8.33729 8.44595 8.44595 8.33729 8.58383 8.2867C8.74213 8.22861 8.9765 8.3008 9.44525 8.44519L20.6732 11.9038C21.247 12.0806 21.5339 12.169 21.6327 12.324C21.7185 12.4586 21.7348 12.6259 21.6768 12.7745C21.61 12.9458 21.3456 13.0881 20.817 13.3728L16.1896 15.8645C16.111 15.9068 16.0717 15.9279 16.0374 15.9551C16.0068 15.9792 15.9792 16.0068 15.9551 16.0374C15.9279 16.0717 15.9068 16.111 15.8645 16.1896Z"/>
           </svg>
         </span>
-        <div>
-          <p class="text-xs font-semibold uppercase tracking-[0.15em] text-zenml-700">
-            MLOps · ZenML
-          </p>
-          <h2 class="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl">
-            ZenML vs. other ML orchestrators &amp; platforms
-          </h2>
-        </div>
-      </div>
+        <p class="mt-6 text-xs font-semibold uppercase tracking-[0.15em] text-zenml-700">
+          ML platforms · ZenML
+        </p>
+        <h2 class="mt-2 text-2xl font-bold tracking-tight text-gray-900 group-hover:text-zenml-700">
+          Compare ZenML
+        </h2>
+        <p class="mt-3 text-base text-gray-600">
+          ZenML vs. MLflow, Kubeflow, Vertex AI, Databricks, and {mlopsCount - 4} more ML orchestration and platform tools.
+        </p>
+        <span class="mt-6 inline-flex items-center gap-1 text-sm font-semibold text-zenml-600 group-hover:gap-2 transition-all">
+          See {mlopsCount} comparisons
+          <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+        </span>
+      </a>
 
-      <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        {mlopsItems.map((item) => (
-          <a
-            href={`/compare/${item.data.slug}`}
-            class="group flex items-center gap-4 rounded-lg border border-zenml-100 bg-white p-5 transition-all hover:border-zenml-300 hover:shadow-md"
-          >
-            {item.data.toolIcon ? (
-              <img
-                src={item.data.toolIcon.url}
-                alt={item.data.toolName || item.data.title}
-                class="h-10 w-10 shrink-0 rounded-md object-contain"
-              />
-            ) : (
-              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-gray-100 text-base font-bold text-gray-400">
-                {(item.data.toolName || item.data.title)[0]}
-              </div>
-            )}
-            <div class="min-w-0">
-              <h3 class="truncate font-semibold text-gray-900 group-hover:text-zenml-700">
-                {item.data.title}
-              </h3>
-              {item.data.category && (
-                <p class="mt-0.5 text-xs uppercase tracking-wider text-gray-500">
-                  {item.data.category.replace(/-/g, " ")}
-                </p>
-              )}
-            </div>
-          </a>
-        ))}
-      </div>
-    </div>
-  </section>
-
-  {/* ════════════════════════════════════════════════════════════════════
-       Agents — Kitaru comparisons (warm orange tint)
-       ════════════════════════════════════════════════════════════════════ */}
-  <section class="border-y border-orange-200/60 bg-orange-50/50">
-    <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
-      <div class="mb-10 flex items-center gap-4">
-        <span class="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-orange-400/15 text-orange-700">
-          <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <a
+        href="/compare/kitaru"
+        data-app="kitaru"
+        class="group flex flex-col rounded-md border border-orange-200/60 bg-linear-to-b from-orange-50 to-white p-8 transition-all hover:border-orange-400/60 hover:shadow-medium"
+        data-analytics="compare-gateway-kitaru"
+      >
+        <span class="inline-flex h-12 w-12 items-center justify-center rounded-md bg-orange-400/15 text-orange-700">
+          <svg class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <circle cx="12" cy="12" r="10"/>
             <path d="M12 6v6l4 2"/>
           </svg>
         </span>
-        <div>
-          <p class="text-xs font-semibold uppercase tracking-[0.15em] text-orange-700">
-            Agents · Kitaru
-          </p>
-          <h2 class="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl">
-            Kitaru vs. other agent runtimes &amp; workflow engines
-          </h2>
-        </div>
-      </div>
-
-      <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        {agentItems.map((item) => (
-          <a
-            href={`/compare/${item.id}`}
-            class="group flex items-center gap-4 rounded-lg border border-orange-200/60 bg-white p-5 transition-all hover:border-orange-400/60 hover:shadow-md"
-          >
-            {item.data.competitorLogo ? (
-              <img
-                src={item.data.competitorLogo}
-                alt={item.data.competitor}
-                class="h-10 w-10 shrink-0 rounded-md object-contain"
-              />
-            ) : (
-              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-orange-100 text-base font-bold text-orange-600">
-                {item.data.competitor[0]}
-              </div>
-            )}
-            <div class="min-w-0">
-              <h3 class="truncate font-semibold text-gray-900 group-hover:text-orange-700">
-                Kitaru vs. {item.data.competitor}
-              </h3>
-              <p class="mt-0.5 text-xs leading-snug text-gray-500 line-clamp-2">
-                {item.data.cardSubtitle}
-              </p>
-            </div>
-          </a>
-        ))}
-      </div>
+        <p class="mt-6 text-xs font-semibold uppercase tracking-[0.15em] text-orange-700">
+          Agent runtimes · Kitaru
+        </p>
+        <h2 class="mt-2 text-2xl font-bold tracking-tight text-gray-900 group-hover:text-orange-700">
+          Compare Kitaru
+        </h2>
+        <p class="mt-3 text-base text-gray-600">
+          Kitaru vs. Temporal, LangGraph, Restate, Inngest, and {agentsCount - 4} more agent runtimes and workflow engines.
+        </p>
+        <span class="mt-6 inline-flex items-center gap-1 text-sm font-semibold text-orange-600 group-hover:gap-2 transition-all">
+          See {agentsCount} comparisons
+          <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+        </span>
+      </a>
     </div>
-  </section>
+  </div>
 </BaseLayout>

--- a/src/pages/compare/index.astro
+++ b/src/pages/compare/index.astro
@@ -48,7 +48,7 @@ const agentsCount = (
           Compare ZenML
         </h2>
         <p class="mt-3 text-base text-gray-600">
-          ZenML vs. MLflow, Kubeflow, Vertex AI, Databricks, and {mlopsCount - 4} more ML orchestration and platform tools.
+          Compare ZenML against {mlopsCount} ML orchestration and platform tools — MLflow, Kubeflow, Vertex AI, Databricks, and more.
         </p>
         <span class="mt-6 inline-flex items-center gap-1 text-sm font-semibold text-zenml-600 group-hover:gap-2 transition-all">
           See {mlopsCount} comparisons
@@ -75,7 +75,7 @@ const agentsCount = (
           Compare Kitaru
         </h2>
         <p class="mt-3 text-base text-gray-600">
-          Kitaru vs. Temporal, LangGraph, Restate, Inngest, and {agentsCount - 4} more agent runtimes and workflow engines.
+          Compare Kitaru against {agentsCount} agent runtimes and workflow engines — Temporal, LangGraph, Restate, Inngest, and more.
         </p>
         <span class="mt-6 inline-flex items-center gap-1 text-sm font-semibold text-orange-600 group-hover:gap-2 transition-all">
           See {agentsCount} comparisons

--- a/src/pages/compare/kitaru/index.astro
+++ b/src/pages/compare/kitaru/index.astro
@@ -1,0 +1,66 @@
+---
+import { getCollection } from "astro:content";
+import BaseLayout from "../../../layouts/BaseLayout.astro";
+
+const items = (
+  await getCollection("compare-kitaru", ({ data }) => !data.draft)
+).sort((a, b) => a.data.order - b.data.order);
+---
+
+<BaseLayout
+  title="Compare Kitaru vs. agent runtimes"
+  description="See how Kitaru stacks up against Temporal, LangGraph, Restate, Inngest, and other workflow engines and agent frameworks."
+  surface="agent"
+>
+  <div data-app="kitaru">
+    <section class="border-b border-orange-200/60 bg-linear-to-b from-orange-50 to-white">
+      <div class="mx-auto max-w-[1440px] px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
+        <header class="max-w-3xl">
+          <p class="text-sm font-semibold uppercase tracking-wider text-orange-700">
+            Compare Kitaru
+          </p>
+          <h1 class="mt-2 text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+            Kitaru vs. other agent runtimes &amp; workflow engines
+          </h1>
+          <p class="mt-4 text-lg text-gray-600">
+            Side-by-side breakdowns of how Kitaru compares to the
+            durable-execution platforms and agent frameworks you're already
+            evaluating.
+          </p>
+        </header>
+      </div>
+    </section>
+
+    <div class="mx-auto max-w-[1440px] px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
+      <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {items.map((item) => (
+          <a
+            href={`/compare/${item.id}`}
+            class="group flex items-center gap-4 rounded-md border border-orange-200/60 bg-white p-6 transition-all hover:border-orange-400/60 hover:shadow-medium"
+            data-analytics="compare-kitaru-card"
+          >
+            {item.data.competitorLogo ? (
+              <img
+                src={item.data.competitorLogo}
+                alt={item.data.competitor}
+                class="h-10 w-10 shrink-0 rounded-md object-contain"
+              />
+            ) : (
+              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-orange-100 text-base font-bold text-orange-600">
+                {item.data.competitor[0]}
+              </div>
+            )}
+            <div class="min-w-0">
+              <h2 class="truncate font-semibold text-gray-900 group-hover:text-orange-700">
+                Kitaru vs. {item.data.competitor}
+              </h2>
+              <p class="mt-0.5 text-xs leading-snug text-gray-500 line-clamp-2">
+                {item.data.cardSubtitle}
+              </p>
+            </div>
+          </a>
+        ))}
+      </div>
+    </div>
+  </div>
+</BaseLayout>

--- a/src/pages/compare/zenml/index.astro
+++ b/src/pages/compare/zenml/index.astro
@@ -1,0 +1,66 @@
+---
+import { getCollection } from "astro:content";
+import BaseLayout from "../../../layouts/BaseLayout.astro";
+
+const items = (
+  await getCollection("compare", ({ data }) => !data.draft)
+).sort((a, b) => a.data.title.localeCompare(b.data.title));
+---
+
+<BaseLayout
+  title="Compare ZenML vs. ML platforms"
+  description="See how ZenML stacks up against MLflow, Kubeflow, Vertex AI, Databricks, and other ML orchestration and platform tools."
+  surface="ml"
+>
+  <section class="border-b border-zenml-100 bg-linear-to-b from-zenml-50 to-white">
+    <div class="mx-auto max-w-[1440px] px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
+      <header class="max-w-3xl">
+        <p class="text-sm font-semibold uppercase tracking-wider text-zenml-600">
+          Compare ZenML
+        </p>
+        <h1 class="mt-2 text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+          ZenML vs. other ML orchestrators &amp; platforms
+        </h1>
+        <p class="mt-4 text-lg text-gray-600">
+          Side-by-side breakdowns of how ZenML compares to the tools you're
+          already considering for ML pipelines, experiment tracking, and
+          model deployment.
+        </p>
+      </header>
+    </div>
+  </section>
+
+  <div class="mx-auto max-w-[1440px] px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
+    <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+      {items.map((item) => (
+        <a
+          href={`/compare/${item.data.slug}`}
+          class="group flex items-center gap-4 rounded-md border border-gray-200 bg-white p-6 transition-all hover:border-zenml-300 hover:shadow-medium"
+          data-analytics="compare-zenml-card"
+        >
+          {item.data.toolIcon ? (
+            <img
+              src={item.data.toolIcon.url}
+              alt={item.data.toolName || item.data.title}
+              class="h-10 w-10 shrink-0 rounded-md object-contain"
+            />
+          ) : (
+            <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-gray-100 text-base font-bold text-gray-400">
+              {(item.data.toolName || item.data.title)[0]}
+            </div>
+          )}
+          <div class="min-w-0">
+            <h2 class="truncate font-semibold text-gray-900 group-hover:text-zenml-700">
+              {item.data.title}
+            </h2>
+            {item.data.category && (
+              <p class="mt-0.5 text-xs uppercase tracking-wider text-gray-500">
+                {item.data.category.replace(/-/g, " ")}
+              </p>
+            )}
+          </div>
+        </a>
+      ))}
+    </div>
+  </div>
+</BaseLayout>

--- a/src/pages/industry-tags/[slug].astro
+++ b/src/pages/industry-tags/[slug].astro
@@ -52,7 +52,7 @@ const commonMLOpsTags = (await getMLOpsTagCounts(mlopsEntries)).slice(0, 8);
 <BaseLayout
   title={`${tag.data.name} Industry - ZenML Databases`}
   description={`LLMOps and MLOps entries in the ${tag.data.name} industry.`}
-  surface="ml"
+  surface="unified"
 >
   <div class="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
     <header class="mb-12">

--- a/src/pages/industry-tags/index.astro
+++ b/src/pages/industry-tags/index.astro
@@ -38,7 +38,7 @@ const industries: TaxonomyCount[] = allIndustries
 <BaseLayout
   title="Industries - ZenML Databases"
   description="Browse all industries represented in the ZenML LLMOps and MLOps databases."
-  surface="ml"
+  surface="unified"
 >
   <div class="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
     <header class="mb-10">

--- a/src/pages/integrations/index.astro
+++ b/src/pages/integrations/index.astro
@@ -75,7 +75,7 @@ for (const i of allIntegrations) {
       <div class="flex flex-col gap-8 lg:flex-row lg:gap-12">
         {/* ── Left: Filter list ─── */}
         <aside class="w-full shrink-0 lg:w-56">
-          <nav id="integration-filters" class="sticky top-24 flex flex-row flex-wrap gap-2 lg:flex-col lg:gap-0">
+          <nav id="integration-filters" class="sticky top-[calc(var(--nav-height)+1rem)] flex flex-row flex-wrap gap-2 lg:flex-col lg:gap-0">
             <button
               data-filter="__all__"
               class="filter-btn is-active w-full rounded-lg px-3 py-2 text-left text-sm font-medium text-gray-900 transition-colors hover:bg-primary-50 hover:text-primary-700"

--- a/src/pages/llmops-database/[slug].astro
+++ b/src/pages/llmops-database/[slug].astro
@@ -80,7 +80,7 @@ const ogImage = entry.data.seo?.ogImage;
   ogTitle={entry.data.seo?.ogTitle}
   ogDescription={entry.data.seo?.ogDescription}
   canonical={entry.data.seo?.canonical}
-  surface="ml"
+  surface="unified"
 >
   <div class="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8" data-pagefind-body>
     {/* Pagefind metadata — slug for result→item mapping, year for sort */}

--- a/src/pages/llmops-database/index.astro
+++ b/src/pages/llmops-database/index.astro
@@ -32,7 +32,7 @@ const entryCount = (
 <BaseLayout
   title="LLMOps Database - ZenML"
   description={`Explore ${entryCount} real-world LLMOps use cases, tools, and implementations. Filter by technology, industry, and more.`}
-  surface="ml"
+  surface="unified"
 >
   <div class="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
     <header class="mb-10">

--- a/src/pages/llmops-tags/[slug].astro
+++ b/src/pages/llmops-tags/[slug].astro
@@ -38,7 +38,7 @@ const commonIndustries = (await getIndustryTagCounts(allEntries)).slice(0, 8);
 <BaseLayout
   title={`${tag.data.name} - LLMOps Database`}
   description={`LLMOps tools and platforms tagged with "${tag.data.name}".`}
-  surface="ml"
+  surface="unified"
 >
   <div class="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
     <header class="mb-12">

--- a/src/pages/llmops-tags/index.astro
+++ b/src/pages/llmops-tags/index.astro
@@ -28,7 +28,7 @@ const tags: TaxonomyCount[] = allTags
 <BaseLayout
   title="LLMOps Tags - ZenML"
   description="Browse all LLMOps tags used in the ZenML LLMOps Database."
-  surface="ml"
+  surface="unified"
 >
   <div class="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
     <header class="mb-10">

--- a/src/pages/mlops-tags/[slug].astro
+++ b/src/pages/mlops-tags/[slug].astro
@@ -39,7 +39,7 @@ const commonIndustries = (await getMLOpsIndustryTagCounts(allEntries)).slice(
 <BaseLayout
   title={`${tag.data.name} - MLOps Database`}
   description={`MLOps case studies and production ML systems tagged with "${tag.data.name}".`}
-  surface="ml"
+  surface="unified"
 >
   <div class="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
     <header class="mb-12">

--- a/src/pages/mlops-tags/index.astro
+++ b/src/pages/mlops-tags/index.astro
@@ -30,7 +30,7 @@ const tags: TaxonomyCount[] = allTags
 <BaseLayout
   title="MLOps Tags - ZenML"
   description="Browse all MLOps topic tags used in the ZenML MLOps Database."
-  surface="ml"
+  surface="unified"
 >
   <div class="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
     <header class="mb-10">

--- a/src/pages/tags/[slug].astro
+++ b/src/pages/tags/[slug].astro
@@ -63,7 +63,7 @@ for (const post of allPosts) {
 <BaseLayout
   title={`Posts tagged "${tag.data.name}" - ZenML Blog`}
   description={`Blog posts tagged with "${tag.data.name}" from the ZenML team.`}
-  surface="ml"
+  surface="unified"
 >
   {/* Section header: sticky CategoryBar with back link */}
   <CategoryBar categories={categories} backLink />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -124,6 +124,18 @@ html { scroll-behavior: smooth; }
 /* ─── 3. ZenML brand scale (original purple, theme-independent) ─────────────
  * Used by components that need an explicit shade from the ZenML brand ladder
  * (e.g. badges, hover backgrounds, dark-section grounds). */
+/* Total height of the sticky top chrome. Bumped on product surfaces where
+ * the secondary subnav strip (44px) sits below the 72px primary nav. Page
+ * sticky elements (sidebars, progress bars, TOCs) should anchor against this
+ * variable so they stay flush with the bottom of the chrome.            */
+:root {
+  --nav-height: 72px;
+}
+html[data-surface="ml"],
+html[data-surface="agent"] {
+  --nav-height: 116px;
+}
+
 :root {
   --color-zenml-25:  #f1ebfe;  /* lightest */
   --color-zenml-50:  #f6f2ff;


### PR DESCRIPTION
## Summary

Combines the two related IA changes into a single PR (they share files and the second blocks the first if shipped separately):

- **#66 — `/compare` split.** New per-product hubs at `/compare/zenml` (surface=ml, 25 ZenML comparisons) and `/compare/kitaru` (surface=agent, 10 Kitaru comparisons). `/compare` becomes a slim neutral two-card gateway. **Existing detail URLs (`/compare/zenml-vs-X`, `/compare/kitaru-vs-X`) are intentionally preserved** — no 301 chains, no R2 OG re-keying, full inbound link equity stays put.

- **#65 — two-tier navigation.** Primary tier (brand-neutral, every page): ZenML · Kitaru · ZenML Pro · Pricing · Case Studies · Blog. Secondary subnav strip below the primary tier on product surfaces only (surface=ml or surface=agent). On mobile, an ElevenLabs-style chip-switcher: one active product context at a time, "Menu ▾" cycles between ZenML / Kitaru / ZenML Pro.

## Key decisions

- **Brand-first naming** (ZenML, Kitaru) over category-first (ML, Agents) — builds Kitaru recognition; matches homepage/footer voice.
- **"Overview" as the first subnav item** — unambiguous, scans fast, matches Linear/Vercel/Stripe convention.
- **Content-hub surfaces flipped to `unified`** — blog, case studies, llmops-database, tag pages, and author pages now show no subnav (they're peers of the products, not under them). Files touched: 10 page templates + BlogLayout default.
- **CSS variable `--nav-height` for sticky offsets** — 72px on unified pages, 116px on product surfaces. Six sticky elements (integration sidebars, blog category bar, reading progress, TOC, compare code columns) anchor via `calc(var(--nav-height) + ...)`. No per-page math, no drift.

## Code-quality work

After the initial pass, ran `/thermo-nuclear-code-quality-review` twice. Round 2 was clean. Round 1 surfaced and fixed:

- **Single source of truth for product anchors.** `PRODUCT_CONTEXTS` is now a derived view of `NAV_PRIMARY` via a `productSurface` tag on each entry. No more parallel arrays.
- **Single source of truth for brand accent colors.** `productAccent(surface)` returns `{ dot, text, border }`. Used by 5 call sites (desktop subnav title, mobile chip, picker dots, subnav active text, subnav active border).
- **Tag-based mobile filter** replaces hardcoded URL filtering (`href !== "/product/zenml" && ...`).
- **No non-null assertions.** JSX guards (`accent && activeContext &&`) narrow the type cleanly.
- **Dead abstractions removed.** Empty `SubNavItem extends NavLink {}` interface and redundant `isProductSurface` derivation eliminated.

Net diff: **−168 lines** across 29 files (`Navigation.astro` 431→309; `navigation.ts` 189→122).

## Test plan

- [x] `pnpm check:surface` — every layout passes `surface=` explicitly.
- [x] `pnpm astro check` — no new TS errors. Two pre-existing errors on main remain (`LogoCloud.placeholder`, `scripts/og/template.tsx` React types).
- [x] `pnpm astro build` — 8.58s, complete, sitemap regenerated.
- [ ] **Browser spot-check across surfaces**:
  - `/` (unified) — primary nav only, no subnav strip.
  - `/product/zenml` — sage subnav (ZenML · Overview · Features · Integrations · Compare · OSS vs Pro · Docs), "Overview" active.
  - `/product/kitaru` — orange subnav (Kitaru · Overview · Compare · Docs).
  - `/compare/zenml`, `/compare/kitaru` — surface-correct subnav, `Compare` active.
  - `/compare/zenml-vs-mlflow`, `/compare/kitaru-vs-temporal` — existing detail URLs still 200, surface=ml/agent.
  - `/pricing`, `/pro`, `/case-studies`, `/blog`, `/llmops-database` — primary nav only.
- [ ] **Mobile (≤ 1023px)** — open hamburger on a product page: brand dot + product name on left, `Menu ▾` chip on right reveals the picker; tap a different product to switch context.
- [ ] **Plausible goal registration** — four new `data-analytics` event names emit clicks: `compare-gateway-zenml`, `compare-gateway-kitaru`, `compare-zenml-card`, `compare-kitaru-card`. Register as goals in the Plausible dashboard before relying on conversion counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)