### PR TITLE
Add GTM Engineer open position to careers page

### DIFF
--- a/src/lib/company.ts
+++ b/src/lib/company.ts
@@ -98,4 +98,9 @@ export const OPEN_POSITIONS = [
     type: "Full-time",
     href: "https://zenml.notion.site/Product-Engineer-ZenML-Kitaru-341f8dff2538800aa826c2624894dfc8",
   },
+  {
+    title: "GTM Engineer - ZenML/Kitaru (f/m/d)",
+    type: "Full-time",
+    href: "https://zenml.notion.site/GTM-Engineer-ZenML-Kitaru-f-m-d-372f8dff253880e586daeebc8f360a29",
+  },
 ] as const;


### PR DESCRIPTION
## What

Adds a new open position — **GTM Engineer - ZenML/Kitaru (f/m/d)** — to the [careers page](https://www.zenml.io/careers), alongside the existing Product Engineer listing.

## How

The careers page (`src/pages/careers.astro`) renders the `OPEN_POSITIONS` array from `src/lib/company.ts` as a list of cards. This PR adds one entry to that array — no layout changes needed.

```ts
{
  title: "GTM Engineer - ZenML/Kitaru (f/m/d)",
  type: "Full-time",
  href: "https://zenml.notion.site/GTM-Engineer-ZenML-Kitaru-f-m-d-372f8dff253880e586daeebc8f360a29",
},
```

The title uses the same `ZenML/Kitaru (f/m/d)` format as the existing Product Engineer entry for visual consistency in the list (the Notion page title itself uses "&").

## Verification

- `pnpm check` — 0 errors
- `pnpm lint` — clean
- `pnpm build` — succeeds, all pages generated