### PR TITLE
Make LLMOps nav count dynamic

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -4,10 +4,11 @@ import {
   formatStars,
   GITHUB_REPO_URL,
 } from "../lib/githubStars";
+import { getNonDraftLlmopsDatabaseCount } from "../lib/llmops";
 import {
+  createNavDropdowns,
   isActivePath,
   NAV_CTAS,
-  NAV_DROPDOWNS,
   NAV_LINKS,
 } from "../lib/navigation";
 import Button from "./Button.astro";
@@ -24,6 +25,8 @@ interface Props {
 
 const { currentPath = Astro.url.pathname } = Astro.props;
 const headerStarsFallback = formatStars(FALLBACK_STARS);
+const llmopsCaseStudyCount = await getNonDraftLlmopsDatabaseCount();
+const navDropdowns = createNavDropdowns({ llmopsCaseStudyCount });
 ---
 
 <header class="sticky top-0 z-50 w-full bg-white/95 backdrop-blur-sm border-b border-gray-200/60">
@@ -37,7 +40,7 @@ const headerStarsFallback = formatStars(FALLBACK_STARS);
       {/* Desktop Nav */}
       <nav class="hidden lg:flex lg:items-center lg:gap-1 lg:ml-12 h-full" role="navigation" aria-label="Main navigation">
         {/* Dropdown menus */}
-        {NAV_DROPDOWNS.map((dropdown) => dropdown.compact ? (
+        {navDropdowns.map((dropdown) => dropdown.compact ? (
           <div class="group relative flex h-full items-center" data-compact-dropdown>
             <button
               class="flex items-center gap-1 rounded-md px-3 py-2 text-sm font-semibold text-gray-900 transition-colors hover:bg-gray-50"
@@ -304,7 +307,7 @@ const headerStarsFallback = formatStars(FALLBACK_STARS);
     <div class="border-t border-gray-200 bg-white px-4 pb-6 pt-4">
       <nav class="space-y-1" role="navigation" aria-label="Mobile navigation">
         {/* Mobile dropdown sections (as accordions) */}
-        {NAV_DROPDOWNS.map((dropdown) => (
+        {navDropdowns.map((dropdown) => (
           <details class="group/accordion">
             <summary class="flex cursor-pointer items-center justify-between rounded-md px-3 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 list-none [&::-webkit-details-marker]:hidden">
               {dropdown.label}

--- a/src/lib/llmops.ts
+++ b/src/lib/llmops.ts
@@ -10,6 +10,17 @@ import { getCollection, getEntry } from "astro:content";
 
 export type LLMOpsEntry = CollectionEntry<"llmops-database">;
 
+let nonDraftCountPromise: Promise<number> | undefined;
+
+export function getNonDraftLlmopsDatabaseCount(): Promise<number> {
+  nonDraftCountPromise ??= getCollection(
+    "llmops-database",
+    ({ data }) => !data.draft,
+  ).then((entries) => entries.length);
+
+  return nonDraftCountPromise;
+}
+
 // ---------------------------------------------------------------------------
 // Filtering & sorting
 // ---------------------------------------------------------------------------

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -74,85 +74,105 @@ const ICON_DATABASE =
 // Dropdown Menus
 // ---------------------------------------------------------------------------
 
-export const NAV_DROPDOWNS: NavDropdown[] = [
-  {
-    label: "Product",
-    compact: true,
-    sections: [
-      {
-        heading: "Products",
-        links: [
-          {
-            label: "ZenML",
-            href: "/product/zenml",
-            description: "Pipelines for ML workflows",
-            icon: ICON_LIGHTNING,
-          },
-          {
-            label: "Kitaru",
-            href: "/product/kitaru",
-            description: "Durable runtime for AI agents",
-            icon: ICON_AGENT,
-          },
-          {
-            label: "ZenML Pro",
-            href: "/pro",
-            description: "Managed control plane for ML + Agent workspaces",
-            icon: ICON_PRO_GEAR,
-          },
-        ],
-      },
-    ],
-  },
-  {
-    label: "Docs",
-    compact: true,
-    sections: [
-      {
-        heading: "Documentation",
-        links: [
-          {
-            label: "ZenML docs",
-            href: "https://docs.zenml.io",
-            description: "Pipelines, components, integrations",
-            external: true,
-            icon: ICON_BOOK,
-          },
-          {
-            label: "Kitaru docs",
-            href: "https://kitaru.ai/docs",
-            description: "Agent runtime primitives and APIs",
-            external: true,
-            icon: ICON_BOOK,
-          },
-        ],
-      },
-    ],
-  },
-  {
-    label: "Case Studies",
-    compact: true,
-    sections: [
-      {
-        heading: "Case studies",
-        links: [
-          {
-            label: "Customer stories",
-            href: "/case-studies",
-            description: "How teams ship ML and agents with ZenML",
-            icon: ICON_BUILDING,
-          },
-          {
-            label: "LLMOps Database",
-            href: "/llmops-database",
-            description: "1,453 LLMOps case studies, searchable",
-            icon: ICON_DATABASE,
-          },
-        ],
-      },
-    ],
-  },
-];
+const LLMOPS_DATABASE_NAV_COUNT_FORMATTER = new Intl.NumberFormat("en-US");
+const navDropdownsByLlmopsCount = new Map<number, NavDropdown[]>();
+
+export function formatLlmopsDatabaseNavDescription(count: number): string {
+  return `${LLMOPS_DATABASE_NAV_COUNT_FORMATTER.format(count)} LLMOps case studies, searchable`;
+}
+
+export function createNavDropdowns({
+  llmopsCaseStudyCount,
+}: {
+  llmopsCaseStudyCount: number;
+}): NavDropdown[] {
+  const cachedDropdowns = navDropdownsByLlmopsCount.get(llmopsCaseStudyCount);
+  if (cachedDropdowns) return cachedDropdowns;
+
+  const navDropdowns: NavDropdown[] = [
+    {
+      label: "Product",
+      compact: true,
+      sections: [
+        {
+          heading: "Products",
+          links: [
+            {
+              label: "ZenML",
+              href: "/product/zenml",
+              description: "Pipelines for ML workflows",
+              icon: ICON_LIGHTNING,
+            },
+            {
+              label: "Kitaru",
+              href: "/product/kitaru",
+              description: "Durable runtime for AI agents",
+              icon: ICON_AGENT,
+            },
+            {
+              label: "ZenML Pro",
+              href: "/pro",
+              description: "Managed control plane for ML + Agent workspaces",
+              icon: ICON_PRO_GEAR,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      label: "Docs",
+      compact: true,
+      sections: [
+        {
+          heading: "Documentation",
+          links: [
+            {
+              label: "ZenML docs",
+              href: "https://docs.zenml.io",
+              description: "Pipelines, components, integrations",
+              external: true,
+              icon: ICON_BOOK,
+            },
+            {
+              label: "Kitaru docs",
+              href: "https://kitaru.ai/docs",
+              description: "Agent runtime primitives and APIs",
+              external: true,
+              icon: ICON_BOOK,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      label: "Case Studies",
+      compact: true,
+      sections: [
+        {
+          heading: "Case studies",
+          links: [
+            {
+              label: "Customer stories",
+              href: "/case-studies",
+              description: "How teams ship ML and agents with ZenML",
+              icon: ICON_BUILDING,
+            },
+            {
+              label: "LLMOps Database",
+              href: "/llmops-database",
+              description:
+                formatLlmopsDatabaseNavDescription(llmopsCaseStudyCount),
+              icon: ICON_DATABASE,
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  navDropdownsByLlmopsCount.set(llmopsCaseStudyCount, navDropdowns);
+  return navDropdowns;
+}
 
 // ---------------------------------------------------------------------------
 // Direct Links (no dropdown)

--- a/src/pages/llmops-database/index.astro
+++ b/src/pages/llmops-database/index.astro
@@ -13,6 +13,7 @@ import LLMOpsFilter from "../../components/islands/LLMOpsFilter";
 import BrevoNewsletterForm from "../../components/sections/BrevoNewsletterForm.astro";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { BREVO_LLMOPS_CONFIG } from "../../lib/formConstants";
+import { getNonDraftLlmopsDatabaseCount } from "../../lib/llmops";
 
 // Resolve tag + industry display names for the filter UI
 const allTags = (await getCollection("llmops-tags"))
@@ -24,9 +25,7 @@ const allIndustries = (await getCollection("industry-tags"))
   .sort((a, b) => a.name.localeCompare(b.name));
 
 // Count for hero text (non-draft entries)
-const entryCount = (
-  await getCollection("llmops-database", ({ data }) => !data.draft)
-).length;
+const entryCount = await getNonDraftLlmopsDatabaseCount();
 ---
 
 <BaseLayout


### PR DESCRIPTION
## Summary
- compute the LLMOps Database nav count from the Astro content collection at build time
- reuse the same non-draft count helper on the LLMOps database page
- avoid client-side fetches or runtime homepage/API calls for this number
- ran the requested simplify review pass and applied the cleanup findings

## Validation
- pnpm check
- pnpm build

## Notes
- intentionally did not stage or commit unrelated untracked `src/content/llmops-database/*.md` files