### PR TITLE
Add Kitaru-branded `/book-your-demo/kitaru` demo page

### DIFF
--- a/src/components/BookingExperience.astro
+++ b/src/components/BookingExperience.astro
@@ -1,0 +1,281 @@
+---
+import {
+  CAL_EMBED_SCRIPT,
+  CAL_ORIGIN,
+  TURNSTILE_SITE_KEY,
+} from "../lib/formConstants";
+import type { CalEmbedConfig, PlaceholderField } from "../lib/formTypes";
+import KitaruLogo from "./brand/KitaruLogo.astro";
+/**
+ * BookingExperience — shared two-column demo-booking body.
+ *
+ * Rendered by both /book-your-demo (ZenML) and /book-your-demo/kitaru
+ * (Kitaru co-brand). Everything that differs between the two is a prop;
+ * the markup, form wiring, and calendar-transition script are shared so
+ * the two routes can never drift apart.
+ *
+ * Brand colour: the page uses `text-zenml-500` / `bg-zenml-500` utilities
+ * throughout (including inside the DemoRequestForm island). Those compile
+ * to `var(--color-zenml-500)`, so the Kitaru variant re-skins the whole
+ * subtree to orange by overriding that variable on the wrapper
+ * (`.booking-brand-kitaru` below) — no per-element or per-island edits.
+ *
+ * NOTE: this deliberately does NOT use the usual `data-app="kitaru"` brand
+ * switch. The `--color-zenml-*` ladder is intentionally data-app-invariant
+ * (global.css), so `data-app="kitaru"` would leave these utilities purple;
+ * and the form island hardcodes `bg-zenml-500`, which `text-primary` can't
+ * reach. Overriding `--color-zenml-*` locally is the one lever that recolours
+ * both the markup and the island. If you audit Kitaru surfaces by grepping
+ * `data-app="kitaru"`, remember this page brands itself a different way.
+ */
+import DemoRequestForm from "./islands/DemoRequestForm.tsx";
+
+interface Props {
+  /** Drives the header logo and the orange brand-token override. */
+  brand: "zenml" | "kitaru";
+  /** Where the header logo links ("/" for ZenML, "/product/kitaru" for Kitaru). */
+  homeHref: string;
+  hero: {
+    headlinePrefix: string;
+    headlineHighlight: string;
+    headlineSuffix: string;
+    deck: string;
+  };
+  /** Optional credibility line shown above the customer logos. */
+  proofLabel?: string;
+  /** Optional 2×2 stat grid. Omit to hide it (Kitaru co-brand does). */
+  stats?: { value: string; label: string }[];
+  logos: { name: string; src: string }[];
+  form: {
+    headline: string;
+    deck: string;
+    calHeadline: string;
+    calDeck: string;
+  };
+  fields: PlaceholderField[];
+  cal: CalEmbedConfig;
+  testimonial: {
+    quote: string;
+    name: string;
+    position: string;
+    avatar: string;
+  };
+}
+
+const {
+  brand,
+  homeHref,
+  hero,
+  proofLabel,
+  stats,
+  logos,
+  form,
+  fields,
+  cal,
+  testimonial,
+} = Astro.props;
+const isKitaru = brand === "kitaru";
+---
+
+<div class:list={["booking-root", isKitaru && "booking-brand-kitaru"]}>
+  {/* Logo header */}
+  <header class="border-b border-gray-100 bg-white">
+    <div class="mx-auto max-w-7xl px-4 py-4 sm:px-6 lg:px-8">
+      {isKitaru ? (
+        <a href={homeHref} aria-label="Kitaru home" class="inline-flex text-gray-900">
+          <KitaruLogo class="h-7 w-auto" />
+        </a>
+      ) : (
+        <a href={homeHref} aria-label="ZenML home">
+          <img
+            src="/images/zenml-logo.svg"
+            alt="ZenML"
+            width="115"
+            height="28"
+            class="h-7 w-auto"
+          />
+        </a>
+      )}
+    </div>
+  </header>
+
+  <main class="bg-white">
+    {/* Two-column section */}
+    <section class="py-12 sm:py-16 lg:py-20">
+      <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div id="demo-form-grid" class="grid items-start gap-12 lg:grid-cols-2 lg:gap-16">
+          {/* ── Left column: marketing copy ── */}
+          <div id="demo-form-marketing">
+            <h1 class="text-3xl font-bold text-gray-900 sm:text-4xl">
+              {hero.headlinePrefix}<span class="text-zenml-500">{hero.headlineHighlight}</span>{hero.headlineSuffix}
+            </h1>
+            <p class="mt-4 text-base leading-relaxed text-gray-600 sm:text-lg">
+              {hero.deck}
+            </p>
+
+            {/* Stats 2×2 grid */}
+            {stats && stats.length > 0 && (
+              <div class="mt-10 grid grid-cols-2 gap-4">
+                {stats.map((stat) => (
+                  <div class="rounded-lg border border-gray-200 px-4 py-5">
+                    <p class="text-2xl font-bold text-gray-900 sm:text-3xl">
+                      {stat.value}
+                    </p>
+                    <p class="mt-1 text-xs leading-snug text-gray-500 sm:text-sm">
+                      {stat.label}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Co-brand credibility line */}
+            {proofLabel && (
+              <p class="mt-10 text-sm font-medium leading-relaxed text-gray-600">
+                {proofLabel}
+              </p>
+            )}
+
+            {/* Customer logos */}
+            <div class:list={["flex flex-wrap items-center gap-6 sm:gap-8", proofLabel ? "mt-6" : "mt-10"]}>
+              {logos.map((logo) => (
+                <img
+                  src={logo.src}
+                  alt={logo.name}
+                  class="h-6 max-w-[100px] object-contain sm:h-7 sm:max-w-[120px]"
+                  loading="lazy"
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* ── Right column: form → calendar ── */}
+          <div id="demo-form-col" data-cal-headline={form.calHeadline} data-cal-deck={form.calDeck}>
+            <h2 id="demo-form-heading" class="text-2xl font-bold text-gray-900 sm:text-3xl">
+              {form.headline}
+            </h2>
+            <p id="demo-form-deck" class="mt-2 text-sm text-gray-500">
+              {form.deck}
+            </p>
+
+            <div class="mt-6">
+              <DemoRequestForm
+                client:load
+                endpoint="/api/forms/demo-request"
+                fields={fields}
+                submitLabel="Send Request"
+                loadingLabel="Sending…"
+                calConfig={cal}
+                calOrigin={CAL_ORIGIN}
+                calEmbedScript={CAL_EMBED_SCRIPT}
+                turnstileSiteKey={TURNSTILE_SITE_KEY}
+              />
+            </div>
+
+            {/* Privacy note */}
+            <p id="demo-form-privacy" class="mt-3 text-center text-xs text-gray-400">
+              By continuing, you agree to our{" "}
+              <a href="/privacy-policy" class="text-zenml-500 underline hover:text-zenml-600">
+                privacy policy
+              </a>.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    {/* Testimonial */}
+    <section class="border-t border-gray-100 bg-gray-50 py-10 sm:py-14">
+      <div class="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
+        <div class="flex flex-col items-center gap-6 sm:flex-row sm:items-start sm:gap-8">
+          <img
+            src={testimonial.avatar}
+            alt={testimonial.name}
+            class="h-16 w-16 flex-shrink-0 rounded-full object-cover"
+            loading="lazy"
+          />
+          <div>
+            <blockquote class="text-base leading-relaxed text-gray-700 sm:text-lg">
+              {testimonial.quote}
+            </blockquote>
+            <p class="mt-3 text-sm font-semibold text-gray-900">
+              {testimonial.name}<span class="font-normal text-gray-500">, {testimonial.position}</span>
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  {/* Minimal footer */}
+  <footer class="border-t border-gray-100 bg-white py-6">
+    <div class="mx-auto flex max-w-7xl flex-col items-center justify-between gap-4 px-4 text-sm text-gray-400 sm:flex-row sm:px-6 lg:px-8">
+      <p>&copy; {new Date().getFullYear()} ZenML. All rights reserved.</p>
+      <nav class="flex gap-6">
+        <a href="/imprint" class="hover:text-gray-600">Imprint</a>
+        <a href="/privacy-policy" class="hover:text-gray-600">Privacy Policy</a>
+        <a href="/terms-of-service" class="hover:text-gray-600">Terms of Service</a>
+      </nav>
+    </div>
+  </footer>
+</div>
+
+<style>
+  /* Kitaru co-brand: re-skin the ZenML brand utilities (headline accent,
+     privacy link, form submit button + focus rings) to Kitaru orange by
+     overriding the CSS variables those utilities resolve. `--primary`
+     drives the Kitaru logo ring glyph. */
+  .booking-brand-kitaru {
+    --color-zenml-500: var(--color-orange-600);
+    --color-zenml-600: var(--color-orange-700);
+    --primary: var(--color-orange-600);
+  }
+
+  @keyframes demoFormSlideUp {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+  /* Applied by JS when calendar replaces the form */
+  #demo-form-grid.demo-cal-active {
+    grid-template-columns: 1fr;
+    max-width: 56rem;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  #demo-form-marketing.demo-cal-hidden {
+    display: none;
+  }
+</style>
+
+{/* Transition: update heading & hide privacy note when calendar appears */}
+<script is:inline>
+  (function () {
+    var target = document.getElementById("demo-form-col");
+    if (!target) return;
+    var calHeadline = target.getAttribute("data-cal-headline") || "";
+    var calDeck = target.getAttribute("data-cal-deck") || "";
+    var observer = new MutationObserver(function () {
+      if (target.querySelector(".demo-form-calendar-transition")) {
+        var heading = document.getElementById("demo-form-heading");
+        var deck = document.getElementById("demo-form-deck");
+        var privacy = document.getElementById("demo-form-privacy");
+        var grid = document.getElementById("demo-form-grid");
+        var marketing = document.getElementById("demo-form-marketing");
+        if (heading) { heading.style.transition = "opacity 0.3s"; heading.style.opacity = "0"; }
+        if (deck) { deck.style.transition = "opacity 0.3s"; deck.style.opacity = "0"; }
+        if (privacy) { privacy.style.transition = "opacity 0.3s"; privacy.style.opacity = "0"; }
+        if (marketing) { marketing.style.transition = "opacity 0.3s"; marketing.style.opacity = "0"; }
+        // Timeout matches the 0.3s CSS transition so layout changes after fade-out completes
+        setTimeout(function () {
+          if (heading) { heading.textContent = calHeadline; heading.style.opacity = "1"; }
+          if (deck) { deck.textContent = calDeck; deck.style.opacity = "1"; }
+          if (privacy) privacy.style.display = "none";
+          if (marketing) { marketing.style.opacity = ""; marketing.style.transition = ""; marketing.classList.add("demo-cal-hidden"); }
+          if (grid) grid.classList.add("demo-cal-active");
+        }, 300);
+        observer.disconnect();
+      }
+    });
+    observer.observe(target, { childList: true, subtree: true });
+  })();
+</script>

--- a/src/components/compare/kitaru/ComparisonCta.astro
+++ b/src/components/compare/kitaru/ComparisonCta.astro
@@ -1,4 +1,6 @@
 ---
+import { KITARU_LINKS } from "../../../lib/productKitaru";
+
 interface Props {
   headline: string;
   eyebrow?: string;
@@ -10,7 +12,7 @@ const {
   headline,
   eyebrow = "The lifecycle layer underneath",
   primaryCtaText = "Book a demo",
-  primaryCtaHref = "/book-your-demo",
+  primaryCtaHref = KITARU_LINKS.demo.href,
 } = Astro.props;
 ---
 
@@ -64,7 +66,7 @@ const {
         <span>Read the docs</span>
       </a>
       <span class="ccta-dot" aria-hidden="true"></span>
-      <a href="/book-your-demo" class="ccta-link">
+      <a href={KITARU_LINKS.demo.href} class="ccta-link">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
         </svg>

--- a/src/components/compare/kitaru/ComparisonHero.astro
+++ b/src/components/compare/kitaru/ComparisonHero.astro
@@ -1,4 +1,6 @@
 ---
+import { KITARU_LINKS } from "../../../lib/productKitaru";
+
 interface CompetitorOption {
   slug: string;
   competitor: string;
@@ -173,7 +175,7 @@ const hasOptions = competitorOptions.length > 0;
           </svg>
         </button>
       </div>
-      <a href="/book-your-demo" class="btn-primary">Book a demo</a>
+      <a href={KITARU_LINKS.demo.href} class="btn-primary">Book a demo</a>
       <a href="https://docs.zenml.io/kitaru" target="_blank" rel="noopener noreferrer" class="btn-secondary">Read the docs</a>
     </div>
   </div>

--- a/src/lib/bookYourDemo.ts
+++ b/src/lib/bookYourDemo.ts
@@ -133,3 +133,29 @@ export const BOOK_YOUR_DEMO_TESTIMONIAL = {
   position: "SPV R&D at HashiCorp",
   avatar: `${R2}/31a5f8ee/653297b0b924af52998661bf_harold.webp`,
 };
+
+// ---------------------------------------------------------------------------
+// Kitaru co-brand variant — /book-your-demo/kitaru
+// ---------------------------------------------------------------------------
+// Reached from the Kitaru landing CTAs (/product/kitaru). Reuses the same
+// form, fields, Cal.com link, customer logos, and testimonial as the ZenML
+// page; only the hero copy, SEO, and co-brand credibility line differ. The
+// orange brand colour is handled in BookingExperience.astro, not here.
+
+export const BOOK_KITARU_DEMO_SEO: SEOProps = {
+  title: "Book a Kitaru demo",
+  description:
+    "See Kitaru in action — the open-source durable runtime for Python agents. Record every step, replay with overrides, and ship updates with confidence. 30 minutes with the ZenML team.",
+  // ogTitle / ogDescription intentionally omitted — resolveSeo() falls back to title / description.
+};
+
+export const BOOK_KITARU_DEMO_HERO = {
+  headlinePrefix: "See ",
+  headlineHighlight: "Kitaru",
+  headlineSuffix: " in action",
+  deck: "Get a personalized walkthrough of Kitaru: record, replay, and improve your Python agents with durable checkpoints, wait/resume, and versioned deployments on your own cloud. 30 minutes with our team.",
+};
+
+/** Co-brand credibility line shown above the customer logos on the Kitaru page. */
+export const BOOK_KITARU_DEMO_PROOF =
+  "Built by the ZenML team — trusted by 1,000+ teams running ML and AI agents in production.";

--- a/src/lib/productKitaru.ts
+++ b/src/lib/productKitaru.ts
@@ -2,7 +2,7 @@ export const KITARU_INSTALL_CMD = "pip install kitaru";
 export const KITARU_LICENSE = "Apache 2.0";
 
 export const KITARU_LINKS = {
-  demo: { label: "Book a demo", href: "/book-your-demo" },
+  demo: { label: "Book a demo", href: "/book-your-demo/kitaru" },
   github: {
     label: "Star on GitHub",
     href: "https://github.com/zenml-io/kitaru",

--- a/src/pages/book-your-demo.astro
+++ b/src/pages/book-your-demo.astro
@@ -1,13 +1,12 @@
 ---
-import DemoRequestForm from "../components/islands/DemoRequestForm.tsx";
+import BookingExperience from "../components/BookingExperience.astro";
 /**
  * Book Your Demo — conversion-optimized two-column layout.
  *
  * Route: /book-your-demo
  * Minimal chrome (no full nav/footer) to reduce distraction.
- * Left: marketing copy + stats + customer logos.
- * Right: ContactForm (demo-request).
- * Below: testimonial + simple footer.
+ * Body markup lives in BookingExperience.astro, shared with the Kitaru
+ * co-brand variant at /book-your-demo/kitaru.
  */
 import MinimalLayout from "../layouts/MinimalLayout.astro";
 import {
@@ -20,11 +19,6 @@ import {
   BOOK_YOUR_DEMO_STATS,
   BOOK_YOUR_DEMO_TESTIMONIAL,
 } from "../lib/bookYourDemo";
-import {
-  CAL_EMBED_SCRIPT,
-  CAL_ORIGIN,
-  TURNSTILE_SITE_KEY,
-} from "../lib/formConstants";
 ---
 
 <MinimalLayout
@@ -34,180 +28,15 @@ import {
   ogDescription={BOOK_YOUR_DEMO_SEO.ogDescription}
   surface="unified"
 >
-  {/* Logo header */}
-  <header class="border-b border-gray-100 bg-white">
-    <div class="mx-auto max-w-7xl px-4 py-4 sm:px-6 lg:px-8">
-      <a href="/" aria-label="ZenML home">
-        <img
-          src="/images/zenml-logo.svg"
-          alt="ZenML"
-          width="115"
-          height="28"
-          class="h-7 w-auto"
-        />
-      </a>
-    </div>
-  </header>
-
-  <main class="bg-white">
-    {/* Two-column section */}
-    <section class="py-12 sm:py-16 lg:py-20">
-      <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div id="demo-form-grid" class="grid items-start gap-12 lg:grid-cols-2 lg:gap-16">
-          {/* ── Left column: marketing copy ── */}
-          <div id="demo-form-marketing">
-            <h1 class="text-3xl font-bold text-gray-900 sm:text-4xl">
-              {BOOK_YOUR_DEMO_HERO.headlinePrefix}<span class="text-zenml-500">{BOOK_YOUR_DEMO_HERO.headlineHighlight}</span>{BOOK_YOUR_DEMO_HERO.headlineSuffix}
-            </h1>
-            <p class="mt-4 text-base leading-relaxed text-gray-600 sm:text-lg">
-              {BOOK_YOUR_DEMO_HERO.deck}
-            </p>
-
-            {/* Stats 2×2 grid */}
-            <div class="mt-10 grid grid-cols-2 gap-4">
-              {BOOK_YOUR_DEMO_STATS.map((stat) => (
-                <div class="rounded-lg border border-gray-200 px-4 py-5">
-                  <p class="text-2xl font-bold text-gray-900 sm:text-3xl">
-                    {stat.value}
-                  </p>
-                  <p class="mt-1 text-xs leading-snug text-gray-500 sm:text-sm">
-                    {stat.label}
-                  </p>
-                </div>
-              ))}
-            </div>
-
-            {/* Customer logos */}
-            <div class="mt-10 flex flex-wrap items-center gap-6 sm:gap-8">
-              {BOOK_YOUR_DEMO_LOGOS.map((logo) => (
-                <img
-                  src={logo.src}
-                  alt={logo.name}
-                  class="h-6 max-w-[100px] object-contain sm:h-7 sm:max-w-[120px]"
-                  loading="lazy"
-                />
-              ))}
-            </div>
-          </div>
-
-          {/* ── Right column: form → calendar ── */}
-          <div id="demo-form-col" data-cal-headline={BOOK_YOUR_DEMO_FORM.calHeadline} data-cal-deck={BOOK_YOUR_DEMO_FORM.calDeck}>
-            <h2 id="demo-form-heading" class="text-2xl font-bold text-gray-900 sm:text-3xl">
-              {BOOK_YOUR_DEMO_FORM.headline}
-            </h2>
-            <p id="demo-form-deck" class="mt-2 text-sm text-gray-500">
-              {BOOK_YOUR_DEMO_FORM.deck}
-            </p>
-
-            <div class="mt-6">
-              <DemoRequestForm
-                client:load
-                endpoint="/api/forms/demo-request"
-                fields={BOOK_YOUR_DEMO_FIELDS}
-                submitLabel="Send Request"
-                loadingLabel="Sending…"
-                calConfig={BOOK_YOUR_DEMO_CAL}
-                calOrigin={CAL_ORIGIN}
-                calEmbedScript={CAL_EMBED_SCRIPT}
-                turnstileSiteKey={TURNSTILE_SITE_KEY}
-              />
-            </div>
-
-            {/* Privacy note */}
-            <p id="demo-form-privacy" class="mt-3 text-center text-xs text-gray-400">
-              By continuing, you agree to our{" "}
-              <a href="/privacy-policy" class="text-zenml-500 underline hover:text-zenml-600">
-                privacy policy
-              </a>.
-            </p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    {/* Testimonial */}
-    <section class="border-t border-gray-100 bg-gray-50 py-10 sm:py-14">
-      <div class="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
-        <div class="flex flex-col items-center gap-6 sm:flex-row sm:items-start sm:gap-8">
-          <img
-            src={BOOK_YOUR_DEMO_TESTIMONIAL.avatar}
-            alt={BOOK_YOUR_DEMO_TESTIMONIAL.name}
-            class="h-16 w-16 flex-shrink-0 rounded-full object-cover"
-            loading="lazy"
-          />
-          <div>
-            <blockquote class="text-base leading-relaxed text-gray-700 sm:text-lg">
-              {BOOK_YOUR_DEMO_TESTIMONIAL.quote}
-            </blockquote>
-            <p class="mt-3 text-sm font-semibold text-gray-900">
-              {BOOK_YOUR_DEMO_TESTIMONIAL.name}<span class="font-normal text-gray-500">, {BOOK_YOUR_DEMO_TESTIMONIAL.position}</span>
-            </p>
-          </div>
-        </div>
-      </div>
-    </section>
-  </main>
-
-  {/* Keyframes for calendar slide-in animation */}
-  <style>
-    @keyframes demoFormSlideUp {
-      from { opacity: 0; transform: translateY(20px); }
-      to { opacity: 1; transform: translateY(0); }
-    }
-    /* Applied by JS when calendar replaces the form */
-    #demo-form-grid.demo-cal-active {
-      grid-template-columns: 1fr;
-      max-width: 56rem;
-      margin-left: auto;
-      margin-right: auto;
-    }
-    #demo-form-marketing.demo-cal-hidden {
-      display: none;
-    }
-  </style>
-
-  {/* Transition: update heading & hide privacy note when calendar appears */}
-  <script is:inline>
-    (function () {
-      var target = document.getElementById("demo-form-col");
-      if (!target) return;
-      var calHeadline = target.getAttribute("data-cal-headline") || "";
-      var calDeck = target.getAttribute("data-cal-deck") || "";
-      var observer = new MutationObserver(function () {
-        if (target.querySelector(".demo-form-calendar-transition")) {
-          var heading = document.getElementById("demo-form-heading");
-          var deck = document.getElementById("demo-form-deck");
-          var privacy = document.getElementById("demo-form-privacy");
-          var grid = document.getElementById("demo-form-grid");
-          var marketing = document.getElementById("demo-form-marketing");
-          if (heading) { heading.style.transition = "opacity 0.3s"; heading.style.opacity = "0"; }
-          if (deck) { deck.style.transition = "opacity 0.3s"; deck.style.opacity = "0"; }
-          if (privacy) { privacy.style.transition = "opacity 0.3s"; privacy.style.opacity = "0"; }
-          if (marketing) { marketing.style.transition = "opacity 0.3s"; marketing.style.opacity = "0"; }
-          // Timeout matches the 0.3s CSS transition so layout changes after fade-out completes
-          setTimeout(function () {
-            if (heading) { heading.textContent = calHeadline; heading.style.opacity = "1"; }
-            if (deck) { deck.textContent = calDeck; deck.style.opacity = "1"; }
-            if (privacy) privacy.style.display = "none";
-            if (marketing) { marketing.style.opacity = ""; marketing.style.transition = ""; marketing.classList.add("demo-cal-hidden"); }
-            if (grid) grid.classList.add("demo-cal-active");
-          }, 300);
-          observer.disconnect();
-        }
-      });
-      observer.observe(target, { childList: true, subtree: true });
-    })();
-  </script>
-
-  {/* Minimal footer */}
-  <footer class="border-t border-gray-100 bg-white py-6">
-    <div class="mx-auto flex max-w-7xl flex-col items-center justify-between gap-4 px-4 text-sm text-gray-400 sm:flex-row sm:px-6 lg:px-8">
-      <p>&copy; {new Date().getFullYear()} ZenML. All rights reserved.</p>
-      <nav class="flex gap-6">
-        <a href="/imprint" class="hover:text-gray-600">Imprint</a>
-        <a href="/privacy-policy" class="hover:text-gray-600">Privacy Policy</a>
-        <a href="/terms-of-service" class="hover:text-gray-600">Terms of Service</a>
-      </nav>
-    </div>
-  </footer>
+  <BookingExperience
+    brand="zenml"
+    homeHref="/"
+    hero={BOOK_YOUR_DEMO_HERO}
+    stats={BOOK_YOUR_DEMO_STATS}
+    logos={BOOK_YOUR_DEMO_LOGOS}
+    form={BOOK_YOUR_DEMO_FORM}
+    fields={BOOK_YOUR_DEMO_FIELDS}
+    cal={BOOK_YOUR_DEMO_CAL}
+    testimonial={BOOK_YOUR_DEMO_TESTIMONIAL}
+  />
 </MinimalLayout>

--- a/src/pages/book-your-demo/kitaru.astro
+++ b/src/pages/book-your-demo/kitaru.astro
@@ -1,0 +1,43 @@
+---
+import BookingExperience from "../../components/BookingExperience.astro";
+/**
+ * Book a Kitaru demo — co-brand variant of /book-your-demo.
+ *
+ * Route: /book-your-demo/kitaru
+ * Reached from the Kitaru landing CTAs (/product/kitaru). Same form and
+ * calendar flow as the ZenML page, but Kitaru-branded (wordmark, orange
+ * accent, agent-focused copy) so visitors don't bounce from a sudden
+ * ZenML/MLOps pitch. surface="agent" tags the pageview as Kitaru-side.
+ */
+import MinimalLayout from "../../layouts/MinimalLayout.astro";
+import {
+  BOOK_KITARU_DEMO_HERO,
+  BOOK_KITARU_DEMO_PROOF,
+  BOOK_KITARU_DEMO_SEO,
+  BOOK_YOUR_DEMO_CAL,
+  BOOK_YOUR_DEMO_FIELDS,
+  BOOK_YOUR_DEMO_FORM,
+  BOOK_YOUR_DEMO_LOGOS,
+  BOOK_YOUR_DEMO_TESTIMONIAL,
+} from "../../lib/bookYourDemo";
+---
+
+<MinimalLayout
+  title={BOOK_KITARU_DEMO_SEO.title}
+  description={BOOK_KITARU_DEMO_SEO.description}
+  ogTitle={BOOK_KITARU_DEMO_SEO.ogTitle}
+  ogDescription={BOOK_KITARU_DEMO_SEO.ogDescription}
+  surface="agent"
+>
+  <BookingExperience
+    brand="kitaru"
+    homeHref="/product/kitaru"
+    hero={BOOK_KITARU_DEMO_HERO}
+    proofLabel={BOOK_KITARU_DEMO_PROOF}
+    logos={BOOK_YOUR_DEMO_LOGOS}
+    form={BOOK_YOUR_DEMO_FORM}
+    fields={BOOK_YOUR_DEMO_FIELDS}
+    cal={BOOK_YOUR_DEMO_CAL}
+    testimonial={BOOK_YOUR_DEMO_TESTIMONIAL}
+  />
+</MinimalLayout>


### PR DESCRIPTION
## Summary

Closes #104. Clicking **"Book a demo"** from the Kitaru landing (`/product/kitaru`) used to drop visitors on `/book-your-demo` — a fully **ZenML-branded** page (ZenML logo, "AI Control Plane" headline, ML stats). Someone reading about agent durability suddenly saw an MLOps pitch under a different product name. Reported by Lennart.

This adds a **co-branded Kitaru variant** at `/book-your-demo/kitaru` and points the Kitaru CTAs there. The ZenML page is untouched.

| | ZenML `/book-your-demo` | Kitaru `/book-your-demo/kitaru` |
|---|---|---|
| Logo | ZenML (purple) | Kitaru wordmark + orange ring |
| Headline | "See the **AI Control Plane** in action" | "See **Kitaru** in action" (orange) |
| Left column | 2×2 ML stats | "Built by the ZenML team — trusted by 1,000+ teams…" + logos |
| Accent / button | purple | orange |
| `surface` | `unified` | `agent` |

## What changed

- **`src/components/BookingExperience.astro` (new)** — extracted the shared two-column booking body (markup, form wiring, Cal.com transition script) into one props-driven component, so the two routes can't drift apart.
- **`src/pages/book-your-demo.astro`** — rewritten to render the component with ZenML data. Output is unchanged (verified by screenshot).
- **`src/pages/book-your-demo/kitaru.astro` (new)** — the Kitaru route. `surface="agent"`, Kitaru wordmark linking back to `/product/kitaru`.
- **`src/lib/bookYourDemo.ts`** — added Kitaru SEO/hero/proof constants; reuses the existing form, fields, Cal.com link, logos, and testimonial.
- **`src/lib/productKitaru.ts`** — `KITARU_LINKS.demo` now points at `/book-your-demo/kitaru` (updates both landing CTAs + the markdown mirror).

## What reviewers should focus on

- **The orange re-skin mechanism.** The Kitaru variant overrides `--color-zenml-*` on a wrapper div (`.booking-brand-kitaru`). This deliberately does **not** use the usual `data-app="kitaru"` switch — the `--color-zenml-*` ladder is intentionally data-app-invariant, and the `DemoRequestForm` island hardcodes `bg-zenml-500`. Overriding the variable is the one lever that recolours both the markup and the island without editing the form. Documented in the component header comment.
- **Path-based, not `?from=kitaru`.** The issue suggested a query param, but the page is statically generated — a query param would cause a brief flash of ZenML branding before JS swapped it. A distinct prebuilt URL avoids that and stays static-first.
- **No ZenML regression.** The shared component inlines its CSS rule into both pages, but the `.booking-brand-kitaru` class only lands on an element on the Kitaru page; the ZenML wrapper is `booking-root` only.
- **Known minor:** the form island's `<noscript>` fallback link still points to `/book-your-demo` (ZenML). Only affects no-JS Kitaru visitors; not worth threading a prop through the shared island. The cookie-consent banner also stays ZenML purple on the Kitaru page (global site furniture, injected outside the wrapper) — left intentionally.

## Validation

- `pnpm check` — 0 errors, 0 warnings (2 pre-existing hints)
- `pnpm lint` — clean
- `pnpm check:surface` — passes (both pages pass explicit `surface=`)
- `pnpm build` — exit 0; both routes generated; `og:title` fallback verified in built HTML
- `/simplify` run (4 agents): de-duplicated the Kitaru SEO constant, documented the brand-override decision; other findings skipped with reasons
- Both pages screenshotted from the build and visually confirmed

## Preview paths to check

- Preview URL + `/book-your-demo/kitaru` (new Kitaru page)
- Preview URL + `/book-your-demo` (confirm unchanged)
- Preview URL + `/product/kitaru` → click "Book a demo" (both Hero and closing CTA)
