### PR TITLE
Add PR quality gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,42 +7,95 @@ on:
     branches: [main]
 
 jobs:
-  deploy:
+  repo-check:
+    name: Repo checks
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      deployments: write
-      pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
-      - run: pnpm check
+      - name: Run Astro and TypeScript checks
+        run: pnpm check
 
-      - run: pnpm lint
+      - name: Run Biome lint
+        run: pnpm lint
 
-      - run: pnpm build
+      - name: Build site
+        run: pnpm build
+
+  deploy:
+    name: Cloudflare Pages deploy
+    runs-on: ubuntu-latest
+    needs: repo-check
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      deployments: write
+      pull-requests: write
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build site
+        run: pnpm build
+
+      - name: Check Cloudflare credentials
+        id: cloudflare-credentials
+        run: |
+          if [ -n "$CLOUDFLARE_API_TOKEN" ] && [ -n "$CLOUDFLARE_ACCOUNT_ID" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "Cloudflare credentials are not available; skipping PR preview deployment."
+          else
+            echo "Cloudflare credentials are required for production deployment." >&2
+            exit 1
+          fi
 
       - name: Deploy to Cloudflare Pages
         id: deploy
+        if: steps.cloudflare-credentials.outputs.available == 'true'
         uses: cloudflare/wrangler-action@v3
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          apiToken: ${{ env.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy dist/ --project-name zenml-io-v2 --branch ${{ github.head_ref || github.ref_name }} --commit-dirty=true
 
       - name: Comment preview URL on PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.cloudflare-credentials.outputs.available == 'true'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: cloudflare-preview

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,20 +3,8 @@ name: Deploy to Cloudflare Pages
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "docs/**"
-      - "scripts/**"
-      - "design/**"
-      - "*.md"
-      - ".claude/**"
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "docs/**"
-      - "scripts/**"
-      - "design/**"
-      - "*.md"
-      - ".claude/**"
 
 jobs:
   deploy:
@@ -38,6 +26,10 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
+
+      - run: pnpm check
+
+      - run: pnpm lint
 
       - run: pnpm build
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ and `MERGE_PLAN.md` for the merge plan + progress log.
 
 ## Testing Guidelines
 - There is no dedicated unit-test suite in root scripts yet.
-- Minimum quality gate before PR: `pnpm check && pnpm lint && pnpm build`.
+- Minimum quality gate before PR: `pnpm check && pnpm lint && pnpm build`. PR CI enforces these before Cloudflare deployment, so previews deploy only after the gates pass.
 - For content-heavy changes, also run `pnpm validate:content`.
 - If you edit code after running checks, rerun the affected checks.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ and `MERGE_PLAN.md` for the merge plan + progress log.
 
 ## Testing Guidelines
 - There is no dedicated unit-test suite in root scripts yet.
-- Minimum quality gate before PR: `pnpm check && pnpm lint && pnpm build`. PR CI enforces these before Cloudflare deployment, so previews deploy only after the gates pass.
+- Minimum quality gate before PR: `pnpm check && pnpm lint && pnpm build`. PR CI enforces these in the required `Repo checks` job. Cloudflare previews deploy afterward when credentials are available, but preview deployment is not the required merge gate.
 - For content-heavy changes, also run `pnpm validate:content`.
 - If you edit code after running checks, rerun the affected checks.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ The Segment loader in `consentConfig.ts` runs a single ZenML write key (D4 was s
 - `design/` folder is for heavy artifacts (exports, screenshots, JSON dumps, internal docs) — **never commit to git**
 - Make targeted git commits (only relevant files)
 - After running tests, re-run them if you make subsequent changes
-- PR CI enforces the package quality gates before Cloudflare deployment: `pnpm check`, `pnpm lint`, then `pnpm build`. PR previews only deploy after these pass
+- PR CI enforces the package quality gates in the required `Repo checks` job: `pnpm check`, `pnpm lint`, then `pnpm build`. PR previews deploy afterward when Cloudflare credentials are available, but preview deployment is not the required merge gate
 - **Build output**: `pnpm build` generates ~2000+ lines of output listing every generated page. Always run it in background mode and use `tail` to check only the final lines for success/failure
 - **Credential management**: When you receive API credentials, tokens, or keys, **always add them to `.env`** for persistence across sessions. The `.env` file is gitignored and safe for secrets
 - VERY IMPORTANT: **Before opening a PR or making a large commit**, always run `/simplify` to review changed code for reuse opportunities, quality issues, and efficiency improvements. Fix any issues it finds before committing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ The Segment loader in `consentConfig.ts` runs a single ZenML write key (D4 was s
 - `design/` folder is for heavy artifacts (exports, screenshots, JSON dumps, internal docs) — **never commit to git**
 - Make targeted git commits (only relevant files)
 - After running tests, re-run them if you make subsequent changes
+- PR CI enforces the package quality gates before Cloudflare deployment: `pnpm check`, `pnpm lint`, then `pnpm build`. PR previews only deploy after these pass
 - **Build output**: `pnpm build` generates ~2000+ lines of output listing every generated page. Always run it in background mode and use `tail` to check only the final lines for success/failure
 - **Credential management**: When you receive API credentials, tokens, or keys, **always add them to `.env`** for persistence across sessions. The `.env` file is gitignored and safe for secrets
 - VERY IMPORTANT: **Before opening a PR or making a large commit**, always run `/simplify` to review changed code for reuse opportunities, quality issues, and efficiency improvements. Fix any issues it finds before committing.

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ ContactForm Preact island → Astro API route at `src/pages/api/forms/[formType]
 | `strickvl`, `htahir1` | Yes (bypass branch protection) |
 | Everyone else | Must use PRs (1 approval required) |
 
-PRs require the `deploy` status check to pass (full build + Cloudflare Pages deploy).
+PRs require the `Repo checks` status check to pass (`pnpm check`, `pnpm lint`, and `pnpm build`). Cloudflare preview deploys run separately after that gate passes when credentials are available, for eligible same-repo PRs.
 
 See `docs/branch-protection-spec.md` for the full governance spec.
 

--- a/docs/branch-protection-spec.md
+++ b/docs/branch-protection-spec.md
@@ -43,7 +43,7 @@ Two tiers based on what changed:
 | Dismiss stale reviews on new pushes | **Yes** |
 | Require review from CODEOWNERS | **Yes** |
 | Require status checks to pass | **Yes** |
-| Required status check | `deploy` (the existing "Deploy to Cloudflare Pages" workflow job) |
+| Required status check | `Repo checks` (the deterministic repository check job in the "Deploy to Cloudflare Pages" workflow) |
 | Require branches to be up to date | **Yes** |
 | Block force pushes | **Yes** (everyone, including admins) |
 | Block branch deletion | **Yes** |
@@ -88,13 +88,14 @@ Two tiers based on what changed:
 
 ### CI workflow
 
-The existing `.github/workflows/deploy.yml` handles both PR checks and production deploys:
+The existing `.github/workflows/deploy.yml` handles deterministic repo checks first, then Cloudflare deployment:
 
-- **On PR**: runs `pnpm check`, `pnpm lint`, and `pnpm build`, then deploys a Cloudflare Pages **preview** only if those gates pass (branch URL like `<branch>.zenml-io-v2.pages.dev`). The `--branch ${{ github.head_ref }}` flag ensures PRs never touch the production deployment.
-- **On push to main**: runs `pnpm check`, `pnpm lint`, and `pnpm build`, then deploys to **production** (the `main` production branch in Cloudflare Pages).
-- The `deploy` job name becomes a required status check in branch protection; it now covers the quality gates and deployment together.
+- **Required PR gate**: `Repo checks` runs `pnpm install --frozen-lockfile`, `pnpm check`, `pnpm lint`, and `pnpm build`. This is the branch-protection status check because it is deterministic and does not depend on Cloudflare credentials or availability.
+- **On same-repo PRs**: after `Repo checks` passes, `Cloudflare Pages deploy` publishes a Cloudflare Pages **preview** when Cloudflare secrets are available (branch URL like `<branch>.zenml-io-v2.pages.dev`). The `--branch ${{ github.head_ref }}` flag ensures PRs never touch the production deployment.
+- **On fork PRs**: `Repo checks` still runs and can satisfy branch protection. Cloudflare preview deployment is skipped because repository secrets are not available to forked PRs.
+- **On push to main**: after `Repo checks` passes, `Cloudflare Pages deploy` deploys to **production** (the `main` production branch in Cloudflare Pages).
 
-Keep as a single workflow for now. Splitting into separate build-only (PR) and deploy (main) workflows can be revisited later if CI speed becomes an issue.
+Keep Cloudflare deployment dependent on `Repo checks`; do not make deployment the required merge gate.
 
 ### Branching model
 
@@ -105,7 +106,7 @@ Keep as a single workflow for now. Splitting into separate build-only (PR) and d
 
 ### Additional quality gates
 
-The required PR gate is the existing `deploy` job, which runs `pnpm check`, `pnpm lint`, and `pnpm build` before preview/deploy. Link checking, Lighthouse, etc. can be added later.
+The required PR gate is `Repo checks`, which runs `pnpm install --frozen-lockfile`, `pnpm check`, `pnpm lint`, and `pnpm build`. Cloudflare preview deployment is dependent and best-effort, not the required merge gate. Link checking, Lighthouse, etc. can be added later.
 
 ### Releases & tags
 

--- a/docs/branch-protection-spec.md
+++ b/docs/branch-protection-spec.md
@@ -90,9 +90,9 @@ Two tiers based on what changed:
 
 The existing `.github/workflows/deploy.yml` handles both PR checks and production deploys:
 
-- **On PR**: builds the site + deploys a Cloudflare Pages **preview** (branch URL like `<branch>.zenml-io-v2.pages.dev`). The `--branch ${{ github.head_ref }}` flag ensures PRs never touch the production deployment.
-- **On push to main**: builds + deploys to **production** (the `main` production branch in Cloudflare Pages).
-- **No changes needed** to the workflow itself. The `deploy` job name becomes a required status check in branch protection.
+- **On PR**: runs `pnpm check`, `pnpm lint`, and `pnpm build`, then deploys a Cloudflare Pages **preview** only if those gates pass (branch URL like `<branch>.zenml-io-v2.pages.dev`). The `--branch ${{ github.head_ref }}` flag ensures PRs never touch the production deployment.
+- **On push to main**: runs `pnpm check`, `pnpm lint`, and `pnpm build`, then deploys to **production** (the `main` production branch in Cloudflare Pages).
+- The `deploy` job name becomes a required status check in branch protection; it now covers the quality gates and deployment together.
 
 Keep as a single workflow for now. Splitting into separate build-only (PR) and deploy (main) workflows can be revisited later if CI speed becomes an issue.
 
@@ -105,7 +105,7 @@ Keep as a single workflow for now. Splitting into separate build-only (PR) and d
 
 ### Additional quality gates
 
-None for now. Only `pnpm build` success required. Link checking, Lighthouse, etc. can be added later.
+The required PR gate is the existing `deploy` job, which runs `pnpm check`, `pnpm lint`, and `pnpm build` before preview/deploy. Link checking, Lighthouse, etc. can be added later.
 
 ### Releases & tags
 

--- a/src/components/compare/_layouts/KitaruCompare.astro
+++ b/src/components/compare/_layouts/KitaruCompare.astro
@@ -14,9 +14,9 @@
 import type { CollectionEntry } from "astro:content";
 import { render } from "astro:content";
 import BaseLayout from "../../../layouts/BaseLayout.astro";
-import ComparisonHero from "../kitaru/ComparisonHero.astro";
 import { compareOgUrl } from "../../../lib/seo";
 import "../../../styles/kitaru-compat.css";
+import ComparisonHero from "../kitaru/ComparisonHero.astro";
 
 interface Props {
   entry: CollectionEntry<"compare-kitaru">;

--- a/src/components/sections/LogoCloud.astro
+++ b/src/components/sections/LogoCloud.astro
@@ -25,7 +25,7 @@ const {
   logos = LOGO_CLOUD.logos,
   bgClass = "border-b border-gray-200 bg-gray-50",
   fadeFromClass = "from-gray-50",
-} = Astro.props;
+}: Props = Astro.props;
 ---
 
 <section class:list={[bgClass, "py-10 sm:py-12"]}>

--- a/src/components/sections/two-workspaces/ResourcesLayout.astro
+++ b/src/components/sections/two-workspaces/ResourcesLayout.astro
@@ -66,7 +66,6 @@ const poolStatusStyle = (status: ResourcePoolStatus): PillStyle => {
         hasDot: true,
         dotColor: "bg-[#16A34A]",
       };
-    case "idle":
     default:
       return {
         bg: "bg-[#F2F4F7]",

--- a/src/lib/getStarted.ts
+++ b/src/lib/getStarted.ts
@@ -93,7 +93,12 @@ export interface GetStartedProjects {
   cta: CtaLink;
 }
 
-export type GetStartedResourceColor = "teal" | "blue" | "purple" | "gray" | "orange";
+export type GetStartedResourceColor =
+  | "teal"
+  | "blue"
+  | "purple"
+  | "gray"
+  | "orange";
 
 export interface GetStartedResource {
   title: string;

--- a/src/scripts/kitaru/canvas-utils.ts
+++ b/src/scripts/kitaru/canvas-utils.ts
@@ -8,8 +8,8 @@ export function sizeCanvasToParent(
   const rect = canvas.parentElement.getBoundingClientRect();
   canvas.width = rect.width * dpr;
   canvas.height = rect.height * dpr;
-  canvas.style.width = rect.width + "px";
-  canvas.style.height = rect.height + "px";
+  canvas.style.width = `${rect.width}px`;
+  canvas.style.height = `${rect.height}px`;
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   return { w: rect.width, h: rect.height };
 }

--- a/src/scripts/kitaru/card-glow.ts
+++ b/src/scripts/kitaru/card-glow.ts
@@ -5,11 +5,11 @@ export function setupCardGlow(selector: string) {
       const rect = card.getBoundingClientRect();
       card.style.setProperty(
         "--mouse-x",
-        ((e.clientX - rect.left) / rect.width) * 100 + "%",
+        `${((e.clientX - rect.left) / rect.width) * 100}%`,
       );
       card.style.setProperty(
         "--mouse-y",
-        ((e.clientY - rect.top) / rect.height) * 100 + "%",
+        `${((e.clientY - rect.top) / rect.height) * 100}%`,
       );
     });
     card.addEventListener("mouseleave", () => {

--- a/src/scripts/kitaru/hero-gl.ts
+++ b/src/scripts/kitaru/hero-gl.ts
@@ -195,8 +195,9 @@ export function initHeroGL(canvas: HTMLCanvasElement): HeroGLController | null {
     console.warn("[hero-gl] WebGL2 context not available");
     return null;
   }
+  const activeGl = gl;
 
-  let program = createProgram(gl);
+  let program = createProgram(activeGl);
   if (!program) {
     console.warn("[hero-gl] Failed to create shader program");
     return null;
@@ -215,24 +216,24 @@ export function initHeroGL(canvas: HTMLCanvasElement): HeroGLController | null {
   let uAttractor1: WebGLUniformLocation | null;
   let uAttractor2: WebGLUniformLocation | null;
 
-  function cacheLocations() {
-    uTime = gl!.getUniformLocation(program!, "uTime");
-    uResolution = gl!.getUniformLocation(program!, "uResolution");
-    uDPR_loc = gl!.getUniformLocation(program!, "uDPR");
-    uMouse = gl!.getUniformLocation(program!, "uMouse");
-    uMouseActive = gl!.getUniformLocation(program!, "uMouseActive");
-    uAttractor1 = gl!.getUniformLocation(program!, "uAttractor1");
-    uAttractor2 = gl!.getUniformLocation(program!, "uAttractor2");
+  function cacheLocations(activeProgram: WebGLProgram) {
+    uTime = activeGl.getUniformLocation(activeProgram, "uTime");
+    uResolution = activeGl.getUniformLocation(activeProgram, "uResolution");
+    uDPR_loc = activeGl.getUniformLocation(activeProgram, "uDPR");
+    uMouse = activeGl.getUniformLocation(activeProgram, "uMouse");
+    uMouseActive = activeGl.getUniformLocation(activeProgram, "uMouseActive");
+    uAttractor1 = activeGl.getUniformLocation(activeProgram, "uAttractor1");
+    uAttractor2 = activeGl.getUniformLocation(activeProgram, "uAttractor2");
   }
-  cacheLocations();
+  cacheLocations(program);
 
   // Empty VAO required by WebGL2
-  let vao = gl.createVertexArray();
-  gl.bindVertexArray(vao);
+  let vao = activeGl.createVertexArray();
+  activeGl.bindVertexArray(vao);
 
   // Blending for alpha
-  gl.enable(gl.BLEND);
-  gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+  activeGl.enable(activeGl.BLEND);
+  activeGl.blendFunc(activeGl.SRC_ALPHA, activeGl.ONE_MINUS_SRC_ALPHA);
 
   // State
   let mouseX = -9999;
@@ -249,39 +250,41 @@ export function initHeroGL(canvas: HTMLCanvasElement): HeroGLController | null {
     const ph = rect.height * DPR;
     canvas.width = pw;
     canvas.height = ph;
-    canvas.style.width = rect.width + "px";
-    canvas.style.height = rect.height + "px";
-    gl!.viewport(0, 0, pw, ph);
+    canvas.style.width = `${rect.width}px`;
+    canvas.style.height = `${rect.height}px`;
+    activeGl.viewport(0, 0, pw, ph);
   }
 
   function render(time: number) {
     if (destroyed) return;
+    const activeProgram = program;
+    if (!activeProgram) return;
     const t = time * 0.001;
     const w = canvas.width / DPR;
     const h = canvas.height / DPR;
 
-    gl!.useProgram(program);
-    gl!.uniform1f(uTime, t);
-    gl!.uniform2f(uResolution, w, h);
-    gl!.uniform1f(uDPR_loc, DPR);
-    gl!.uniform2f(uMouse, mouseX, mouseY);
-    gl!.uniform1f(uMouseActive, mouseActiveVal);
+    activeGl.useProgram(activeProgram);
+    activeGl.uniform1f(uTime, t);
+    activeGl.uniform2f(uResolution, w, h);
+    activeGl.uniform1f(uDPR_loc, DPR);
+    activeGl.uniform2f(uMouse, mouseX, mouseY);
+    activeGl.uniform1f(uMouseActive, mouseActiveVal);
 
     // Compute attractor Lissajous positions on CPU (avoids per-fragment trig)
-    gl!.uniform2f(
+    activeGl.uniform2f(
       uAttractor1,
       w * 0.5 + Math.sin(t * 0.25) * w * 0.42,
       h * 0.5 + Math.cos(t * 0.18) * h * 0.38,
     );
-    gl!.uniform2f(
+    activeGl.uniform2f(
       uAttractor2,
       w * 0.5 + Math.cos(t * 0.15) * w * 0.35,
       h * 0.5 + Math.sin(t * 0.22) * h * 0.32,
     );
 
-    gl!.clearColor(0, 0, 0, 0);
-    gl!.clear(gl!.COLOR_BUFFER_BIT);
-    gl!.drawArrays(gl!.TRIANGLES, 0, 3);
+    activeGl.clearColor(0, 0, 0, 0);
+    activeGl.clear(activeGl.COLOR_BUFFER_BIT);
+    activeGl.drawArrays(activeGl.TRIANGLES, 0, 3);
 
     if (visible && !reducedMotion) {
       animId = requestAnimationFrame(render);
@@ -298,19 +301,20 @@ export function initHeroGL(canvas: HTMLCanvasElement): HeroGLController | null {
   }
 
   function handleContextRestored() {
-    program = createProgram(gl!);
-    if (!program) {
+    const restoredProgram = createProgram(activeGl);
+    if (!restoredProgram) {
       console.warn(
         "[hero-gl] Shader program recreation failed after context restore",
       );
       canvas.style.display = "none";
       return;
     }
-    cacheLocations();
-    vao = gl!.createVertexArray();
-    gl!.bindVertexArray(vao);
-    gl!.enable(gl!.BLEND);
-    gl!.blendFunc(gl!.SRC_ALPHA, gl!.ONE_MINUS_SRC_ALPHA);
+    program = restoredProgram;
+    cacheLocations(restoredProgram);
+    vao = activeGl.createVertexArray();
+    activeGl.bindVertexArray(vao);
+    activeGl.enable(activeGl.BLEND);
+    activeGl.blendFunc(activeGl.SRC_ALPHA, activeGl.ONE_MINUS_SRC_ALPHA);
     sizeCanvas();
     if (visible && !reducedMotion) {
       animId = requestAnimationFrame(render);
@@ -380,8 +384,8 @@ export function initHeroGL(canvas: HTMLCanvasElement): HeroGLController | null {
         // @ts-expect-error — removeListener is deprecated but matches addListener
         motionMql.removeListener(handleMotionChange);
       }
-      gl!.deleteVertexArray(vao);
-      if (program) gl!.deleteProgram(program);
+      activeGl.deleteVertexArray(vao);
+      if (program) activeGl.deleteProgram(program);
     },
   };
 }

--- a/src/scripts/kitaru/hero-gl.ts
+++ b/src/scripts/kitaru/hero-gl.ts
@@ -242,9 +242,10 @@ export function initHeroGL(canvas: HTMLCanvasElement): HeroGLController | null {
   let animId = 0;
   let visible = true;
   let destroyed = false;
+  let contextLost = false;
 
   function sizeCanvas() {
-    if (!canvas.parentElement) return;
+    if (contextLost || !canvas.parentElement) return;
     const rect = canvas.parentElement.getBoundingClientRect();
     const pw = rect.width * DPR;
     const ph = rect.height * DPR;
@@ -256,7 +257,7 @@ export function initHeroGL(canvas: HTMLCanvasElement): HeroGLController | null {
   }
 
   function render(time: number) {
-    if (destroyed) return;
+    if (destroyed || contextLost) return;
     const activeProgram = program;
     if (!activeProgram) return;
     const t = time * 0.001;
@@ -286,7 +287,7 @@ export function initHeroGL(canvas: HTMLCanvasElement): HeroGLController | null {
     activeGl.clear(activeGl.COLOR_BUFFER_BIT);
     activeGl.drawArrays(activeGl.TRIANGLES, 0, 3);
 
-    if (visible && !reducedMotion) {
+    if (visible && !reducedMotion && !contextLost) {
       animId = requestAnimationFrame(render);
     } else {
       animId = 0;
@@ -296,17 +297,23 @@ export function initHeroGL(canvas: HTMLCanvasElement): HeroGLController | null {
   // Context loss/restore — named handlers for cleanup in destroy()
   function handleContextLost(e: Event) {
     e.preventDefault();
+    contextLost = true;
     cancelAnimationFrame(animId);
     animId = 0;
   }
 
   function handleContextRestored() {
+    if (destroyed) return;
+    contextLost = false;
+    cancelAnimationFrame(animId);
+    animId = 0;
     const restoredProgram = createProgram(activeGl);
     if (!restoredProgram) {
       console.warn(
         "[hero-gl] Shader program recreation failed after context restore",
       );
       canvas.style.display = "none";
+      contextLost = true;
       return;
     }
     program = restoredProgram;
@@ -316,7 +323,7 @@ export function initHeroGL(canvas: HTMLCanvasElement): HeroGLController | null {
     activeGl.enable(activeGl.BLEND);
     activeGl.blendFunc(activeGl.SRC_ALPHA, activeGl.ONE_MINUS_SRC_ALPHA);
     sizeCanvas();
-    if (visible && !reducedMotion) {
+    if (visible && !reducedMotion && !contextLost) {
       animId = requestAnimationFrame(render);
     } else {
       render(0);
@@ -328,8 +335,8 @@ export function initHeroGL(canvas: HTMLCanvasElement): HeroGLController | null {
     if (e.matches) {
       cancelAnimationFrame(animId);
       animId = 0;
-      render(0);
-    } else if (visible && animId === 0) {
+      if (!contextLost) render(0);
+    } else if (visible && !contextLost && animId === 0) {
       animId = requestAnimationFrame(render);
     }
   }
@@ -361,7 +368,7 @@ export function initHeroGL(canvas: HTMLCanvasElement): HeroGLController | null {
     },
     setVisible(v: boolean) {
       visible = v;
-      if (v && !reducedMotion && animId === 0) {
+      if (v && !reducedMotion && !contextLost && animId === 0) {
         animId = requestAnimationFrame(render);
       } else if (!v) {
         cancelAnimationFrame(animId);
@@ -370,7 +377,7 @@ export function initHeroGL(canvas: HTMLCanvasElement): HeroGLController | null {
     },
     resize() {
       sizeCanvas();
-      if (reducedMotion) render(0);
+      if (reducedMotion && !contextLost) render(0);
     },
     destroy() {
       destroyed = true;


### PR DESCRIPTION
## Summary
- add a required deterministic `Repo checks` job that runs `pnpm check`, `pnpm lint`, and `pnpm build`
- split Cloudflare Pages deployment into a dependent non-required job, so preview deployment is not the merge gate
- keep Cloudflare previews for same-repo PRs when credentials are available; skip preview deploys for fork PRs while still allowing repo checks to pass
- remove workflow path filters so required PR checks are always created
- update README, AGENTS, CLAUDE, and branch-protection docs to describe the new gate
- fix existing check/lint blockers so the new gate starts green, including safer WebGL context-loss handling

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deploy.yml'); puts 'YAML parsed OK'"`
- `pnpm check`
- `pnpm lint`
- `pnpm build`

## Notes
- Branch protection should require the `Repo checks` status check, not the Cloudflare deployment job.
- Cloudflare preview deployment remains useful feedback, but it is intentionally not the required merge gate.
