### PR TITLE
Add homepage Markdown mirror and schema metadata

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -14,6 +14,7 @@ const sitemapExcludePaths = new Set([
   "/blog/rss.xml",
   "/llmops-database/rss.xml",
   "/mlops-database/rss.xml",
+  "/index.md",
   "/pricing.md",
   "/product/zenml.md",
   "/product/kitaru.md",

--- a/public/_headers
+++ b/public/_headers
@@ -7,7 +7,7 @@
   Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' 'unsafe-inline' https://plausible.io https://*.googletagmanager.com https://cdn.segment.com https://js-eu1.hs-scripts.com https://challenges.cloudflare.com https://js-eu1.hs-analytics.net https://js-eu1.hscollectedforms.net https://js-eu1.hsadspixel.net https://js-eu1.hs-banner.com https://*.hotjar.com https://*.clarity.ms https://static.reo.dev https://t.reo.dev https://app.cal.com https://js.storylane.io https://buttons.github.io https://s3-us-west-2.amazonaws.com https://assets.apollo.io https://cdn.ap3c.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://assets.zenml.io https://static.scarf.sh https://*.google-analytics.com https://*.googletagmanager.com https://*.hotjar.com https://*.clarity.ms https://*.hsforms.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://plausible.io https://*.google-analytics.com https://*.analytics.google.com https://cdn.segment.com https://api.segment.io https://*.hotjar.com https://*.hotjar.io https://*.clarity.ms https://js-eu1.hs-analytics.net https://t.reo.dev https://api.github.com https://capture-api-eu.ortto.app https://63e37fdf.sibforms.com; frame-src https://app.cal.com https://js.storylane.io https://zenml.storylane.io https://challenges.cloudflare.com; worker-src 'self' blob:; report-uri /api/csp-report
 
 /
-  Link: </llms.txt>; rel="help"
+  Link: </llms.txt>; rel="help", </index.md>; rel="alternate"; type="text/markdown"
 
 /pricing
   Link: </llms.txt>; rel="help", </pricing.md>; rel="alternate"; type="text/markdown"

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -24,6 +24,7 @@ ZenML's site is organized into product pages (features, pricing, Pro offering an
 
 These repo-owned Markdown mirrors are alternate, cleaner representations of high-value marketing pages for agents and readers. They omit decorative UI, navigation, analytics snippets, and other browser chrome.
 
+- [Homepage Markdown](https://www.zenml.io/index.md): plain Markdown mirror of the homepage positioning, ZenML and Kitaru workspaces, platform value points, FAQs, and CTAs.
 - [Pricing Markdown](https://www.zenml.io/pricing.md): plain Markdown mirror of pricing plans, Pro inclusions, comparison tables, compliance notes, FAQs, and CTAs.
 - [ZenML Product Markdown](https://www.zenml.io/product/zenml.md): plain Markdown mirror of the ZenML product page for ML pipelines and MLOps orchestration.
 - [Kitaru Product Markdown](https://www.zenml.io/product/kitaru.md): plain Markdown mirror of the Kitaru product page for durable Python agents.

--- a/src/lib/homepageJsonLd.ts
+++ b/src/lib/homepageJsonLd.ts
@@ -1,0 +1,116 @@
+import { SITE_URL } from "./constants";
+import { FAQ } from "./homepage";
+import {
+  HOMEPAGE_UNIFIED_SEO,
+  HOMEPAGE_UNIFIED_VALUES,
+  HOMEPAGE_UNIFIED_WORKSPACES,
+} from "./homepage-unified";
+import { absoluteUrl } from "./seo";
+import { htmlToPlainText } from "./text";
+
+function homepageFeatureList(): string[] {
+  return [
+    ...HOMEPAGE_UNIFIED_WORKSPACES.items.flatMap((workspace) => [
+      `${workspace.name}: ${workspace.tagline}`,
+      ...workspace.bullets,
+    ]),
+    ...HOMEPAGE_UNIFIED_VALUES.items.map(
+      (item) => `${item.name}: ${item.body}`,
+    ),
+  ];
+}
+
+export function buildHomepageJsonLd(): Record<string, unknown> {
+  const organizationId = `${SITE_URL}/#organization`;
+  const webPageId = `${SITE_URL}/#webpage`;
+  const softwareId = `${SITE_URL}/#software`;
+  const breadcrumbId = `${SITE_URL}/#breadcrumb`;
+  const faqId = `${SITE_URL}/#faq`;
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Organization",
+        "@id": organizationId,
+        name: "ZenML",
+        legalName: "ZenML GmbH",
+        url: SITE_URL,
+        logo: absoluteUrl("/images/zenml-logo.svg"),
+        sameAs: [
+          "https://github.com/zenml-io/zenml",
+          "https://twitter.com/zenml_io",
+          "https://www.linkedin.com/company/zenml",
+        ],
+        address: {
+          "@type": "PostalAddress",
+          streetAddress: "Schellingstr. 36",
+          postalCode: "80799",
+          addressLocality: "Munich",
+          addressCountry: "DE",
+        },
+        contactPoint: {
+          "@type": "ContactPoint",
+          contactType: "sales",
+          url: absoluteUrl("/book-your-demo"),
+        },
+      },
+      {
+        "@type": "WebPage",
+        "@id": webPageId,
+        url: SITE_URL,
+        name: HOMEPAGE_UNIFIED_SEO.title,
+        description: HOMEPAGE_UNIFIED_SEO.description,
+        publisher: { "@id": organizationId },
+        mainEntity: { "@id": softwareId },
+        breadcrumb: { "@id": breadcrumbId },
+      },
+      {
+        "@type": "BreadcrumbList",
+        "@id": breadcrumbId,
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "Home",
+            item: SITE_URL,
+          },
+        ],
+      },
+      {
+        "@type": "SoftwareApplication",
+        "@id": softwareId,
+        name: "ZenML",
+        applicationCategory: "DeveloperApplication",
+        url: SITE_URL,
+        description: HOMEPAGE_UNIFIED_SEO.description,
+        publisher: { "@id": organizationId },
+        featureList: homepageFeatureList(),
+        potentialAction: [
+          {
+            "@type": "ContactAction",
+            name: "Book a demo",
+            target: absoluteUrl("/book-your-demo"),
+          },
+          {
+            "@type": "ReadAction",
+            name: "Read Docs",
+            target: absoluteUrl("/docs"),
+          },
+        ],
+      },
+      {
+        "@type": "FAQPage",
+        "@id": faqId,
+        mainEntity: FAQ.items.map((item) => ({
+          "@type": "Question",
+          name: item.question,
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: htmlToPlainText(item.answer),
+          },
+        })),
+      },
+    ],
+  };
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,40 +25,10 @@ import JsonLd from "../components/seo/JsonLd.astro";
  * Route: / (homepage)
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
-import { SITE_URL } from "../lib/constants";
-import { FAQ } from "../lib/homepage";
 import { HOMEPAGE_UNIFIED_SEO } from "../lib/homepage-unified";
+import { buildHomepageJsonLd } from "../lib/homepageJsonLd";
 
-/** Strip HTML tags from a string (for JSON-LD plain text) */
-function stripHtml(html: string): string {
-  return html.replace(/<[^>]+>/g, "");
-}
-
-const orgJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "Organization",
-  name: "ZenML",
-  url: SITE_URL,
-  logo: `${SITE_URL}/images/zenml-logo.svg`,
-  sameAs: [
-    "https://github.com/zenml-io/zenml",
-    "https://twitter.com/zenml_io",
-    "https://www.linkedin.com/company/zenml",
-  ],
-};
-
-const faqJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  mainEntity: FAQ.items.map((item) => ({
-    "@type": "Question",
-    name: item.question,
-    acceptedAnswer: {
-      "@type": "Answer",
-      text: stripHtml(item.answer),
-    },
-  })),
-};
+const homepageJsonLd = buildHomepageJsonLd();
 ---
 
 <BaseLayout
@@ -67,8 +37,7 @@ const faqJsonLd = {
   ogTitle={HOMEPAGE_UNIFIED_SEO.title}
   surface={HOMEPAGE_UNIFIED_SEO.surface}
 >
-  <JsonLd data={orgJsonLd} slot="head" />
-  <JsonLd data={faqJsonLd} slot="head" />
+  <JsonLd data={homepageJsonLd} slot="head" />
   <UnifiedAnnouncementBanner slot="before-nav" />
 
   <main>

--- a/src/pages/index.md.ts
+++ b/src/pages/index.md.ts
@@ -10,7 +10,6 @@ import { FAQ } from "../lib/homepage";
 import {
   HOMEPAGE_UNIFIED_FINAL_CTA,
   HOMEPAGE_UNIFIED_HERO,
-  HOMEPAGE_UNIFIED_PRICING_TEASER,
   HOMEPAGE_UNIFIED_SEO,
   HOMEPAGE_UNIFIED_VALUES,
   HOMEPAGE_UNIFIED_WORKSPACES,
@@ -83,14 +82,6 @@ export function GET(): Response {
       HOMEPAGE_UNIFIED_WORKSPACES.items.map(renderWorkspace).join("\n\n"),
     ),
     renderValues(),
-    joinMarkdownSections(
-      `## ${HOMEPAGE_UNIFIED_PRICING_TEASER.headline}`,
-      HOMEPAGE_UNIFIED_PRICING_TEASER.body,
-      markdownCtaList([
-        HOMEPAGE_UNIFIED_PRICING_TEASER.primaryCta,
-        HOMEPAGE_UNIFIED_PRICING_TEASER.secondaryCta,
-      ]),
-    ),
     joinMarkdownSections(
       "## Key product links",
       markdownBulletList([

--- a/src/pages/index.md.ts
+++ b/src/pages/index.md.ts
@@ -1,0 +1,115 @@
+import {
+  joinMarkdownSections,
+  markdownBulletList,
+  markdownCtaList,
+  markdownLink,
+  markdownPreamble,
+  markdownResponse,
+} from "../lib/agentMarkdown";
+import { FAQ } from "../lib/homepage";
+import {
+  HOMEPAGE_UNIFIED_FINAL_CTA,
+  HOMEPAGE_UNIFIED_HERO,
+  HOMEPAGE_UNIFIED_PRICING_TEASER,
+  HOMEPAGE_UNIFIED_SEO,
+  HOMEPAGE_UNIFIED_VALUES,
+  HOMEPAGE_UNIFIED_WORKSPACES,
+} from "../lib/homepage-unified";
+import { htmlToPlainText } from "../lib/text";
+
+export const prerender = true;
+
+function renderWorkspace(
+  workspace: (typeof HOMEPAGE_UNIFIED_WORKSPACES.items)[number],
+): string {
+  return joinMarkdownSections(
+    `### ${workspace.name}`,
+    workspace.tagline,
+    workspace.body,
+    markdownBulletList(workspace.bullets),
+    `CTA: ${markdownLink(workspace.cta.label, workspace.cta.href)}`,
+  );
+}
+
+function renderValues(): string {
+  return joinMarkdownSections(
+    `## ${HOMEPAGE_UNIFIED_VALUES.headline}`,
+    ...HOMEPAGE_UNIFIED_VALUES.items.map((item) =>
+      joinMarkdownSections(`### ${item.name}`, item.body),
+    ),
+  );
+}
+
+function renderFaq(): string {
+  return joinMarkdownSections(
+    `## ${FAQ.headline}`,
+    FAQ.subheadline,
+    FAQ.items
+      .map((item) =>
+        joinMarkdownSections(
+          `### ${item.question}`,
+          htmlToPlainText(item.answer),
+        ),
+      )
+      .join("\n\n"),
+    `${markdownLink(FAQ.slackCta.label, FAQ.slackCta.href)}`,
+  );
+}
+
+export function GET(): Response {
+  const markdown = joinMarkdownSections(
+    markdownPreamble({
+      title: HOMEPAGE_UNIFIED_SEO.title,
+      description: HOMEPAGE_UNIFIED_SEO.description,
+      canonicalPath: "/",
+    }),
+    joinMarkdownSections(
+      "## Summary",
+      `${HOMEPAGE_UNIFIED_HERO.subtitleLead} ${HOMEPAGE_UNIFIED_HERO.subtitle}`,
+      "ZenML presents one platform for two related workloads: reproducible ML pipelines in the ZenML workspace, and production AI agents in the Kitaru workspace.",
+    ),
+    joinMarkdownSections(
+      "## Main CTAs",
+      markdownCtaList([
+        HOMEPAGE_UNIFIED_HERO.primaryCta,
+        HOMEPAGE_UNIFIED_HERO.secondaryCta,
+        HOMEPAGE_UNIFIED_FINAL_CTA.primaryCta,
+        HOMEPAGE_UNIFIED_FINAL_CTA.secondaryCta,
+      ]),
+    ),
+    joinMarkdownSections(
+      `## ${HOMEPAGE_UNIFIED_WORKSPACES.headline}`,
+      HOMEPAGE_UNIFIED_WORKSPACES.note,
+      HOMEPAGE_UNIFIED_WORKSPACES.items.map(renderWorkspace).join("\n\n"),
+    ),
+    renderValues(),
+    joinMarkdownSections(
+      `## ${HOMEPAGE_UNIFIED_PRICING_TEASER.headline}`,
+      HOMEPAGE_UNIFIED_PRICING_TEASER.body,
+      markdownCtaList([
+        HOMEPAGE_UNIFIED_PRICING_TEASER.primaryCta,
+        HOMEPAGE_UNIFIED_PRICING_TEASER.secondaryCta,
+      ]),
+    ),
+    joinMarkdownSections(
+      "## Key product links",
+      markdownBulletList([
+        `${markdownLink("ZenML product page", "/product/zenml")} — ML pipelines and MLOps orchestration.`,
+        `${markdownLink("Kitaru product page", "/product/kitaru")} — durable Python agents with record, replay, and improvement workflows.`,
+        `${markdownLink("Pricing", "/pricing")} — unified plans for ML, agent, or both workloads.`,
+        `${markdownLink("Documentation", "/docs")} — product docs, tutorials, and setup guides.`,
+      ]),
+    ),
+    renderFaq(),
+    joinMarkdownSections(
+      `## ${HOMEPAGE_UNIFIED_FINAL_CTA.headline}`,
+      HOMEPAGE_UNIFIED_FINAL_CTA.body,
+      markdownCtaList([
+        HOMEPAGE_UNIFIED_FINAL_CTA.primaryCta,
+        HOMEPAGE_UNIFIED_FINAL_CTA.secondaryCta,
+      ]),
+    ),
+  );
+
+  return markdownResponse(markdown);
+}


### PR DESCRIPTION
## Summary

Adds the confirmed P1 agent-readiness fixes from the Ora suggestions investigation:

- Adds `/index.md` as a repo-owned Markdown mirror of the homepage
- Enriches homepage JSON-LD via a dedicated `buildHomepageJsonLd()` helper
- Advertises the homepage Markdown mirror from root headers and `llms.txt`
- Excludes `/index.md` from the generated sitemap so `/` stays canonical

## What reviewers should focus on

- Whether the homepage Markdown mirror captures the right high-level positioning without becoming too verbose
- Whether the homepage JSON-LD is factual and appropriately scoped
- Whether the discovery headers advertise only routes that now exist

## Validation

- `pnpm check` ✅
- `pnpm lint` ✅
- `pnpm build` ✅
- Verified `dist/index.md` exists ✅
- Verified `dist/sitemap-0.xml` does not include `index.md` ✅

## Notes

- Intentionally did not add `/.well-known/agent.json`, robots crawler rules, `Vary: Accept`, or broad Markdown mirror expansion.
- No screenshots included: this change affects Markdown/metadata/discovery output, not visual UI.
