### PR TITLE
Add Kitaru LangGraph + Claude Agent SDK adapter blog posts

### DIFF
--- a/src/content/blog/claude-agent-sdk-durable-runtime.md
+++ b/src/content/blog/claude-agent-sdk-durable-runtime.md
@@ -1,0 +1,336 @@
+---
+title: "Don't make Claude do the same work twice"
+slug: "claude-agent-sdk-durable-runtime"
+draft: false
+author: "alex-strick-van-linschoten"
+category: "kitaru"
+tags:
+  - "kitaru"
+  - "agents"
+  - "llmops"
+  - "production"
+  - "open-source"
+date: "2026-06-01T00:00:00.000Z"
+readingTime: "8 mins"
+mainImage:
+  url: "https://assets.zenml.io/content/blog/claude-agent-sdk-durable-runtime/bd454895/kit-claude.avif"
+  alt: "Kitaru durable runtime around a Claude Agent SDK invocation"
+seo:
+  title: "Don't make Claude do the same work twice - ZenML Blog"
+  description: "Claude Agent SDK runs the agent loop. Kitaru adds the durable runtime around a completed invocation — checkpointed results, artifacts, replay boundaries, and waits."
+  canonical: "https://www.zenml.io/blog/claude-agent-sdk-durable-runtime"
+  ogImage: "https://assets.zenml.io/content/blog/claude-agent-sdk-durable-runtime/3d194f26/kit-claude.jpg"
+---
+
+Claude Agent SDK gives you Claude Code's agent loop as a library. Claude can read files, edit code, run commands, use MCP servers, follow permissions, keep sessions, and work through a real task inside your application.
+
+That is exactly why teams want to use it.
+
+Then the workflow leaves the happy path, and different questions appear:
+
+- What did Claude produce, and where is that result saved?
+- Can a reviewer approve tomorrow without keeping a Python process alive?
+- Can replay retry the failed suffix without asking Claude to redo the review?
+- Can an engineer or coding assistant inspect the artifacts, logs, warnings, and failure context later?
+- If this is deployed, which flow version or route handled the run?
+
+Kitaru's Claude Agent SDK adapter is not trying to replace that loop. It adds the durable runtime around it: a completed Claude run becomes checkpointed workflow state, with a typed result, named artifacts, logs and run summaries, session and cost context when the SDK reports it, replay/rerun behavior, and wait/resume surfaces that humans or agents can inspect and operate later.
+
+```text
+one completed Claude Agent SDK invocation = one Kitaru checkpoint
+```
+
+Claude owns what happens inside the invocation. Kitaru records the completed boundary around it, so the larger workflow can reuse that finished work as durable workflow state.
+
+## You already have a Claude Agent SDK workflow
+
+Imagine a compliance workflow.
+
+A customer uploads an IT security policy. Your workflow asks Claude to review it against SOC 2 controls. Claude reads the relevant documents, follows the project rules, spends a few turns building the finding, and returns a clear answer.
+
+Then the boring production thing happens.
+
+The report upload fails. Or the reviewer notification gets throttled. Or the workflow needs to wait overnight for a human to approve the next step.
+
+The expensive part already happened. Claude already did the review. The workflow should not ask Claude to do the same work again just because a downstream step broke.
+
+The useful production question is not only "can replay skip Claude?" It is also "what can the team see and do next?" The run should have a durable result, named artifacts, warnings if transcript capture was best-effort, logs and failure context for debugging, a pending wait that can be answered from another surface, and a replay/rerun path that starts from the right boundary.
+
+That is the runtime problem Kitaru solves around Claude Agent SDK.
+
+Claude Agent SDK is the harness. It decides how Claude reads, reasons, calls tools, runs commands, follows permissions, and keeps session history. Kitaru is the runtime around completed invocations: it records what finished, what artifacts and logs explain it, where the workflow can wait or resume, and which replay/rerun boundary should be reused instead of asking Claude to do completed work again.
+
+Harnesses define behavior. Runtimes make completed work durable.
+
+Kitaru should not pretend to own what Claude still owns. The point is not to pull Claude's agent loop apart. The point is to give the completed Claude invocation somewhere durable to land.
+
+## The boundary Kitaru draws: one invocation, one checkpoint
+
+Here is the basic shape:
+
+```python
+from pathlib import Path
+
+from claude_agent_sdk import ClaudeAgentOptions
+from kitaru import flow
+from kitaru.adapters.claude_agent_sdk import (
+    ClaudeRunRequest,
+    ClaudeRunResult,
+    KitaruClaudeRunner,
+)
+
+runner = KitaruClaudeRunner(
+    name="claude_sdk_summary",
+    options_factory=lambda request: ClaudeAgentOptions(
+        allowed_tools=[],
+        cwd=request.cwd,
+        resume=request.resume_session_id,
+        max_turns=request.max_turns,
+    ),
+)
+
+@flow
+def summarize(prompt: str) -> ClaudeRunResult:
+    request = ClaudeRunRequest.start(
+        prompt,
+        cwd=str(Path.cwd()),
+        max_turns=1,
+    )
+    return runner.run_sync(request)
+```
+
+This is the same runner name used by the runnable example in the repo, so the Kitaru UI will show a checkpoint named:
+
+```text
+claude_sdk_summary_claude_invocation
+```
+
+Mechanically, the flow looks like this:
+
+```text
+flow body calls runner.run_sync(...)
+→ adapter opens one Kitaru checkpoint
+→ adapter calls claude_agent_sdk.query(...)
+→ Claude runs its internal loop
+→ Claude emits a final ResultMessage
+→ adapter returns ClaudeRunResult
+→ Kitaru stores that result as checkpoint output
+```
+
+![Kitaru records the completed invocation. Claude owns the internal loop.](https://assets.zenml.io/content/blog/claude-agent-sdk-durable-runtime/a9b5ac7d/1-one-invocation-checkpoint.avif)
+
+The important word is **completed**.
+
+If the Claude invocation completes, Kitaru has a durable checkpoint output: the `ClaudeRunResult`. On replay, when Kitaru can reuse that completed checkpoint, Claude does not need to be called again for that completed invocation.
+
+If the Claude invocation fails halfway through, there is no completed invocation result to reuse. Retrying that checkpoint means starting the invocation again.
+
+That boundary is deliberate.
+
+Claude owns the internal model calls, tool calls, Bash commands, MCP calls, hooks, permission checks, and session behavior. Kitaru records the completed outer boundary. Seeing that Claude used Bash, called a tool, or touched an MCP server is useful observability, but it is not the same as having a replay-safe Python function body that Kitaru can rerun or skip independently.
+
+A trace is not a replay boundary.
+
+Granularity is a design choice, not a badge of honor. For this adapter, the honest durable unit is the completed Claude Agent SDK invocation.
+
+One practical note: call the runner from the flow body, as in the example above. If you call it from inside an existing Kitaru checkpoint, the adapter raises by default so replay does not quietly turn into another Claude call. There is an opt-in escape hatch for unusual cases, but the normal pattern is: let the adapter create the Claude invocation checkpoint itself.
+
+## Session resume is not Kitaru replay
+
+Claude Agent SDK sessions and Kitaru checkpoints are related, but they are not the same thing.
+
+A Claude session is the conversation handle Claude can pick up again. A Kitaru checkpoint is the workflow receipt that says: this boundary finished, here is the saved result.
+
+You often want both.
+
+```python
+first = runner.run_sync(
+    ClaudeRunRequest.start("Review the policy.", cwd="/repo", max_turns=3)
+)
+
+follow_up = runner.run_sync(
+    ClaudeRunRequest.resume(
+        "Now explain the highest-risk gap.",
+        session_id=first.session_id,
+        cwd="/repo",
+        max_turns=2,
+    )
+)
+```
+
+In that example, `ClaudeRunRequest.resume(...)` tells Claude Agent SDK to continue the Claude session identified by `first.session_id`.
+
+Kitaru replay is different. Kitaru replay says: this workflow checkpoint already completed, and replay rules allow us to reuse the saved output instead of running that boundary again.
+
+A compact way to keep the ideas separate:
+
+| Concept | Owned by | What it means |
+| --- | --- | --- |
+| Claude `session_id` | Claude Agent SDK | Continue a Claude conversation/session. |
+| Claude transcript | Claude SDK / local filesystem | Conversation record for debugging or audit when available. |
+| Claude file checkpointing | Claude Agent SDK | Rewind supported file edits in a session. |
+| Kitaru checkpoint | Kitaru | Reuse or replay completed workflow work. |
+| Workspace snapshot | Not provided by this adapter | Recreate arbitrary files/process state after a crash. |
+
+This distinction matters most when something fails.
+
+If a completed Claude invocation sits before the failure, Kitaru can reuse that completed checkpoint. If Claude failed halfway through, Kitaru cannot resume from Claude's sixth internal tool call. Claude may have its own session and recovery features, but the Kitaru adapter boundary is one completed invocation.
+
+That is the honest contract.
+
+## Side effects: what belongs inside Claude, what belongs in Kitaru
+
+The easiest way to understand the boundary is to talk about files.
+
+Suppose Claude is allowed to use Bash. Inside its agent loop, Claude writes a file:
+
+```text
+report.md
+```
+
+Claude returns a final message like:
+
+```text
+I wrote report.md with the compliance summary.
+```
+
+Kitaru stores the completed `ClaudeRunResult` as the checkpoint output.
+
+Then a later workflow step fails. Maybe the workflow was about to notify a reviewer, and Slack returned a temporary error. You replay the workflow. Kitaru sees that the Claude invocation checkpoint already completed and can reuse the saved `ClaudeRunResult`.
+
+That part works.
+
+But if the replay runs in a fresh workspace, or a different pod, `report.md` may not exist. The file write happened inside Claude's Bash/tool loop. Kitaru recorded the completed invocation result; it did not snapshot arbitrary workspace files.
+
+This is not a reason to avoid Claude tools. It is a reason to be explicit about which system owns which side effect.
+
+If the file is just a temporary thing Claude used while reasoning, fine. Keep it inside Claude's loop.
+
+If the file must become durable workflow output, make the file write visible to Kitaru:
+
+```python
+from pathlib import Path
+
+import kitaru
+
+@kitaru.checkpoint
+def write_report(text: str, path: str) -> str:
+    Path(path).write_text(text)
+    return path
+
+@kitaru.flow
+def report_flow(prompt: str) -> str:
+    result = runner.run_sync(ClaudeRunRequest.start(prompt, max_turns=1))
+    return write_report(result.final_text or "", "report.md")
+```
+
+Now the workflow shape is clearer:
+
+```text
+Claude invocation checkpoint
+  → returns report text
+
+write_report checkpoint
+  → writes report.md as Kitaru-owned work
+
+notify_reviewer checkpoint
+  → sends the notification
+```
+
+![If a side effect must be durable workflow state, make it visible to Kitaru.](https://assets.zenml.io/content/blog/claude-agent-sdk-durable-runtime/e3fd7869/2-side-effects-claude-vs-kitaru.avif)
+
+The rule of thumb is simple:
+
+> If the file must be durable, make the file write visible to Kitaru.
+
+Claude Agent SDK also has its own file checkpointing feature. That is useful, but it is a different mechanism. Claude file checkpointing helps rewind supported file edits inside a Claude session. A Kitaru checkpoint helps replay or reuse completed workflow work. The adapter does not turn Claude file checkpointing into Kitaru workflow checkpointing, and it does not provide a general workspace snapshot system.
+
+Again, the goal is not to constrain Claude. Claude can still use tools, Bash, MCP, hooks, and permissions. The question is which system is responsible for replaying or reusing the result later.
+
+## What you can inspect after the run
+
+After a completed invocation, the adapter returns a typed `ClaudeRunResult`. Depending on what the SDK reports and what capture settings you choose, that result can include fields such as:
+
+- `final_text`
+- `session_id`
+- `transcript_path`
+- `usage`
+- `cost_usd`
+- `model_usage`
+- `stop_reason`
+- `num_turns`
+- artifact names
+- `warnings`
+- `metadata`
+
+The cost fields need a small but important caveat. Claude Agent SDK populates cost fields with its own client-side estimate. Treat them as a development signal or approximate budgeting aid, not as finance source of truth.
+
+By default, Kitaru captures the boundary data that is useful for replay inspection and audits:
+
+- prompt and SDK message records
+- best-effort local transcript JSONL payload
+- redacted options manifest
+- final output
+- usage and cost information when the SDK reports it
+- model usage when the SDK reports it
+- event log
+- run summary
+
+You can reduce what is stored with `ClaudeCapturePolicy`:
+
+```python
+from kitaru.adapters.claude_agent_sdk import ClaudeCapturePolicy, KitaruClaudeRunner
+
+runner = KitaruClaudeRunner(
+    name="private_claude_run",
+    capture=ClaudeCapturePolicy(
+        save_prompt=False,
+        save_messages=False,
+        save_transcript_file=False,
+        save_usage=True,
+    ),
+)
+```
+
+This matters because messages and transcripts are conversation data. They may contain prompts, retrieved snippets, tool arguments, command output, file content, and model output. Turn them off when the conversation itself is sensitive.
+
+Transcript capture also deserves plain language. On your laptop, a local transcript file may be easy to find. On Kubernetes or any distributed runner, the local Claude transcript is a pod-local file and may not be visible from the next pod that runs the workflow. The durable record is the Kitaru checkpoint output and persisted Kitaru artifacts, not the local JSONL file.
+
+One more boundary: Claude options can carry live process objects — MCP servers, hooks, callbacks, permission handlers, session stores. For that reason, adapter-created Claude checkpoints do not support Kitaru's isolated runtime today. That is a boundary choice for this adapter, not a general limitation of Kitaru checkpoints.
+
+The useful thing is that the completed boundary becomes inspectable. You can see what request was made, what result came back, which session ID was reported, which artifacts were captured, and where the workflow should resume or replay from.
+
+Because those execution records are exposed through SDK, CLI, UI, and MCP tools, a human operator or coding assistant can ask structured questions of the run: list waiting executions, inspect artifacts, fetch logs when available, provide wait input, retry, or start a replay.
+
+## Try it
+
+The repo includes a small real Claude Agent SDK integration example. It keeps Claude's tools disabled so the first run is easy to reason about: one prompt goes in, one completed Claude result comes back, and Kitaru stores that completed invocation.
+
+```bash
+uv sync --extra local --extra claude-agent-sdk
+uv run kitaru init
+export ANTHROPIC_API_KEY='<your-anthropic-api-key>'
+uv run python examples/integrations/claude_agent_sdk_agent/claude_agent_sdk_adapter.py
+```
+
+If you want to inspect the script without making a Claude API call:
+
+```bash
+uv run python examples/integrations/claude_agent_sdk_agent/claude_agent_sdk_adapter.py --help
+```
+
+When you run it, look for:
+
+- Claude's final text
+- the Claude session ID
+- the transcript path if captured
+- usage and cost information if reported by the SDK
+- Kitaru artifact names
+- warnings if best-effort capture had a problem
+- a Kitaru checkpoint named `claude_sdk_summary_claude_invocation`
+
+For a larger workflow shape, see the [compliance-review example](https://github.com/zenml-io/kitaru/tree/main/examples/end_to_end/compliance_review). It uses the same boundary lesson in a more realistic audit flow: Claude completes review turns, Kitaru records those completed turns, and later workflow failures do not erase earlier completed work.
+
+If you already have a Claude Agent SDK workflow, start by wrapping one completed invocation. Put the runner call in the flow body, inspect the `ClaudeRunResult`, then move any durable downstream side effects into explicit Kitaru checkpoints.
+
+Keep Claude Agent SDK for the loop. Add Kitaru when the completed invocation needs to become durable workflow state.

--- a/src/content/blog/langgraph-durable-runtime.md
+++ b/src/content/blog/langgraph-durable-runtime.md
@@ -1,0 +1,371 @@
+---
+title: "Your LangGraph agent works. Now make the workflow durable."
+slug: "langgraph-durable-runtime"
+draft: false
+author: "alex-strick-van-linschoten"
+category: "kitaru"
+tags:
+  - "kitaru"
+  - "agents"
+  - "llmops"
+  - "production"
+  - "open-source"
+date: "2026-05-29T00:00:00.000Z"
+readingTime: "9 mins"
+mainImage:
+  url: "https://assets.zenml.io/content/blog/langgraph-durable-runtime/34f20d10/kit-langgraph.avif"
+  alt: "Kitaru durable runtime around a LangGraph agent"
+seo:
+  title: "Your LangGraph agent works. Now make the workflow durable. - ZenML Blog"
+  description: "LangGraph keeps graph state, threads, and interrupts. Kitaru adds the durable workflow around the graph call — replay boundaries, durable waits, and inspectable runs."
+  canonical: "https://www.zenml.io/blog/langgraph-durable-runtime"
+  ogImage: "https://assets.zenml.io/content/blog/langgraph-durable-runtime/56558d48/kit-langgraph.jpg"
+---
+
+You already have a LangGraph graph.
+
+It has nodes, edges, state, a `thread_id`, maybe a checkpointer, maybe an `interrupt(...)` for human approval. It works. A support ticket comes in, the graph classifies it, looks up context, asks for approval if needed, and returns a decision.
+
+That graph is valuable. It is also not the whole product.
+
+In production, the graph usually sits inside a larger workflow:
+
+```text
+load ticket
+→ run LangGraph review graph, possibly pausing for approval
+→ persist summary
+→ notify customer or reviewer
+→ expose artifacts to humans, services, or other agents
+```
+
+The graph may finish perfectly and the next step may fail. The report write times out. The notification payload is malformed. The pod disappears after the model work is already done. Without a durable outer boundary, the easiest way back is often to start the script again and ask the graph to redo work it already completed.
+
+Kitaru adds that outer boundary. LangGraph stays in charge of the graph; Kitaru records and runs the durable Python workflow around it. That means replaying completed work is only part of the story. The same execution also becomes something your team — and your own development agents — can inspect later: checkpoints, logs, artifacts, summaries, failed boundaries, and production-vs-local context are all available through Kitaru's UI, SDK, CLI, and MCP server instead of disappearing into a terminal scrollback or a one-off trace.
+
+![LangGraph controls the inside of the box. Kitaru records the durable workflow boundary around the box.](https://assets.zenml.io/content/blog/langgraph-durable-runtime/d7f0b542/1-two-runtimes-one-workflow.avif)
+
+LangGraph is not just a thin harness around a model call. It has real runtime concepts: graph state, checkpointers, threads, interrupts, stores, graph-local replay, and long-running execution semantics. Kitaru should not pretend to take those over. The Kitaru LangGraph adapter is useful precisely because it draws a smaller and more honest boundary: keep LangGraph in charge of graph state, and put Kitaru around the workflow that runs it.
+
+## The default boundary: one graph call, one Kitaru checkpoint
+
+The default LangGraph adapter strategy is `graph_call`.
+
+In plain language:
+
+```text
+one completed graph.invoke(...) = one Kitaru checkpoint
+```
+
+That means Kitaru treats the outer graph invocation as the durable unit. A graph-like object here means something with `invoke(...)` or `ainvoke(...)`: a compiled LangGraph graph, or a LangChain agent runnable that follows the same shape.
+
+A minimal Kitaru flow looks like this:
+
+```python
+import kitaru
+from kitaru import checkpoint, flow
+from kitaru.adapters.langgraph import KitaruGraphRunner, LangGraphRunRequest
+
+runner = KitaruGraphRunner(
+    graph,
+    name="ticket_review_graph",
+    checkpoint_strategy="graph_call",  # default, explicit here for clarity
+)
+
+@checkpoint
+def persist_summary(summary: dict) -> dict:
+    kitaru.save("summary__ticket_review", summary, type="context")
+    return summary
+
+@flow
+def review_ticket(ticket_id: str) -> None:
+    result = runner.invoke(
+        LangGraphRunRequest.start(
+            {"ticket": ticket_id},
+            thread_id=ticket_id,
+        )
+    )
+
+    if result.status == "completed":
+        persist_summary(
+            {
+                "thread_id": result.thread_id,
+                "output": result.output,
+            }
+        )
+```
+
+Kitaru is not stepping into LangGraph's node-level replay system here. It is doing something simpler: if the outer graph-call checkpoint completed, Kitaru replay of the larger workflow can reuse the saved `LangGraphRunResult` instead of invoking the graph again.
+
+Concretely:
+
+```text
+First run:
+load_ticket ✓ → graph_call ✓ → persist_summary ✗
+
+Replay:
+load_ticket reused or rerun by its own policy
+→ graph_call result reused
+→ persist_summary retried
+```
+
+The useful thing is not to pretend Kitaru can replay every hidden LangGraph node. The useful thing is to remember that the graph call already finished.
+
+This is why `graph_call` is the boring default on purpose. It works at the boundary every compatible graph has: the outer call. LangGraph still owns what happens inside that call — nodes, state, checkpointer snapshots, stores, interrupts, and where graph-local resume continues.
+
+![In graph_call mode, Kitaru records each outer LangGraph invocation as one durable boundary.](https://assets.zenml.io/content/blog/langgraph-durable-runtime/985bcfa8/3-inspect-graph-call.avif)
+
+The `thread_id` is the important little detail that makes this honest.
+
+Think of `thread_id` as the label on LangGraph's folder. Start writes into that folder. Resume opens the same folder. Change the label, and LangGraph is looking somewhere else.
+
+```text
+LangGraph checkpointer
+├── thread_id="ticket-17"
+├── thread_id="ticket-42"  ← start and resume both go here
+└── thread_id="ticket-99"
+```
+
+Kitaru records and preserves that graph-owned identity, but it is not a Kitaru execution ID. The Kitaru execution is the outer workflow. The `thread_id` is how LangGraph finds its own graph state.
+
+That split matters even more when a graph pauses for human input.
+
+## Interrupts stay LangGraph-owned; waits become Kitaru-owned
+
+LangGraph already has a good primitive for human-in-the-loop graph execution: [`interrupt(...)`](https://docs.langchain.com/oss/python/langgraph/interrupts). A node calls `interrupt(...)`, LangGraph saves graph state through its checkpointer, and the graph waits until you resume it with a `Command(resume=...)` value using the same `thread_id`.
+
+Kitaru does not replace that. Instead, the adapter turns the interrupted graph result into something the outer workflow can durably wait on.
+
+The chain looks like this:
+
+```text
+LangGraph node calls interrupt(...)
+→ LangGraph checkpointer records graph state
+→ adapter returns LangGraphRunResult(status="interrupted")
+→ Kitaru opens a durable wait at flow scope
+→ human or service provides input later
+→ adapter builds Command(resume=...)
+→ runner.invoke(...) resumes the same thread_id
+```
+
+In code:
+
+```python
+from kitaru import flow
+from kitaru.adapters.langgraph import (
+    KitaruGraphRunner,
+    LangGraphRunRequest,
+    wait_for_interrupt,
+)
+
+runner = KitaruGraphRunner(graph, name="ticket_review_graph")
+
+@flow
+def review_ticket(ticket_id: str) -> None:
+    result = runner.invoke(
+        LangGraphRunRequest.start({"ticket": ticket_id}, thread_id=ticket_id)
+    )
+
+    if result.status == "interrupted":
+        resume_request = wait_for_interrupt(
+            result,
+            schema=bool,
+            question="Approve this ticket escalation?",
+        )
+        result = runner.invoke(resume_request)
+
+    if result.status == "completed":
+        persist_summary(result.output)
+```
+
+LangGraph creates the graph-local pause and records graph state through its checkpointer. Kitaru turns the returned interrupted result into a durable workflow wait.
+
+That means the worker does not need to sit idle while a human is at lunch, asleep, or in a different queue. The Kitaru run can pause, release compute, and resume when input arrives. The resumed graph still uses LangGraph's own resume mechanics.
+
+There is one important LangGraph caveat here: when a graph resumes from an interrupt, LangGraph re-enters the node where `interrupt(...)` was called. Code before the interrupt can run again. That is LangGraph's graph-local behavior, not something Kitaru erases. Side effects before `interrupt(...)` should be idempotent, or moved to safer boundaries.
+
+A simple way to remember the split:
+
+> LangGraph decides where the graph paused. Kitaru makes the surrounding workflow pause durable.
+
+## Smaller boundaries with `calls` mode
+
+Sometimes the outer graph-call boundary is too coarse.
+
+For example, suppose you built a LangChain agent on top of LangGraph with `create_agent(...)`. You may want Kitaru checkpoints around the model calls and local tool calls inside that agent, not just around the outer graph invocation.
+
+That is what `checkpoint_strategy="calls"` is for.
+
+But this mode is intentionally narrow. Kitaru can checkpoint a model or tool call only when it is physically standing around the call that runs it. In the LangGraph adapter today, that means synchronous LangChain model/tool handler calls that pass through `KitaruLangGraphMiddleware`.
+
+```python
+from langchain.agents import create_agent
+from langgraph.checkpoint.memory import InMemorySaver
+
+from kitaru.adapters.langgraph import KitaruGraphRunner, LangGraphRunRequest
+from kitaru.adapters.langgraph.langchain import KitaruLangGraphMiddleware
+
+agent_graph = create_agent(
+    model=model,
+    tools=[lookup_ticket, approve_ticket],
+    middleware=[KitaruLangGraphMiddleware()],
+    checkpointer=InMemorySaver(),
+)
+
+runner = KitaruGraphRunner(
+    agent_graph,
+    name="ticket_agent",
+    checkpoint_strategy="calls",
+)
+
+result = runner.invoke(
+    LangGraphRunRequest.start(
+        {"messages": [{"role": "user", "content": "Handle ticket-42"}]},
+        thread_id="ticket-42",
+    )
+)
+```
+
+The mechanism is simple once you picture the doorway:
+
+```text
+LangChain is about to call the model or tool
+        ↓
+Kitaru middleware receives (request, handler)
+        ↓
+Kitaru opens a checkpoint
+        ↓
+inside that checkpoint, the middleware calls handler(request)
+        ↓
+the model or tool runs
+```
+
+![calls mode works only where Kitaru middleware is physically wrapped around the model/tool handler.](https://assets.zenml.io/content/blog/langgraph-durable-runtime/752c0413/2-middleware-doorway.avif)
+
+This is why middleware can become a replay boundary and callbacks cannot.
+
+A callback says, "a tool call started" or "a tool call ended." That is useful for a trace. But it is not the same as owning the Python call that performs the work. If Kitaru only hears that `send_slack_message` already happened, it cannot safely make replay skip or deduplicate that Slack message.
+
+Middleware is different. The middleware receives the handler before the call happens. It can open a Kitaru checkpoint, call the handler inside it, and let Kitaru record the result.
+
+So the rule is:
+
+> Callbacks and streams are traces, not replay boundaries.
+
+This is not a complaint about callbacks or streams. They are useful. They explain what happened. They are just not the same thing as a callable boundary Kitaru can rerun or reuse.
+
+The no-middleware case is worth saying plainly: `checkpoint_strategy="calls"` without `KitaruLangGraphMiddleware` is not magic introspection. The graph may run, and Kitaru may still record aggregate run metadata where it has execution context, but true model/tool Kitaru checkpoints only appear when a Kitaru-aware wrapper is actually around the handler.
+
+That restraint is deliberate. Granularity is useful only when it is real.
+
+![In calls mode, Kitaru records sync model/tool calls that pass through the LangChain middleware seam.](https://assets.zenml.io/content/blog/langgraph-durable-runtime/f9868340/4-inspect-calls-mode.avif)
+
+## Checkpointers: local demos vs production durability
+
+The sharpest boundary in this integration is the LangGraph checkpointer.
+
+Kitaru checkpoints persist Kitaru workflow boundaries. LangGraph checkpointers persist graph-internal state. These are different layers.
+
+This matters in the most concrete possible way:
+
+```text
+Pod A starts a LangGraph graph with InMemorySaver.
+The graph reaches interrupt(...).
+Kitaru turns the interrupted result into a durable workflow wait.
+Pod A disappears.
+A human approves later.
+Kitaru resumes the flow on Pod B.
+Pod B has the same code and the same Kitaru execution.
+But Pod B does not have Pod A's memory.
+LangGraph cannot find the old in-memory thread state.
+```
+
+Kitaru remembered the workflow. LangGraph's in-memory checkpointer forgot the graph.
+
+That is not a Kitaru bug and not a LangGraph bug. It is the boundary doing exactly what the boundary says. `InMemorySaver` is excellent for local examples, tests, and quick demos. It is not restart-durable across process or container loss.
+
+For production graph resume, use a persistent LangGraph checkpointer or store, as described in the [LangGraph persistence docs](https://docs.langchain.com/oss/python/langgraph/persistence). Kitaru can make the outer workflow durable, but LangGraph's own checkpointer remains the thing that stores graph state, interrupt position, and graph-local resume data.
+
+This is the most important trust-building point in the whole adapter:
+
+> Kitaru remembers the workflow. LangGraph's persistent checkpointer remembers the graph.
+
+## What you can inspect in Kitaru
+
+When the adapter runs inside a Kitaru execution context, it can persist event-log and run-summary artifacts for the graph invocation.
+
+Those artifacts answer operational questions:
+
+- Which graph ran?
+- Which `thread_id` did it use?
+- Did the graph call complete, interrupt, or fail?
+- Which latest LangGraph checkpoint metadata was observed, where available?
+- Which Kitaru checkpoint boundary completed?
+- In `calls` mode, which sync model/tool calls passed through the middleware seam?
+- Which user-facing artifacts did the workflow save?
+- What changed between a local development run and the production run that failed?
+- What context can another agent inspect without you manually pasting logs into a chat window?
+
+The default capture policy is metadata-first. It is meant to be useful without dumping full graph state into Kitaru artifacts. If your graph state contains prompts, tool outputs, customer data, or secrets, be deliberate before opting into deeper capture such as full state values.
+
+This is also where Kitaru's agent-native story matters. The execution is not just a page in a dashboard. Through Kitaru's MCP server, an assistant or debugging agent can query executions, inspect checkpoints, read artifacts, fetch logs, and compare what happened in development with what happened in production. That changes the debugging loop from "paste me the traceback" to "look at this failed execution and tell me which boundary broke."
+
+Failed graph calls still follow the adapter contract: failures can be recorded in events and run summaries where persistence is available, while the graph call itself may propagate an exception to user code. Do not think of the adapter as swallowing graph failures into a returned object in every case. Think of it as giving the Kitaru execution a durable trail of what the adapter could observe and persist.
+
+This is also where Kitaru fits alongside LangSmith rather than replacing it. If you already use LangSmith traces for LangGraph or LangChain runs, keep them. Kitaru is not trying to be your graph trace UI. Kitaru is giving the larger workflow a durable runtime surface: checkpoints, replay, waits, artifacts, deployment, and invocation.
+
+A small responsibility map is clearer than a feature scoreboard:
+
+| Concern | LangGraph keeps owning | Kitaru adds |
+| --- | --- | --- |
+| Graph state | Nodes, edges, state schema, thread checkpoints | Records which graph call ran and which Kitaru boundary completed |
+| Thread identity | `thread_id` and checkpointer lookup | Requires and preserves `thread_id` in adapter requests |
+| Human interrupt | `interrupt(...)`, graph pause point, resume semantics | `kitaru.wait(...)` bridge and workflow-level suspension |
+| Replay | Graph-local replay / time travel | Replay of Kitaru workflow checkpoints around graph calls |
+| Model/tool calls | LangChain / LangGraph execution | Optional sync call checkpoints via Kitaru middleware |
+| Observability | LangSmith / LangGraph traces if used | Kitaru event logs, run summaries, artifacts, execution metadata |
+| Deployment | LangGraph Platform or your own service | Kitaru flow deployment, versioning, and self-hosted runtime |
+
+If your whole company is standardized on LangGraph plus the hosted LangGraph/LangSmith stack, Kitaru may add less. Kitaru becomes more interesting when LangGraph is one framework inside a broader Python platform with Pydantic AI, OpenAI Agents SDK, Claude Agent SDK, custom loops, and non-agent workflow steps.
+
+The point is not to replace LangGraph Platform or LangSmith traces. The point is to let LangGraph runs participate in Kitaru's broader workflow runtime.
+
+## Try it
+
+The repo includes a LangGraph adapter example with two paths.
+
+Start with the local `graph_call` demo. It uses a tiny LangGraph graph with `interrupt(...)`, needs no model provider API key, and shows the outer boundary:
+
+```bash
+uv sync --extra local --extra langgraph
+uv run kitaru init
+uv run kitaru login
+uv run examples/integrations/langgraph_agent/langgraph_adapter.py --strategy graph_call
+```
+
+That demo:
+
+- starts a Kitaru flow;
+- runs a local LangGraph graph;
+- pauses at a `request_decision` node;
+- resumes with a `Command(resume=...)` request;
+- records two graph-call checkpoints;
+- saves a readable `summary__langgraph_demo` artifact.
+
+Then try the OpenAI-backed `calls` demo:
+
+```bash
+uv sync --extra local --extra langgraph-openai
+uv run kitaru init
+uv run kitaru login
+export OPENAI_API_KEY='sk-...'
+export LANGGRAPH_AGENT_MODEL='gpt-5-nano'  # optional override
+uv run examples/integrations/langgraph_agent/langgraph_adapter.py --strategy calls
+```
+
+That demo builds a LangChain support agent with deterministic local ticket tools and `KitaruLangGraphMiddleware`. You should see model-call checkpoints, a `tool_call__lookup_ticket_...` checkpoint when the model follows the lookup instruction, and a `langgraph_summary__...` checkpoint. Depending on the model's exact behavior, you may also see a `tool_call__approve_ticket_...` checkpoint.
+
+The full guide is here: [LangGraph Adapter](https://kitaru.ai/docs/guides/langgraph-adapter/).
+
+If your LangGraph graph is still a local experiment, LangGraph's own checkpointer may be all you need. If that graph is becoming one step in a larger production workflow — surrounded by loading, reporting, approval, notification, artifacts, deployment, and replay — Kitaru gives that outer workflow a durable runtime without taking graph state away from LangGraph.
+
+Keep LangGraph in charge of graph state. Put Kitaru around the workflow that runs it.

--- a/src/content/blog/openai-agents-sdk-durable-runtime.md
+++ b/src/content/blog/openai-agents-sdk-durable-runtime.md
@@ -10,7 +10,7 @@ tags:
   - "llmops"
   - "production"
   - "open-source"
-date: "2026-06-01T00:00:00.000Z"
+date: "2026-05-27T00:00:00.000Z"
 readingTime: "10 mins"
 mainImage:
   url: "https://assets.zenml.io/content/blog/openai-agents-sdk-durable-runtime/a823a4d0/kit-openai.avif"


### PR DESCRIPTION
## Summary

Adds two new posts to the **Kitaru adapter series** and backdates the already-merged OpenAI post so all three read as a natural cadence over the past week (rather than three posts dropped on the same day):

| Post | Slug | Date | Status |
|------|------|------|--------|
| OpenAI Agents are great. Production still needs a runtime. | `openai-agents-sdk-durable-runtime` | 2026-05-27 | re-dated (series opener) |
| Your LangGraph agent works. Now make the workflow durable. | `langgraph-durable-runtime` | 2026-05-29 | **new** |
| Don't make Claude do the same work twice | `claude-agent-sdk-durable-runtime` | 2026-06-01 | **new** |

- Author: `alex-strick-van-linschoten` (existing)
- Both new posts: `category: "kitaru"` + `"kitaru"` as first tag (Kitaru-blog convention); reuse the series tag set `kitaru, agents, llmops, production, open-source` — no new tag/author files needed.
- Source: Notion (Kitaru GTM content). Body images converted to AVIF (1200px wide for diagram/screenshot legibility) and uploaded to R2.
- Covers: `kit-langgraph` / `kit-claude` — AVIF for `mainImage.url`, JPEG twin for `seo.ogImage` (social cards reject AVIF).
- Image **alt text uses the SEO captions** authored as comments on each Notion page.
- The only change to the OpenAI post is its `date:` line (re-dated as the series opener).

## Images

- LangGraph: 4 body images (`two-runtimes-one-workflow`, `middleware-doorway`, two UI screenshots) + cover.
- Claude: 2 body images (`one-invocation-checkpoint`, `side-effects-claude-vs-kitaru`) + cover.
- All 10 R2 public URLs verified returning HTTP 200.

## Validation

- [x] `pnpm validate:content` — 0 errors (10 pre-existing slug-format warnings on unrelated posts)
- [x] `pnpm check` — 0 errors / 0 warnings
- [x] `pnpm build` — exit 0; all three `/blog/*-durable-runtime.html` pages generated

## Test plan

- [ ] Verify both new posts render on the Cloudflare Pages preview
- [ ] Confirm cover + body images load and OG cards preview correctly (LinkedIn/Slack)
- [ ] Check external links (LangGraph docs, Kitaru docs, compliance-review example)
- [ ] Confirm blog listing order reflects the staggered dates