### PR TITLE
Align Kitaru landing with shipped replay API

### DIFF
--- a/src/components/compare/kitaru/ComparisonCta.astro
+++ b/src/components/compare/kitaru/ComparisonCta.astro
@@ -1,5 +1,5 @@
 ---
-import { KITARU_LINKS } from "../../../lib/productKitaru";
+import { KITARU_INSTALL_CMD, KITARU_LINKS } from "../../../lib/productKitaru";
 
 interface Props {
   headline: string;
@@ -32,11 +32,11 @@ const {
     <div class="ccta-shelf">
       <div class="ccta-install">
         <span class="ccta-install-prompt" aria-hidden="true">$</span>
-        <code class="ccta-install-cmd">pip install kitaru</code>
+        <code class="ccta-install-cmd">{KITARU_INSTALL_CMD}</code>
         <button
           class="ccta-copy-btn"
           aria-label="Copy install command"
-          data-copy="pip install kitaru"
+          data-copy={KITARU_INSTALL_CMD}
         >
           <svg class="ccta-copy-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <rect x="9" y="9" width="13" height="13" rx="2"/>

--- a/src/components/compare/kitaru/ComparisonHero.astro
+++ b/src/components/compare/kitaru/ComparisonHero.astro
@@ -1,5 +1,5 @@
 ---
-import { KITARU_LINKS } from "../../../lib/productKitaru";
+import { KITARU_INSTALL_CMD, KITARU_LINKS } from "../../../lib/productKitaru";
 
 interface CompetitorOption {
   slug: string;
@@ -160,11 +160,11 @@ const hasOptions = competitorOptions.length > 0;
       <!-- Visually-hidden live region announces copy success to screen readers -->
       <span class="sr-only" id="chero-copy-status" aria-live="polite" aria-atomic="true"></span>
       <div class="chero-install">
-        <code class="chero-install-cmd">pip install kitaru</code>
+        <code class="chero-install-cmd">{KITARU_INSTALL_CMD}</code>
         <button
           class="chero-copy-btn"
           aria-label="Copy install command"
-          data-copy="pip install kitaru"
+          data-copy={KITARU_INSTALL_CMD}
         >
           <svg class="chero-copy-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <rect x="9" y="9" width="13" height="13" rx="2"/>

--- a/src/components/compare/kitaru/graphics/hatchet/LlmLineage.astro
+++ b/src/components/compare/kitaru/graphics/hatchet/LlmLineage.astro
@@ -33,7 +33,7 @@
   <div class="panel panel--kitaru">
     <div class="panel-head">
       <span class="panel-label panel-label--accent">Kitaru · LLM as a captured checkpoint event</span>
-      <span class="panel-sub">Prompt, response, tokens, latency, and cost on every call</span>
+      <span class="panel-sub">Prompt, response, tokens, latency, and cost on captured LLM calls when reported</span>
     </div>
 
     <div class="code code--accent">

--- a/src/components/compare/kitaru/graphics/restate/EmbeddedVsServerRegistered.astro
+++ b/src/components/compare/kitaru/graphics/restate/EmbeddedVsServerRegistered.astro
@@ -1,4 +1,5 @@
 ---
+import { KITARU_INSTALL_CMD } from "../../../../../lib/productKitaru";
 ---
 
 <figure class="fig">
@@ -60,7 +61,7 @@
           <span class="mono deco-key">kitaru.llm()</span>
         </div>
       </div>
-      <span class="proc-foot">pip install kitaru · no server process in the request path</span>
+      <span class="proc-foot">{KITARU_INSTALL_CMD} · no server process in the request path</span>
     </div>
 
     <div class="meta-group">

--- a/src/components/kitaru/AgentDriven.astro
+++ b/src/components/kitaru/AgentDriven.astro
@@ -42,9 +42,9 @@ const agents = [
             <span class="ad-window-title">agent · kitaru mcp</span>
           </div>
           <div class="ad-transcript">
-            <div class="ad-line ad-line-agent">replay #4127 &middot; model=<span class="ad-str">"gpt-5-nano"</span></div>
+            <div class="ad-line ad-line-agent">replay #4127 &middot; at=<span class="ad-str">"decide"</span> · invocation_overrides → <span class="ad-str">"gpt-5-mini"</span></div>
             <div class="ad-line ad-line-out ad-bad">81% cheaper, but skipped the escalation &#10007;</div>
-            <div class="ad-line ad-line-agent">replay #4127 &middot; model=<span class="ad-str">"gpt-5-nano"</span>, keep=<span class="ad-str">escalate</span></div>
+            <div class="ad-line ad-line-agent">replay #4127 &middot; at=<span class="ad-str">"decide"</span> · invocation_overrides → <span class="ad-str">"gpt-5-mini"</span> · skip=<span class="ad-str">["escalate_call"]</span></div>
             <div class="ad-line ad-line-out ad-good">78% cheaper, decisions match &#10003;</div>
             <div class="ad-line ad-line-agent ad-kept">kept this variant, opening a PR</div>
           </div>

--- a/src/components/kitaru/AgentDriven.astro
+++ b/src/components/kitaru/AgentDriven.astro
@@ -42,14 +42,14 @@ const agents = [
             <span class="ad-window-title">agent · kitaru mcp</span>
           </div>
           <div class="ad-transcript">
-            <div class="ad-line ad-line-agent">replay #4127 &middot; at=<span class="ad-str">"decide"</span> · invocation_overrides → <span class="ad-str">"gpt-5-mini"</span></div>
+            <div class="ad-line ad-line-agent">replay #4127 &middot; from_=<span class="ad-str">"decide"</span> · model=<span class="ad-str">"gpt-5-mini"</span></div>
             <div class="ad-line ad-line-out ad-bad">81% cheaper, but skipped the escalation &#10007;</div>
-            <div class="ad-line ad-line-agent">replay #4127 &middot; at=<span class="ad-str">"decide"</span> · invocation_overrides → <span class="ad-str">"gpt-5-mini"</span> · skip=<span class="ad-str">["escalate_call"]</span></div>
+            <div class="ad-line ad-line-agent">replay #4127 &middot; from_=<span class="ad-str">"decide"</span> · model=<span class="ad-str">"fast"</span></div>
             <div class="ad-line ad-line-out ad-good">78% cheaper, decisions match &#10003;</div>
             <div class="ad-line ad-line-agent ad-kept">kept this variant, opening a PR</div>
           </div>
         </div>
-        <p class="ad-loop-caption">Three replays, no human in the loop. The diff is the agent&rsquo;s reward signal.</p>
+        <p class="ad-loop-caption">A few replays, no human in the loop. The diff is the agent&rsquo;s reward signal.</p>
       </div>
     </div>
   </div>

--- a/src/components/kitaru/Architecture.astro
+++ b/src/components/kitaru/Architecture.astro
@@ -24,7 +24,7 @@
             <div class="arch-layer-label">Inner Harness</div>
             <div class="arch-layer-pills">
               <span class="arch-pill">OpenAI Agents SDK</span>
-              <span class="arch-pill">Anthropic Agent SDK</span>
+              <span class="arch-pill">Claude Agent SDK</span>
               <span class="arch-pill">PydanticAI</span>
               <span class="arch-pill">LangGraph</span>
               <span class="arch-pill">Raw Python</span>

--- a/src/components/kitaru/CodeShowcase.astro
+++ b/src/components/kitaru/CodeShowcase.astro
@@ -9,7 +9,7 @@
       Every what-if is one replay call.
     </h2>
     <p class="showcase-note" data-reveal data-reveal-delay="1">
-      Swap a model invocation, inject a tool result, or replace a flaky tool with mock code: one replay API, one scoped override. Hover any line to see what it does.
+      Swap a model input, replace a checkpoint result, or replay with a test-mode flow input: one replay API, one change at a time. Hover any line to see what it does.
     </p>
 
     <div class="showcase-grid">
@@ -25,19 +25,28 @@
             </div>
             <span class="showcase-code-filename">whatif.py</span>
           </div>
-          <pre class="showcase-code-pre code-syntax" aria-label="Example Kitaru what-if: replay real executions on a cheaper model with a faked tool, then diff"><code><span class="code-line"><span class="kw">import</span> kitaru</span>
+          <pre class="showcase-code-pre code-syntax" aria-label="Example Kitaru what-if: replay real executions on a cheaper model with a faked checkpoint result, then diff"><code><span class="code-line"><span class="kw">import</span> kitaru</span>
 <span class="code-line"> </span>
 <span class="code-line">client <span class="op">=</span> kitaru.<span class="fn">KitaruClient</span>()</span>
 <span class="code-line"><span class="cmt"># your agent exposes replayable checkpoints through Kitaru</span></span>
 <span class="code-line" data-primitive="run">exec <span class="op">=</span> support_agent.<span class="fn">run</span>(ticket).<span class="fn">wait</span>()</span>
 <span class="code-line"> </span>
-<span class="code-line"><span class="cmt"># reproduce faithfully, then change ONE scoped target</span></span>
-<span class="code-line" data-primitive="rerun">baseline <span class="op">=</span> client.executions.<span class="fn">replay</span>(exec.exec_id, at<span class="op">=</span><span class="str">"decide"</span>)</span>
-<span class="code-line" data-primitive="model">cheaper  <span class="op">=</span> client.executions.<span class="fn">replay</span>(exec.exec_id, at<span class="op">=</span><span class="str">"decide"</span>, invocation_overrides<span class="op">=</span>&#123;<span class="str">"decide:model_call_1"</span>: &#123;<span class="str">"model"</span>: <span class="str">"glm-5.4"</span>&#125;&#125;)</span>
-<span class="code-line" data-primitive="output">faked    <span class="op">=</span> client.executions.<span class="fn">replay</span>(exec.exec_id, at<span class="op">=</span><span class="str">"lookup_order"</span>, checkpoint_overrides<span class="op">=</span>&#123;<span class="str">"lookup_order"</span>: &#123;<span class="str">"output"</span>: stale_order&#125;&#125;)</span>
-<span class="code-line" data-primitive="code">timeout  <span class="op">=</span> client.executions.<span class="fn">replay</span>(exec.exec_id, at<span class="op">=</span><span class="str">"lookup_order"</span>, checkpoint_overrides<span class="op">=</span>&#123;<span class="str">"lookup_order"</span>: &#123;<span class="str">"code"</span>: <span class="str">"mocks.lookup_order_timeout"</span>&#125;&#125;)</span>
+<span class="code-line"><span class="cmt"># reproduce faithfully, then change ONE thing</span></span>
+<span class="code-line" data-primitive="rerun">baseline <span class="op">=</span> client.executions.<span class="fn">replay</span>(</span>
+<span class="code-line code-line-indent" data-primitive="rerun">exec.exec_id, from_<span class="op">=</span><span class="str">"decide"</span>,</span>
+<span class="code-line" data-primitive="rerun">)</span>
+<span class="code-line" data-primitive="model">cheaper <span class="op">=</span> client.executions.<span class="fn">replay</span>(</span>
+<span class="code-line code-line-indent" data-primitive="model">exec.exec_id, from_<span class="op">=</span><span class="str">"decide"</span>, model<span class="op">=</span><span class="str">"glm-5.4"</span>,</span>
+<span class="code-line" data-primitive="model">)</span>
+<span class="code-line" data-primitive="output">faked <span class="op">=</span> client.executions.<span class="fn">replay</span>(</span>
+<span class="code-line code-line-indent" data-primitive="output">exec.exec_id, from_<span class="op">=</span><span class="str">"lookup_order"</span>,</span>
+<span class="code-line code-line-indent" data-primitive="output">overrides<span class="op">=</span>&#123;<span class="str">"checkpoint.lookup_order"</span>: stale_order&#125;,</span>
+<span class="code-line" data-primitive="output">)</span>
+<span class="code-line" data-primitive="code">timeout <span class="op">=</span> client.executions.<span class="fn">replay</span>(</span>
+<span class="code-line code-line-indent" data-primitive="code">exec.exec_id, from_<span class="op">=</span><span class="str">"lookup_order"</span>, lookup_mode<span class="op">=</span><span class="str">"timeout"</span>,</span>
+<span class="code-line" data-primitive="code">)</span>
 <span class="code-line"> </span>
-<span class="code-line" data-primitive="diff">kitaru.<span class="fn">diff</span>(exec.exec_id, cheaper.results[0].replay_exec_id)<span class="cmt">   # did the decision move?</span></span></code></pre>
+<span class="code-line" data-primitive="diff">kitaru.<span class="fn">diff</span>(exec.exec_id, cheaper.exec_id)</span></code></pre>
         </div>
       </div>
 
@@ -48,20 +57,20 @@
           <p>Run in production. Kitaru-visible calls and steps become replayable checkpoints, addressable later.</p>
         </div>
         <div class="annotation" data-highlight="rerun">
-          <code class="annotation-label">replay(at="decide")</code>
+          <code class="annotation-label">replay(from_="decide")</code>
           <p>Reproduce from a checkpoint with no change. Earlier checkpoints reuse recorded outputs. The faithful baseline.</p>
         </div>
         <div class="annotation" data-highlight="model">
-          <code class="annotation-label">invocation_overrides</code>
-          <p>Replay one recorded model call on glm-5.4. Same inputs, different model.</p>
+          <code class="annotation-label">model="glm-5.4"</code>
+          <p>Pass a different flow input for this replay. Same execution history, cheaper model choice.</p>
         </div>
         <div class="annotation" data-highlight="output">
-          <code class="annotation-label">checkpoint_overrides: output</code>
-          <p>Inject a different checkpoint result. The targeted checkpoint does not run.</p>
+          <code class="annotation-label">overrides={"checkpoint..."}</code>
+          <p>Replace one recorded checkpoint result. Kitaru replays the consumers of that changed value.</p>
         </div>
         <div class="annotation" data-highlight="code">
-          <code class="annotation-label">checkpoint_overrides: code</code>
-          <p>Replace the lookup checkpoint with mock code that times out, then watch how the agent recovers.</p>
+          <code class="annotation-label">lookup_mode="timeout"</code>
+          <p>Use a flow input your agent already understands to run the replay against a timeout path.</p>
         </div>
         <div class="annotation" data-highlight="diff">
           <code class="annotation-label">kitaru.diff(...)</code>
@@ -81,10 +90,14 @@
 
   .showcase-grid {
     display: grid;
-    grid-template-columns: 1.4fr 1fr;
+    grid-template-columns: minmax(0, 1.35fr) minmax(280px, 1fr);
     gap: 40px;
     align-items: start;
     margin-top: 40px;
+  }
+
+  .showcase-code {
+    min-width: 0;
   }
 
   /* Code window — reuses Architecture patterns */
@@ -120,17 +133,22 @@
     overflow-x: auto;
     font-family: var(--font-mono);
     font-size: 0.78rem;
-    line-height: 1.7;
+    line-height: 1.58;
     color: var(--color-dark-text);
     -webkit-overflow-scrolling: touch;
   }
 
   /* Highlight lines */
   .code-line {
+    display: block;
     transition: background 0.2s, opacity 0.2s;
     border-radius: 3px;
     padding: 0 4px;
     margin: 0 -4px;
+  }
+
+  .code-line-indent {
+    padding-left: 22px;
   }
 
   .code-line[data-primitive] {
@@ -164,6 +182,7 @@
     display: flex;
     flex-direction: column;
     gap: 12px;
+    min-width: 0;
     padding-top: 16px;
   }
 

--- a/src/components/kitaru/CodeShowcase.astro
+++ b/src/components/kitaru/CodeShowcase.astro
@@ -29,21 +29,22 @@
 <span class="code-line"> </span>
 <span class="code-line">client <span class="op">=</span> kitaru.<span class="fn">KitaruClient</span>()</span>
 <span class="code-line"><span class="cmt"># your agent exposes replayable checkpoints through Kitaru</span></span>
-<span class="code-line" data-primitive="run">exec <span class="op">=</span> support_agent.<span class="fn">run</span>(ticket).<span class="fn">wait</span>()</span>
+<span class="code-line" data-primitive="run">source <span class="op">=</span> support_agent.<span class="fn">run</span>(ticket)</span>
+<span class="code-line" data-primitive="run">result <span class="op">=</span> source.<span class="fn">wait</span>()</span>
 <span class="code-line"> </span>
 <span class="code-line"><span class="cmt"># reproduce faithfully, then change ONE thing</span></span>
 <span class="code-line" data-primitive="rerun">baseline <span class="op">=</span> client.executions.<span class="fn">replay</span>(</span>
-<span class="code-line code-line-indent" data-primitive="rerun">exec.exec_id, from_<span class="op">=</span><span class="str">"decide"</span>,</span>
+<span class="code-line code-line-indent" data-primitive="rerun">source.exec_id, from_<span class="op">=</span><span class="str">"decide"</span>,</span>
 <span class="code-line" data-primitive="rerun">)</span>
 <span class="code-line" data-primitive="model">cheaper <span class="op">=</span> client.executions.<span class="fn">replay</span>(</span>
-<span class="code-line code-line-indent" data-primitive="model">exec.exec_id, from_<span class="op">=</span><span class="str">"decide"</span>, model<span class="op">=</span><span class="str">"glm-5.4"</span>,</span>
+<span class="code-line code-line-indent" data-primitive="model">source.exec_id, from_<span class="op">=</span><span class="str">"decide"</span>, model<span class="op">=</span><span class="str">"glm-5.4"</span>,</span>
 <span class="code-line" data-primitive="model">)</span>
 <span class="code-line" data-primitive="output">faked <span class="op">=</span> client.executions.<span class="fn">replay</span>(</span>
-<span class="code-line code-line-indent" data-primitive="output">exec.exec_id, from_<span class="op">=</span><span class="str">"lookup_order"</span>,</span>
+<span class="code-line code-line-indent" data-primitive="output">source.exec_id, from_<span class="op">=</span><span class="str">"lookup_order"</span>,</span>
 <span class="code-line code-line-indent" data-primitive="output">overrides<span class="op">=</span>&#123;<span class="str">"checkpoint.lookup_order"</span>: stale_order&#125;,</span>
 <span class="code-line" data-primitive="output">)</span>
 <span class="code-line" data-primitive="code">timeout <span class="op">=</span> client.executions.<span class="fn">replay</span>(</span>
-<span class="code-line code-line-indent" data-primitive="code">exec.exec_id, from_<span class="op">=</span><span class="str">"lookup_order"</span>, lookup_mode<span class="op">=</span><span class="str">"timeout"</span>,</span>
+<span class="code-line code-line-indent" data-primitive="code">source.exec_id, from_<span class="op">=</span><span class="str">"lookup_order"</span>, lookup_mode<span class="op">=</span><span class="str">"timeout"</span>,</span>
 <span class="code-line" data-primitive="code">)</span>
 <span class="code-line"> </span>
 <span class="code-line" data-primitive="inspect">usage <span class="op">=</span> cheaper.llm_usage_summary</span></code></pre>
@@ -54,7 +55,7 @@
       <div class="showcase-annotations" data-reveal="fade-right" data-reveal-delay="3">
         <div class="annotation" data-highlight="run">
           <code class="annotation-label">support_agent.run()</code>
-          <p>Run in production. Kitaru-visible calls and steps become replayable checkpoints, addressable later.</p>
+          <p>Run in production. Keep the returned handle: it carries the execution ID that replay needs.</p>
         </div>
         <div class="annotation" data-highlight="rerun">
           <code class="annotation-label">replay(from_="decide")</code>
@@ -182,7 +183,6 @@
     flex-direction: column;
     gap: 12px;
     min-width: 0;
-    padding-top: 16px;
   }
 
   .annotation {

--- a/src/components/kitaru/CodeShowcase.astro
+++ b/src/components/kitaru/CodeShowcase.astro
@@ -46,7 +46,7 @@
 <span class="code-line code-line-indent" data-primitive="code">exec.exec_id, from_<span class="op">=</span><span class="str">"lookup_order"</span>, lookup_mode<span class="op">=</span><span class="str">"timeout"</span>,</span>
 <span class="code-line" data-primitive="code">)</span>
 <span class="code-line"> </span>
-<span class="code-line" data-primitive="diff">kitaru.<span class="fn">diff</span>(exec.exec_id, cheaper.exec_id)</span></code></pre>
+<span class="code-line" data-primitive="inspect">usage <span class="op">=</span> cheaper.llm_usage_summary</span></code></pre>
         </div>
       </div>
 
@@ -72,9 +72,9 @@
           <code class="annotation-label">lookup_mode="timeout"</code>
           <p>Use a flow input your agent already understands to run the replay against a timeout path.</p>
         </div>
-        <div class="annotation" data-highlight="diff">
-          <code class="annotation-label">kitaru.diff(...)</code>
-          <p>Did the decision move? Compare the source execution and replay, with cost and quality deltas.</p>
+        <div class="annotation" data-highlight="inspect">
+          <code class="annotation-label">llm_usage_summary</code>
+          <p>Inspect shipped execution metadata, checkpoints, and artifacts to compare the source execution and replay.</p>
         </div>
       </div>
 
@@ -133,14 +133,13 @@
     overflow-x: auto;
     font-family: var(--font-mono);
     font-size: 0.78rem;
-    line-height: 1.58;
+    line-height: 1.65;
     color: var(--color-dark-text);
     -webkit-overflow-scrolling: touch;
   }
 
   /* Highlight lines */
   .code-line {
-    display: block;
     transition: background 0.2s, opacity 0.2s;
     border-radius: 3px;
     padding: 0 4px;

--- a/src/components/kitaru/CodeShowcase.astro
+++ b/src/components/kitaru/CodeShowcase.astro
@@ -1,5 +1,5 @@
 ---
-// CodeShowcase.astro — "Show me the code" section with all 8 primitives + hover highlight
+// CodeShowcase.astro — "Show me the code" section for replay overrides + hover highlights
 ---
 
 <section class="dark-section section-pad" id="code-showcase">
@@ -9,7 +9,7 @@
       Every what-if is one replay call.
     </h2>
     <p class="showcase-note" data-reveal data-reveal-delay="1">
-      Swap the model, fake a tool, fail a call: the same line, one different keyword. Hover any line to see what it does.
+      Swap a model invocation, inject a tool result, or replace a flaky tool with mock code: one replay API, one scoped override. Hover any line to see what it does.
     </p>
 
     <div class="showcase-grid">
@@ -25,18 +25,19 @@
             </div>
             <span class="showcase-code-filename">whatif.py</span>
           </div>
-          <pre class="showcase-code-pre code-syntax" aria-label="Example Kitaru what-if: replay real runs on a cheaper model with a faked tool, then diff"><code><span class="code-line"><span class="kw">from</span> kitaru <span class="kw">import</span> flow, checkpoint</span>
+          <pre class="showcase-code-pre code-syntax" aria-label="Example Kitaru what-if: replay real executions on a cheaper model with a faked tool, then diff"><code><span class="code-line"><span class="kw">import</span> kitaru</span>
 <span class="code-line"> </span>
-<span class="code-line"><span class="cmt"># your agent's steps are durable checkpoints</span></span>
+<span class="code-line">client <span class="op">=</span> kitaru.<span class="fn">KitaruClient</span>()</span>
+<span class="code-line"><span class="cmt"># your agent exposes replayable checkpoints through Kitaru</span></span>
 <span class="code-line" data-primitive="run">exec <span class="op">=</span> support_agent.<span class="fn">run</span>(ticket).<span class="fn">wait</span>()</span>
 <span class="code-line"> </span>
-<span class="code-line"><span class="cmt"># reproduce faithfully, then change ONE thing</span></span>
-<span class="code-line" data-primitive="rerun">rerun   <span class="op">=</span> support_agent.<span class="fn">replay</span>(exec, from_<span class="op">=</span><span class="str">"decide"</span>)</span>
-<span class="code-line" data-primitive="model">cheaper <span class="op">=</span> support_agent.<span class="fn">replay</span>(exec, from_<span class="op">=</span><span class="str">"decide"</span>, model<span class="op">=</span><span class="str">"glm-4.6"</span>)</span>
-<span class="code-line" data-primitive="output">faked   <span class="op">=</span> support_agent.<span class="fn">replay</span>(exec, from_<span class="op">=</span><span class="str">"decide"</span>, output<span class="op">=</span>stale_order)</span>
-<span class="code-line" data-primitive="raise">failed  <span class="op">=</span> support_agent.<span class="fn">replay</span>(exec, from_<span class="op">=</span><span class="str">"decide"</span>, raise_<span class="op">=</span>Timeout)</span>
+<span class="code-line"><span class="cmt"># reproduce faithfully, then change ONE scoped target</span></span>
+<span class="code-line" data-primitive="rerun">baseline <span class="op">=</span> client.executions.<span class="fn">replay</span>(exec.exec_id, at<span class="op">=</span><span class="str">"decide"</span>)</span>
+<span class="code-line" data-primitive="model">cheaper  <span class="op">=</span> client.executions.<span class="fn">replay</span>(exec.exec_id, at<span class="op">=</span><span class="str">"decide"</span>, invocation_overrides<span class="op">=</span>&#123;<span class="str">"decide:model_call_1"</span>: &#123;<span class="str">"model"</span>: <span class="str">"glm-5.4"</span>&#125;&#125;)</span>
+<span class="code-line" data-primitive="output">faked    <span class="op">=</span> client.executions.<span class="fn">replay</span>(exec.exec_id, at<span class="op">=</span><span class="str">"lookup_order"</span>, checkpoint_overrides<span class="op">=</span>&#123;<span class="str">"lookup_order"</span>: &#123;<span class="str">"output"</span>: stale_order&#125;&#125;)</span>
+<span class="code-line" data-primitive="code">timeout  <span class="op">=</span> client.executions.<span class="fn">replay</span>(exec.exec_id, at<span class="op">=</span><span class="str">"lookup_order"</span>, checkpoint_overrides<span class="op">=</span>&#123;<span class="str">"lookup_order"</span>: &#123;<span class="str">"code"</span>: <span class="str">"mocks.lookup_order_timeout"</span>&#125;&#125;)</span>
 <span class="code-line"> </span>
-<span class="code-line" data-primitive="diff">cheaper.<span class="fn">diff</span>(rerun)<span class="cmt">   # did the decision move?</span></span></code></pre>
+<span class="code-line" data-primitive="diff">kitaru.<span class="fn">diff</span>(exec.exec_id, cheaper.results[0].replay_exec_id)<span class="cmt">   # did the decision move?</span></span></code></pre>
         </div>
       </div>
 
@@ -44,27 +45,27 @@
       <div class="showcase-annotations" data-reveal="fade-right" data-reveal-delay="3">
         <div class="annotation" data-highlight="run">
           <code class="annotation-label">support_agent.run()</code>
-          <p>Run in production. Every step is a durable checkpoint, addressable later.</p>
+          <p>Run in production. Kitaru-visible calls and steps become replayable checkpoints, addressable later.</p>
         </div>
         <div class="annotation" data-highlight="rerun">
-          <code class="annotation-label">replay(from_="decide")</code>
-          <p>Reproduce from a checkpoint with no change. Earlier steps come from cache. The faithful baseline.</p>
+          <code class="annotation-label">replay(at="decide")</code>
+          <p>Reproduce from a checkpoint with no change. Earlier checkpoints reuse recorded outputs. The faithful baseline.</p>
         </div>
         <div class="annotation" data-highlight="model">
-          <code class="annotation-label">model="glm-4.6"</code>
-          <p>Replay that step on a cheaper model. Same inputs, different model.</p>
+          <code class="annotation-label">invocation_overrides</code>
+          <p>Replay one recorded model call on glm-5.4. Same inputs, different model.</p>
         </div>
         <div class="annotation" data-highlight="output">
-          <code class="annotation-label">output=</code>
-          <p>Return a different tool result instead of calling it.</p>
+          <code class="annotation-label">checkpoint_overrides: output</code>
+          <p>Inject a different checkpoint result. The targeted checkpoint does not run.</p>
         </div>
-        <div class="annotation" data-highlight="raise">
-          <code class="annotation-label">raise_=</code>
-          <p>Make a tool call fail, to test how the agent recovers.</p>
+        <div class="annotation" data-highlight="code">
+          <code class="annotation-label">checkpoint_overrides: code</code>
+          <p>Replace the lookup checkpoint with mock code that times out, then watch how the agent recovers.</p>
         </div>
         <div class="annotation" data-highlight="diff">
-          <code class="annotation-label">.diff(rerun)</code>
-          <p>Did the decision move? Compared against the faithful baseline, with cost and quality deltas.</p>
+          <code class="annotation-label">kitaru.diff(...)</code>
+          <p>Did the decision move? Compare the source execution and replay, with cost and quality deltas.</p>
         </div>
       </div>
 

--- a/src/components/kitaru/Deploy.astro
+++ b/src/components/kitaru/Deploy.astro
@@ -1,6 +1,6 @@
 ---
 // Deploy.astro — Terminal-led "run it" section, with a forward-looking roadmap nudge
-import { KITARU_LINKS } from "../../lib/productKitaru";
+import { KITARU_INSTALL_CMD, KITARU_LINKS } from "../../lib/productKitaru";
 ---
 
 <section id="deploy" class="section-pad-compact deploy-section">
@@ -15,8 +15,8 @@ import { KITARU_LINKS } from "../../lib/productKitaru";
 
     <div class="deploy-install" data-reveal data-reveal-delay="3">
       <span class="deploy-install-prompt" aria-hidden="true">$</span>
-      <code class="deploy-install-cmd">uv add kitaru &amp;&amp; kitaru init</code>
-      <button class="deploy-install-copy" type="button" aria-label="Copy install command" data-copy="uv add kitaru && kitaru init">
+      <code class="deploy-install-cmd">{KITARU_INSTALL_CMD}</code>
+      <button class="deploy-install-copy" type="button" aria-label="Copy install command" data-copy={KITARU_INSTALL_CMD}>
         <svg class="copy-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
         <svg class="check-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
       </button>

--- a/src/components/kitaru/Features.astro
+++ b/src/components/kitaru/Features.astro
@@ -1,6 +1,7 @@
 ---
 // Features.astro — the what-if workflow, told as the cheap-model use case:
-// replay 200 real runs with a cheaper model and a faked flaky tool, then diff.
+// replay 200 real runs with a cheaper model and a faked checkpoint result,
+// then diff.
 // Replaces the old durable-execution scroll-stack. No fragile scroll JS —
 // data-reveal only.
 const steps = [
@@ -15,8 +16,8 @@ const steps = [
     n: "02",
     tag: "Change one thing",
     title: "Cheaper model, flaky tool",
-    body: "Swap the pricey invocation to a cheap model. Replace the flaky lookup with a timeout mock. Only those replay targets change.",
-    code: 'client.executions.replay(exec_ids, at="decide", invocation_overrides=…, checkpoint_overrides=…)',
+    body: "Replay from the decision point with a cheaper model, or replace a recorded lookup result. Production stays exactly as it was.",
+    code: 'replay(id, from_="decide", model="fast")',
   },
   {
     n: "03",
@@ -43,7 +44,7 @@ const recordedSources = [
       <span class="section-eyebrow">THE WHAT-IF WORKFLOW</span>
       <h2 class="section-title">Find a cheaper model without touching production.</h2>
       <p class="section-desc">
-        Same question every time: can it run cheaper, and does it survive a flaky tool? Replay the runs you already have, change one thing, read the diff.
+        Same question every time: can it run cheaper, and does it survive a flaky tool result? Replay the runs you already have, change one thing, read the diff.
       </p>
 
     </div>
@@ -88,7 +89,7 @@ const recordedSources = [
     <div class="whatif-payoff" data-reveal="fade-up" data-reveal-delay="3">
       <div class="whatif-payoff-label">
         <span class="whatif-payoff-eyebrow">The diff</span>
-        <p>Same 200 executions. Cheap model. Order-lookup timeout mocked.</p>
+        <p>Same 200 executions. Cheap model. Order lookup result replaced.</p>
       </div>
       <div class="whatif-payoff-metrics">
         <div class="whatif-metric">
@@ -222,7 +223,7 @@ const recordedSources = [
   /* ─── Steps ─── */
   .whatif-steps {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 20px;
   }
 
@@ -230,6 +231,7 @@ const recordedSources = [
     display: flex;
     flex-direction: column;
     gap: 14px;
+    min-width: 0;
     padding: 28px 26px;
     border: 1px solid var(--color-border);
     border-radius: 16px;
@@ -294,8 +296,8 @@ const recordedSources = [
     border: 1px solid oklch(0.65 0.16 45 / 0.18);
     border-radius: 8px;
     padding: 10px 12px;
-    white-space: nowrap;
-    overflow-x: auto;
+    white-space: normal;
+    overflow-wrap: anywhere;
   }
 
   /* ─── Payoff: the diff ─── */

--- a/src/components/kitaru/Features.astro
+++ b/src/components/kitaru/Features.astro
@@ -24,7 +24,7 @@ const steps = [
     tag: "Diff",
     title: "See what would have happened",
     body: "Compare each candidate to its source execution: cost, changed outputs, first divergence. The decision now has evidence.",
-    code: "kitaru.diff_matrix(exec_ids)",
+    code: "cheap.llm_usage_summary",
   },
 ] as const;
 

--- a/src/components/kitaru/Features.astro
+++ b/src/components/kitaru/Features.astro
@@ -7,41 +7,33 @@ const steps = [
   {
     n: "01",
     tag: "Replay",
-    title: "Start from real runs",
-    body: "200 recorded runs. Every model and tool call already captured. Nothing reruns.",
-    code: 'execs = support_agent.history(last="7d")',
+    title: "Start from execution IDs",
+    body: "200 real executions whose Kitaru-visible steps and model/tool calls are already checkpointed. Production stays untouched.",
+    code: "exec_ids = cohort.exec_ids",
   },
   {
     n: "02",
     tag: "Change one thing",
     title: "Cheaper model, flaky tool",
-    body: "Swap the pricey step to a cheap model. Fake the flaky tool: a timeout, a stale result. Only that boundary changes.",
-    code: 'replay(execs, model="fast", output=stale_order)',
+    body: "Swap the pricey invocation to a cheap model. Replace the flaky lookup with a timeout mock. Only those replay targets change.",
+    code: 'client.executions.replay(exec_ids, at="decide", invocation_overrides=…, checkpoint_overrides=…)',
   },
   {
     n: "03",
     tag: "Diff",
     title: "See what would have happened",
-    body: "Compare each candidate to its real run: cost, changed outputs, first divergence. The decision now has evidence.",
-    code: "diff(execs, candidates)",
+    body: "Compare each candidate to its source execution: cost, changed outputs, first divergence. The decision now has evidence.",
+    code: "kitaru.diff_matrix(exec_ids)",
   },
 ] as const;
 
-// Source logos for the "Start from" toggle. slug → /images/kitaru-sources/{slug}.png
+// Source logos for the "Start from" panel. slug → /images/kitaru-sources/{slug}.png
 const recordedSources = [
   { slug: "pydantic", name: "Pydantic AI" },
   { slug: "langgraph", name: "LangGraph" },
   { slug: "openai", name: "OpenAI Agents SDK" },
   { slug: "claude", name: "Claude Agent SDK" },
   { slug: "python", name: "Raw Python" },
-] as const;
-
-const traceSources = [
-  { slug: "opentelemetry", name: "OpenTelemetry" },
-  { slug: "datadog", name: "Datadog" },
-  { slug: "langfuse", name: "Langfuse" },
-  { slug: "phoenix", name: "Phoenix" },
-  { slug: "braintrust", name: "Braintrust" },
 ] as const;
 ---
 
@@ -58,30 +50,15 @@ const traceSources = [
 
     <div class="whatif-sources" data-reveal>
       <span class="whatif-sources-label">Start from</span>
-      <button type="button" class="src-tab is-active" data-src="recorded" aria-selected="true">runs Kitaru recorded</button>
-      <span class="whatif-source-or">or</span>
-      <button type="button" class="src-tab" data-src="traces" aria-selected="false">traces you already collect</button>
+      <span class="src-pill">Kitaru-recorded executions</span>
     </div>
 
     <div class="src-panels" data-reveal>
-      <div class="src-panel is-active" id="src-recorded" role="region" aria-label="Start from runs Kitaru recorded">
-        <p class="src-line">One line to wrap and deploy your agent. Every model and tool call is recorded.</p>
+      <div class="src-panel is-active" id="src-recorded" role="region" aria-label="Start from Kitaru-recorded executions">
+        <p class="src-line">Wrap your agent so model/tool calls and steps exposed through Kitaru primitives or adapters become replayable checkpoints.</p>
         <div class="src-logos">
           {
             recordedSources.map((s) => (
-              <span class="src-logo">
-                <img src={`/images/kitaru-sources/${s.slug}.png`} alt="" aria-hidden="true" width="22" height="22" loading="lazy" />
-                {s.name}
-              </span>
-            ))
-          }
-        </div>
-      </div>
-      <div class="src-panel" id="src-traces" role="region" aria-label="Start from traces you already collect" hidden>
-        <p class="src-line">Already collecting traces? Connect your tool and start replaying from there.</p>
-        <div class="src-logos">
-          {
-            traceSources.map((s) => (
               <span class="src-logo">
                 <img src={`/images/kitaru-sources/${s.slug}.png`} alt="" aria-hidden="true" width="22" height="22" loading="lazy" />
                 {s.name}
@@ -111,7 +88,7 @@ const traceSources = [
     <div class="whatif-payoff" data-reveal="fade-up" data-reveal-delay="3">
       <div class="whatif-payoff-label">
         <span class="whatif-payoff-eyebrow">The diff</span>
-        <p>Same 200 runs. Cheap model. Order-lookup tool faked.</p>
+        <p>Same 200 executions. Cheap model. Order-lookup timeout mocked.</p>
       </div>
       <div class="whatif-payoff-metrics">
         <div class="whatif-metric">
@@ -130,7 +107,7 @@ const traceSources = [
     </div>
 
     <p class="whatif-foot" data-reveal>
-      Illustrative numbers. Tool-level what-ifs are fullest on Pydantic AI and the OpenAI Agents SDK.
+      Illustrative numbers. Tool-level detail depends on the primitives or adapter boundaries your agent exposes to Kitaru.
     </p>
   </div>
 </section>
@@ -154,7 +131,7 @@ const traceSources = [
     font-weight: 300;
   }
 
-  /* ─── "Start from" sources toggle ─── */
+  /* ─── "Start from" source panel ─── */
   .whatif-sources {
     display: flex;
     flex-wrap: wrap;
@@ -172,34 +149,15 @@ const traceSources = [
     color: var(--color-muted);
   }
 
-  .src-tab {
+  .src-pill {
     font-family: inherit;
     font-size: 0.9rem;
-    font-weight: 500;
-    color: var(--color-secondary);
-    padding: 6px 14px;
-    border: 1px solid var(--color-border);
-    border-radius: 100px;
-    background: var(--color-surface);
-    cursor: pointer;
-    transition: color 0.2s, border-color 0.2s, background 0.2s;
-  }
-
-  .src-tab:hover {
-    color: var(--color-primary);
-    border-color: oklch(0.65 0.16 45 / 0.3);
-  }
-
-  .src-tab.is-active {
-    color: var(--color-accent);
-    border-color: oklch(0.65 0.16 45 / 0.4);
-    background: oklch(0.65 0.16 45 / 0.08);
     font-weight: 600;
-  }
-
-  .whatif-source-or {
-    font-size: 0.82rem;
-    color: var(--color-muted);
+    color: var(--color-accent);
+    padding: 6px 14px;
+    border: 1px solid oklch(0.65 0.16 45 / 0.4);
+    border-radius: 100px;
+    background: oklch(0.65 0.16 45 / 0.08);
   }
 
   /* Reveal panels */
@@ -219,9 +177,6 @@ const traceSources = [
     animation: src-fade 0.3s ease;
   }
 
-  .src-panel[hidden] {
-    display: none;
-  }
 
   @keyframes src-fade {
     from { opacity: 0; transform: translateY(6px); }
@@ -442,29 +397,3 @@ const traceSources = [
     }
   }
 </style>
-
-<script>
-  // "Start from" toggle — swap between recorded-runs and traces source panels.
-  const section = document.getElementById('how-it-works');
-  if (section) {
-    const tabs = section.querySelectorAll<HTMLButtonElement>('.src-tab');
-    const panels = section.querySelectorAll<HTMLElement>('.src-panel');
-    tabs.forEach(tab => {
-      tab.addEventListener('click', () => {
-        const target = tab.dataset.src;
-        if (!target) return;
-        tabs.forEach(t => {
-          const active = t === tab;
-          t.classList.toggle('is-active', active);
-          t.setAttribute('aria-selected', String(active));
-        });
-        panels.forEach(panel => {
-          const active = panel.id === `src-${target}`;
-          panel.classList.toggle('is-active', active);
-          if (active) panel.removeAttribute('hidden');
-          else panel.setAttribute('hidden', '');
-        });
-      });
-    });
-  }
-</script>

--- a/src/components/kitaru/Hero.astro
+++ b/src/components/kitaru/Hero.astro
@@ -36,7 +36,7 @@ import {
       </p>
 
       <p class="hero-subtitle" data-reveal data-reveal-delay="2">
-        Kitaru records every model and tool call. Replay a run with one thing changed and see what would have happened. No production reruns.
+        Kitaru turns the model/tool calls and steps your primitives or adapters expose into replayable checkpoints. Replay an execution ID with one scoped override and see what would have happened. No production reruns.
       </p>
 
       <p class="hero-install-tag" data-reveal data-reveal-delay="3">Lightweight, wraps your existing agent</p>
@@ -59,7 +59,7 @@ import {
     </div>
 
     <div class="hero-visual" data-reveal data-reveal-delay="3">
-      <div class="hv-panel" role="img" aria-label="Example: replay 200 recorded support-agent runs on an open model, GLM via OpenRouter, then diff the cost and answers against the real runs">
+      <div class="hv-panel" role="img" aria-label="Example: replay 200 recorded support-agent executions on glm-5.4, then diff the cost and answers against the real runs">
         <div class="hv-panel-head">
           <span class="hv-panel-dots">
             <span class="hv-dot"></span>
@@ -71,15 +71,16 @@ import {
         </div>
 
         <div class="hv-code">
-          <div class="hv-code-line hv-code-comment"># a production run, every step checkpointed</div>
+          <div class="hv-code-line hv-code-comment"># abbreviated: imports and client setup omitted</div>
+          <div class="hv-code-line hv-code-comment"># a production run, Kitaru-visible calls checkpointed</div>
           <div class="hv-code-line">exec <span class="hv-code-op">=</span> support_agent.<span class="hv-code-fn">run</span>(ticket).<span class="hv-code-fn">wait</span>()</div>
           <div class="hv-code-line"> </div>
-          <div class="hv-code-line hv-code-comment"># reproduce, then replay with one thing changed</div>
-          <div class="hv-code-line">rerun <span class="hv-code-op">=</span> support_agent.<span class="hv-code-fn">replay</span>(exec, from_<span class="hv-code-op">=</span><span class="hv-code-str">"decide"</span>)</div>
-          <div class="hv-code-line hv-code-hl">cheap <span class="hv-code-op">=</span> support_agent.<span class="hv-code-fn">replay</span>(exec, from_<span class="hv-code-op">=</span><span class="hv-code-str">"decide"</span>, model<span class="hv-code-op">=</span><span class="hv-code-str">"glm-4.6"</span>)</div>
-          <div class="hv-code-line hv-code-hl">mock <span class="hv-code-op">=</span> support_agent.<span class="hv-code-fn">replay</span>(exec, from_<span class="hv-code-op">=</span><span class="hv-code-str">"decide"</span>, lookup_order<span class="hv-code-op">=</span>stub)</div>
+          <div class="hv-code-line hv-code-comment"># reproduce, then replay with scoped overrides</div>
+          <div class="hv-code-line">rerun <span class="hv-code-op">=</span> client.executions.<span class="hv-code-fn">replay</span>(exec.exec_id, at<span class="hv-code-op">=</span><span class="hv-code-str">"decide"</span>)</div>
+          <div class="hv-code-line hv-code-hl">cheap <span class="hv-code-op">=</span> client.executions.<span class="hv-code-fn">replay</span>(exec.exec_id, at<span class="hv-code-op">=</span><span class="hv-code-str">"decide"</span>, invocation_overrides<span class="hv-code-op">=</span>&#123;"decide:model_call_1":&#123;"model":"glm-5.4"&#125;&#125;)</div>
+          <div class="hv-code-line hv-code-hl">mock <span class="hv-code-op">=</span> client.executions.<span class="hv-code-fn">replay</span>(exec.exec_id, at<span class="hv-code-op">=</span><span class="hv-code-str">"lookup_order"</span>, checkpoint_overrides<span class="hv-code-op">=</span>&#123;"lookup_order":&#123;"code":"mocks.lookup_order_timeout"&#125;&#125;)</div>
           <div class="hv-code-line"> </div>
-          <div class="hv-code-line">cheap.<span class="hv-code-fn">diff</span>(rerun)<span class="hv-code-comment">  # cheaper, same decision?</span></div>
+          <div class="hv-code-line">kitaru.<span class="hv-code-fn">diff</span>(exec.exec_id, cheap.results[0].replay_exec_id)<span class="hv-code-comment">  # cheaper, same decision?</span></div>
         </div>
 
         <div class="hv-diff">
@@ -102,7 +103,7 @@ import {
         </div>
 
         <div class="hv-caption">
-          Same 200 runs, on an open model. Same answers, a fraction of the cost.
+          Same 200 executions, replayed on glm-5.4. Same answers, a fraction of the cost.
         </div>
       </div>
     </div>

--- a/src/components/kitaru/Hero.astro
+++ b/src/components/kitaru/Hero.astro
@@ -85,7 +85,7 @@ import {
           <div class="hv-code-line hv-code-hl hv-code-indent">overrides<span class="hv-code-op">=</span>&#123;<span class="hv-code-str">"checkpoint.lookup_order"</span>: stale_order&#125;,</div>
           <div class="hv-code-line hv-code-hl">)</div>
           <div class="hv-code-line"> </div>
-          <div class="hv-code-line">kitaru.<span class="hv-code-fn">diff</span>(exec.exec_id, cheap.exec_id)<span class="hv-code-comment">  # cheaper, same decision?</span></div>
+          <div class="hv-code-line">cheap.llm_usage_summary<span class="hv-code-comment">  # inspect replay cost</span></div>
         </div>
 
         <div class="hv-diff">

--- a/src/components/kitaru/Hero.astro
+++ b/src/components/kitaru/Hero.astro
@@ -36,7 +36,7 @@ import {
       </p>
 
       <p class="hero-subtitle" data-reveal data-reveal-delay="2">
-        Kitaru turns the model/tool calls and steps your primitives or adapters expose into replayable checkpoints. Replay an execution ID with one scoped override and see what would have happened. No production reruns.
+        Kitaru turns the model/tool calls and steps your primitives or adapters expose into replayable checkpoints. Replay an execution ID with one input or checkpoint override and see what would have happened. No production reruns.
       </p>
 
       <p class="hero-install-tag" data-reveal data-reveal-delay="3">Lightweight, wraps your existing agent</p>
@@ -75,12 +75,17 @@ import {
           <div class="hv-code-line hv-code-comment"># a production run, Kitaru-visible calls checkpointed</div>
           <div class="hv-code-line">exec <span class="hv-code-op">=</span> support_agent.<span class="hv-code-fn">run</span>(ticket).<span class="hv-code-fn">wait</span>()</div>
           <div class="hv-code-line"> </div>
-          <div class="hv-code-line hv-code-comment"># reproduce, then replay with scoped overrides</div>
-          <div class="hv-code-line">rerun <span class="hv-code-op">=</span> client.executions.<span class="hv-code-fn">replay</span>(exec.exec_id, at<span class="hv-code-op">=</span><span class="hv-code-str">"decide"</span>)</div>
-          <div class="hv-code-line hv-code-hl">cheap <span class="hv-code-op">=</span> client.executions.<span class="hv-code-fn">replay</span>(exec.exec_id, at<span class="hv-code-op">=</span><span class="hv-code-str">"decide"</span>, invocation_overrides<span class="hv-code-op">=</span>&#123;"decide:model_call_1":&#123;"model":"glm-5.4"&#125;&#125;)</div>
-          <div class="hv-code-line hv-code-hl">mock <span class="hv-code-op">=</span> client.executions.<span class="hv-code-fn">replay</span>(exec.exec_id, at<span class="hv-code-op">=</span><span class="hv-code-str">"lookup_order"</span>, checkpoint_overrides<span class="hv-code-op">=</span>&#123;"lookup_order":&#123;"code":"mocks.lookup_order_timeout"&#125;&#125;)</div>
+          <div class="hv-code-line hv-code-comment"># reproduce, then replay with one change</div>
+          <div class="hv-code-line">rerun <span class="hv-code-op">=</span> exec.<span class="hv-code-fn">replay</span>(from_<span class="hv-code-op">=</span><span class="hv-code-str">"decide"</span>)</div>
+          <div class="hv-code-line hv-code-hl">cheap <span class="hv-code-op">=</span> exec.<span class="hv-code-fn">replay</span>(</div>
+          <div class="hv-code-line hv-code-hl hv-code-indent">from_<span class="hv-code-op">=</span><span class="hv-code-str">"decide"</span>, model<span class="hv-code-op">=</span><span class="hv-code-str">"glm-5.4"</span>,</div>
+          <div class="hv-code-line hv-code-hl">)</div>
+          <div class="hv-code-line hv-code-hl">mock <span class="hv-code-op">=</span> exec.<span class="hv-code-fn">replay</span>(</div>
+          <div class="hv-code-line hv-code-hl hv-code-indent">from_<span class="hv-code-op">=</span><span class="hv-code-str">"lookup_order"</span>,</div>
+          <div class="hv-code-line hv-code-hl hv-code-indent">overrides<span class="hv-code-op">=</span>&#123;<span class="hv-code-str">"checkpoint.lookup_order"</span>: stale_order&#125;,</div>
+          <div class="hv-code-line hv-code-hl">)</div>
           <div class="hv-code-line"> </div>
-          <div class="hv-code-line">kitaru.<span class="hv-code-fn">diff</span>(exec.exec_id, cheap.results[0].replay_exec_id)<span class="hv-code-comment">  # cheaper, same decision?</span></div>
+          <div class="hv-code-line">kitaru.<span class="hv-code-fn">diff</span>(exec.exec_id, cheap.exec_id)<span class="hv-code-comment">  # cheaper, same decision?</span></div>
         </div>
 
         <div class="hv-diff">
@@ -440,10 +445,10 @@ import {
     color: var(--color-primary);
     background: var(--color-bg);
     border-bottom: 1px solid var(--color-border);
-    overflow-x: auto;
   }
 
   .hv-code-line { white-space: pre; }
+  .hv-code-indent { padding-left: 18px; }
   .hv-code-comment { color: var(--color-muted); font-style: italic; }
   .hv-code-fn { color: var(--color-accent); font-weight: 500; }
   .hv-code-str { color: oklch(0.5 0.13 155); }

--- a/src/components/kitaru/Hero.astro
+++ b/src/components/kitaru/Hero.astro
@@ -73,15 +73,16 @@ import {
         <div class="hv-code">
           <div class="hv-code-line hv-code-comment"># abbreviated: imports and client setup omitted</div>
           <div class="hv-code-line hv-code-comment"># a production run, Kitaru-visible calls checkpointed</div>
-          <div class="hv-code-line">exec <span class="hv-code-op">=</span> support_agent.<span class="hv-code-fn">run</span>(ticket).<span class="hv-code-fn">wait</span>()</div>
+          <div class="hv-code-line">source <span class="hv-code-op">=</span> support_agent.<span class="hv-code-fn">run</span>(ticket)</div>
+          <div class="hv-code-line">result <span class="hv-code-op">=</span> source.<span class="hv-code-fn">wait</span>()</div>
           <div class="hv-code-line"> </div>
           <div class="hv-code-line hv-code-comment"># reproduce, then replay with one change</div>
-          <div class="hv-code-line">rerun <span class="hv-code-op">=</span> exec.<span class="hv-code-fn">replay</span>(from_<span class="hv-code-op">=</span><span class="hv-code-str">"decide"</span>)</div>
-          <div class="hv-code-line hv-code-hl">cheap <span class="hv-code-op">=</span> exec.<span class="hv-code-fn">replay</span>(</div>
-          <div class="hv-code-line hv-code-hl hv-code-indent">from_<span class="hv-code-op">=</span><span class="hv-code-str">"decide"</span>, model<span class="hv-code-op">=</span><span class="hv-code-str">"glm-5.4"</span>,</div>
+          <div class="hv-code-line">rerun <span class="hv-code-op">=</span> client.executions.<span class="hv-code-fn">replay</span>(source.exec_id, from_<span class="hv-code-op">=</span><span class="hv-code-str">"decide"</span>)</div>
+          <div class="hv-code-line hv-code-hl">cheap <span class="hv-code-op">=</span> client.executions.<span class="hv-code-fn">replay</span>(</div>
+          <div class="hv-code-line hv-code-hl hv-code-indent">source.exec_id, from_<span class="hv-code-op">=</span><span class="hv-code-str">"decide"</span>, model<span class="hv-code-op">=</span><span class="hv-code-str">"glm-5.4"</span>,</div>
           <div class="hv-code-line hv-code-hl">)</div>
-          <div class="hv-code-line hv-code-hl">mock <span class="hv-code-op">=</span> exec.<span class="hv-code-fn">replay</span>(</div>
-          <div class="hv-code-line hv-code-hl hv-code-indent">from_<span class="hv-code-op">=</span><span class="hv-code-str">"lookup_order"</span>,</div>
+          <div class="hv-code-line hv-code-hl">mock <span class="hv-code-op">=</span> client.executions.<span class="hv-code-fn">replay</span>(</div>
+          <div class="hv-code-line hv-code-hl hv-code-indent">source.exec_id, from_<span class="hv-code-op">=</span><span class="hv-code-str">"lookup_order"</span>,</div>
           <div class="hv-code-line hv-code-hl hv-code-indent">overrides<span class="hv-code-op">=</span>&#123;<span class="hv-code-str">"checkpoint.lookup_order"</span>: stale_order&#125;,</div>
           <div class="hv-code-line hv-code-hl">)</div>
           <div class="hv-code-line"> </div>
@@ -459,6 +460,10 @@ import {
     border-radius: 4px;
     margin: 0 -8px;
     padding: 0 8px;
+  }
+
+  .hv-code-hl.hv-code-indent {
+    padding-left: 26px;
   }
 
   /* ─── Hero visual: what-if diff table ─── */

--- a/src/components/kitaru/Hero.astro
+++ b/src/components/kitaru/Hero.astro
@@ -77,9 +77,12 @@ import {
           <div class="hv-code-line">result <span class="hv-code-op">=</span> source.<span class="hv-code-fn">wait</span>()</div>
           <div class="hv-code-line"> </div>
           <div class="hv-code-line hv-code-comment"># reproduce, then replay with one change</div>
-          <div class="hv-code-line">rerun <span class="hv-code-op">=</span> client.executions.<span class="hv-code-fn">replay</span>(source.exec_id, from_<span class="hv-code-op">=</span><span class="hv-code-str">"decide"</span>)</div>
+          <div class="hv-code-line">rerun <span class="hv-code-op">=</span> client.executions.<span class="hv-code-fn">replay</span>(</div>
+          <div class="hv-code-line hv-code-indent">source.exec_id, from_<span class="hv-code-op">=</span><span class="hv-code-str">"decide"</span>,</div>
+          <div class="hv-code-line">)</div>
           <div class="hv-code-line hv-code-hl">cheap <span class="hv-code-op">=</span> client.executions.<span class="hv-code-fn">replay</span>(</div>
-          <div class="hv-code-line hv-code-hl hv-code-indent">source.exec_id, from_<span class="hv-code-op">=</span><span class="hv-code-str">"decide"</span>, model<span class="hv-code-op">=</span><span class="hv-code-str">"glm-5.4"</span>,</div>
+          <div class="hv-code-line hv-code-hl hv-code-indent">source.exec_id, from_<span class="hv-code-op">=</span><span class="hv-code-str">"decide"</span>,</div>
+          <div class="hv-code-line hv-code-hl hv-code-indent">model<span class="hv-code-op">=</span><span class="hv-code-str">"glm-5.4"</span>,</div>
           <div class="hv-code-line hv-code-hl">)</div>
           <div class="hv-code-line hv-code-hl">mock <span class="hv-code-op">=</span> client.executions.<span class="hv-code-fn">replay</span>(</div>
           <div class="hv-code-line hv-code-hl hv-code-indent">source.exec_id, from_<span class="hv-code-op">=</span><span class="hv-code-str">"lookup_order"</span>,</div>
@@ -446,6 +449,8 @@ import {
     color: var(--color-primary);
     background: var(--color-bg);
     border-bottom: 1px solid var(--color-border);
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
   }
 
   .hv-code-line { white-space: pre; }

--- a/src/components/kitaru/OneImport.astro
+++ b/src/components/kitaru/OneImport.astro
@@ -6,17 +6,17 @@
   <div class="section-inner">
     <span class="section-eyebrow" data-reveal>POWERED BY DURABLE EXECUTION</span>
     <h2 class="section-title" data-reveal data-reveal-delay="1">
-      Keep your agent SDK. Kitaru records every call.
+      Keep your agent SDK. Make its runs replayable.
     </h2>
     <p class="one-import-desc" data-reveal data-reveal-delay="2">
-      One wrap, and every model and tool call is checkpointed. That durable record is what replay reads back, so a what-if is faithful, not a guess.
+      Wrap the calls and steps your SDK exposes, and Kitaru stores them as replayable checkpoints. That durable record is what replay reads back, so a what-if is faithful, not a guess.
     </p>
 
     <!-- Tabs -->
     <div class="one-import-tabs" role="tablist" data-reveal data-reveal-delay="3">
       <button class="one-import-tab is-active" role="tab" aria-selected="true" data-tab="pydanticai">PydanticAI</button>
       <button class="one-import-tab" role="tab" aria-selected="false" data-tab="openai">OpenAI Agents SDK</button>
-      <button class="one-import-tab" role="tab" aria-selected="false" data-tab="anthropic">Anthropic Agent SDK</button>
+      <button class="one-import-tab" role="tab" aria-selected="false" data-tab="anthropic">Claude Agent SDK</button>
       <button class="one-import-tab" role="tab" aria-selected="false" data-tab="custom">Raw Python</button>
     </div>
 
@@ -33,7 +33,7 @@
 
 agent <span class="op">=</span> <span class="fn">SandboxAgent</span>(
     name<span class="op">=</span><span class="str">"Compliance Reviewer"</span>,
-    model<span class="op">=</span><span class="str">"gpt-5.4"</span>,
+    model<span class="op">=</span><span class="str">"gpt-5-mini"</span>,
     default_manifest<span class="op">=</span>manifest,
 )
 
@@ -55,7 +55,7 @@ result <span class="op">=</span> <span class="kw">await</span> Runner.<span clas
 
 agent <span class="op">=</span> <span class="fn">SandboxAgent</span>(
     name<span class="op">=</span><span class="str">"Compliance Reviewer"</span>,
-    model<span class="op">=</span><span class="str">"gpt-5.4"</span>,
+    model<span class="op">=</span><span class="str">"gpt-5-mini"</span>,
     default_manifest<span class="op">=</span>manifest,
 )
 
@@ -77,7 +77,7 @@ result <span class="op">=</span> <span class="kw">await</span> runner.<span clas
 
 options <span class="op">=</span> <span class="fn">ClaudeAgentOptions</span>(
     system_prompt<span class="op">=</span><span class="str">"You are a compliance reviewer."</span>,
-    allowed_tools<span class="op">=</span>[<span class="str">"search_docs"</span>, <span class="str">"fetch_policy"</span>],
+    allowed_tools<span class="op">=</span>[],
 )
 
 <span class="kw">async for</span> msg <span class="kw">in</span> <span class="fn">query</span>(prompt<span class="op">=</span>task, options<span class="op">=</span>options):
@@ -94,22 +94,22 @@ options <span class="op">=</span> <span class="fn">ClaudeAgentOptions</span>(
               <span class="one-import-code-label is-after">With Kitaru</span>
               <span class="one-import-code-filename">agent.py</span>
             </div>
-            <pre class="one-import-code-pre code-syntax"><code><span class="kw">from</span> kitaru <span class="kw">import</span> flow, checkpoint
-<span class="kw">from</span> claude_agent_sdk <span class="kw">import</span> query, ClaudeAgentOptions
+            <pre class="one-import-code-pre code-syntax"><code><span class="kw">from</span> kitaru <span class="kw">import</span> flow
+<span class="kw">from</span> claude_agent_sdk <span class="kw">import</span> ClaudeAgentOptions
+<span class="kw">from</span> kitaru.adapters.claude_agent_sdk <span class="kw">import</span> ClaudeRunRequest, ClaudeRunResult, KitaruClaudeRunner
 
-options <span class="op">=</span> <span class="fn">ClaudeAgentOptions</span>(
-    system_prompt<span class="op">=</span><span class="str">"You are a compliance reviewer."</span>,
-    allowed_tools<span class="op">=</span>[<span class="str">"search_docs"</span>, <span class="str">"fetch_policy"</span>],
+runner <span class="op">=</span> <span class="fn">KitaruClaudeRunner</span>(
+    name<span class="op">=</span><span class="str">"compliance_review"</span>,
+    options_factory<span class="op">=</span><span class="kw">lambda</span> request: <span class="fn">ClaudeAgentOptions</span>(
+        system_prompt<span class="op">=</span><span class="str">"You are a compliance reviewer."</span>,
+        allowed_tools<span class="op">=</span>[],
+        max_turns<span class="op">=</span>request.max_turns,
+    ),
 )
 
-<span class="dec">@checkpoint</span>
-<span class="kw">async def</span> <span class="fn">run_claude</span>(task: <span class="var">str</span>) <span class="op">-></span> <span class="var">list</span>:
-    <span class="kw">return</span> [msg <span class="kw">async for</span> msg <span class="kw">in</span> <span class="fn">query</span>(prompt<span class="op">=</span>task, options<span class="op">=</span>options)]
-
 <span class="dec">@flow</span>
-<span class="kw">async def</span> <span class="fn">review</span>(task: <span class="var">str</span>):
-    <span class="kw">for</span> msg <span class="kw">in</span> <span class="kw">await</span> <span class="fn">run_claude</span>(task):
-        process(msg)</code></pre>
+<span class="kw">def</span> <span class="fn">review</span>(task: <span class="var">str</span>) <span class="op">-></span> <span class="var">ClaudeRunResult</span>:
+    <span class="kw">return</span> runner.<span class="fn">run_sync</span>(ClaudeRunRequest.<span class="fn">start</span>(task, max_turns<span class="op">=</span>3))</code></pre>
           </div>
         </div>
       </div>
@@ -125,7 +125,7 @@ options <span class="op">=</span> <span class="fn">ClaudeAgentOptions</span>(
             <pre class="one-import-code-pre code-syntax"><code><span class="kw">from</span> pydantic_ai <span class="kw">import</span> Agent
 
 agent <span class="op">=</span> <span class="fn">Agent</span>(
-    <span class="str">"openai:gpt-5.4"</span>,
+    <span class="str">"openai:gpt-5-mini"</span>,
     system_prompt<span class="op">=</span><span class="str">"You are a compliance reviewer."</span>,
     tools<span class="op">=</span>[search_docs, fetch_policy],
 )
@@ -147,7 +147,7 @@ result <span class="op">=</span> <span class="kw">await</span> agent.<span class
 <span class="kw">from</span> pydantic_ai <span class="kw">import</span> Agent
 
 agent <span class="op">=</span> <span class="fn">KitaruAgent</span>(<span class="fn">Agent</span>(
-    <span class="str">"openai:gpt-5.4"</span>,
+    <span class="str">"openai:gpt-5-mini"</span>,
     system_prompt<span class="op">=</span><span class="str">"You are a compliance reviewer."</span>,
     tools<span class="op">=</span>[search_docs, fetch_policy],
 ))

--- a/src/components/kitaru/ScenarioStrip.astro
+++ b/src/components/kitaru/ScenarioStrip.astro
@@ -1,28 +1,32 @@
 ---
 // ScenarioStrip.astro — the prominent second section. One recorded execution,
 // a different replay question each time. Each card shows a compact version of
-// the current `at` + scoped override API shape.
+// the shipped `from_` + `overrides` replay API shape.
 const scenarios = [
   {
     move: "fail",
     q: "Search tool times out?",
-    code: 'at="lookup_order" · checkpoint_overrides={"lookup_order": {"code": "mocks.timeout"}}',
+    code: 'lookup_mode="timeout"',
   },
   {
     move: "mock",
     q: "Tool returns something else?",
-    code: 'checkpoint_overrides={"lookup_order": {"output": …}}',
+    code: 'overrides={"checkpoint.lookup_order": stale_order}',
   },
   {
     move: "degrade",
     q: "Retriever gets worse?",
-    code: 'checkpoint_overrides={"retrieve": {"output": degraded}}',
+    code: 'overrides={"checkpoint.retrieve": degraded_docs}',
   },
-  { move: "drop", q: "Keep a later result?", code: 'skip=["rerank_call_1"]' },
+  {
+    move: "drop",
+    q: "Ignore the reranker?",
+    code: 'overrides={"checkpoint.rerank": []}',
+  },
   {
     move: "swap",
     q: "Run on a cheaper model?",
-    code: 'invocation_overrides={"decide:model_call_1": {"model": "fast"}}',
+    code: 'model="fast"',
   },
 ] as const;
 ---
@@ -98,6 +102,7 @@ const scenarios = [
     display: flex;
     flex-direction: column;
     gap: 14px;
+    min-width: 0;
     padding: 22px 20px;
     border: 1px solid var(--color-border);
     border-radius: 16px;
@@ -140,15 +145,15 @@ const scenarios = [
     display: block;
     width: 100%;
     font-family: var(--font-mono);
-    font-size: 0.8rem;
-    line-height: 1.5;
+    font-size: 0.68rem;
+    line-height: 1.45;
     color: var(--color-accent);
     background: oklch(0.65 0.16 45 / 0.08);
     border: 1px solid oklch(0.65 0.16 45 / 0.2);
     border-radius: 8px;
     padding: 10px 12px;
-    white-space: nowrap;
-    overflow-x: auto;
+    white-space: normal;
+    overflow-wrap: anywhere;
   }
 
   @media (max-width: 1100px) {

--- a/src/components/kitaru/ScenarioStrip.astro
+++ b/src/components/kitaru/ScenarioStrip.astro
@@ -93,7 +93,7 @@ const scenarios = [
 
   .scenario-grid {
     display: grid;
-    grid-template-columns: repeat(5, 1fr);
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 180px), 1fr));
     gap: 16px;
   }
 
@@ -156,16 +156,7 @@ const scenarios = [
     overflow-wrap: anywhere;
   }
 
-  @media (max-width: 1100px) {
-    .scenario-grid {
-      grid-template-columns: repeat(3, 1fr);
-    }
-  }
-
   @media (max-width: 720px) {
-    .scenario-grid {
-      grid-template-columns: repeat(2, 1fr);
-    }
     .scenario-card {
       min-height: 0;
     }

--- a/src/components/kitaru/ScenarioStrip.astro
+++ b/src/components/kitaru/ScenarioStrip.astro
@@ -1,14 +1,29 @@
 ---
-// ScenarioStrip.astro — the prominent second section. One recorded run, a
-// different question each time. Each card is a human-facing name for an
-// override kind, all expressed through the one `replay` verb. The cheap-model
-// card is featured — it's the buyer's cost pain.
+// ScenarioStrip.astro — the prominent second section. One recorded execution,
+// a different replay question each time. Each card shows a compact version of
+// the current `at` + scoped override API shape.
 const scenarios = [
-  { move: "fail", q: "Search tool times out?", code: "raise_=Timeout" },
-  { move: "mock", q: "Tool returns something else?", code: "output=…" },
-  { move: "degrade", q: "Retriever gets worse?", code: "output=degraded(…)" },
-  { move: "drop", q: "Cut the reranker?", code: "re-run · no tool" },
-  { move: "swap", q: "Run on a cheaper model?", code: 'model="fast"' },
+  {
+    move: "fail",
+    q: "Search tool times out?",
+    code: 'at="lookup_order" · checkpoint_overrides={"lookup_order": {"code": "mocks.timeout"}}',
+  },
+  {
+    move: "mock",
+    q: "Tool returns something else?",
+    code: 'checkpoint_overrides={"lookup_order": {"output": …}}',
+  },
+  {
+    move: "degrade",
+    q: "Retriever gets worse?",
+    code: 'checkpoint_overrides={"retrieve": {"output": degraded}}',
+  },
+  { move: "drop", q: "Keep a later result?", code: 'skip=["rerank_call_1"]' },
+  {
+    move: "swap",
+    q: "Run on a cheaper model?",
+    code: 'invocation_overrides={"decide:model_call_1": {"model": "fast"}}',
+  },
 ] as const;
 ---
 
@@ -17,7 +32,7 @@ const scenarios = [
     <div class="scenario-head" data-reveal>
       <span class="section-eyebrow">THE SAME MOVE, EVERY TIME</span>
       <h2 class="scenario-title">
-        One recorded run.<br /><span class="scenario-title-accent">A different question each time.</span>
+        One recorded execution.<br /><span class="scenario-title-accent">A different question each time.</span>
       </h2>
       <p class="scenario-sub">
         Replay the run. Change one thing. Read the answer off a diff. Nothing reruns in production.

--- a/src/lib/getStarted.ts
+++ b/src/lib/getStarted.ts
@@ -13,6 +13,7 @@
  * (decorators: @flow + @checkpoint; flows are invoked via `.run()`).
  */
 import type { CtaLink } from "./marketingPageTypes";
+import { KITARU_INSTALL_CMD } from "./productKitaru";
 
 // ---------------------------------------------------------------------------
 // SEO (one page, one URL)
@@ -233,7 +234,7 @@ export const GET_STARTED_KITARU = {
       {
         title: "Install Kitaru",
         body: "Get Kitaru up and running in minutes. You just need to install it.",
-        code: "pip install kitaru",
+        code: KITARU_INSTALL_CMD,
       },
       {
         title: "Add a human-in-the-loop gate",
@@ -242,8 +243,8 @@ export const GET_STARTED_KITARU = {
 from kitaru.adapters.pydantic_ai import KitaruAgent
 from pydantic_ai import Agent
 
-# KitaruAgent checkpoints every model + tool call for you.
-agent = KitaruAgent(Agent("openai:gpt-5.4", system_prompt="You draft customer replies."))
+# KitaruAgent turns PydanticAI model + tool calls into replayable checkpoints.
+agent = KitaruAgent(Agent("openai:gpt-5-mini", system_prompt="You draft customer replies."))
 
 @flow
 def support_flow(ticket: str) -> str:

--- a/src/lib/productKitaru.ts
+++ b/src/lib/productKitaru.ts
@@ -1,4 +1,4 @@
-export const KITARU_INSTALL_CMD = "pip install kitaru";
+export const KITARU_INSTALL_CMD = "uv add kitaru && uv run kitaru init";
 export const KITARU_LICENSE = "Apache 2.0";
 
 export const KITARU_LINKS = {
@@ -13,7 +13,7 @@ export const KITARU_LINKS = {
 export const PRODUCT_KITARU_SEO = {
   title: "Kitaru: ask what-if about your agent's real runs | ZenML",
   description:
-    "Open-source runtime that records every model and tool call in your agents' runs. Replay a real run with one thing changed: a model, a tool's output, a failed call. See what would have happened, with no production reruns. Durable checkpoints, wait/resume, and isolated execution on your own cloud. Built by the ZenML team.",
+    "Open-source runtime that records model/tool calls and steps exposed through Kitaru primitives and adapters as replayable checkpoints. Replay a real execution with one scoped override: a model, a checkpoint output, or replacement code for a flaky tool. See what would have happened, with no production reruns. Durable checkpoints, wait/resume, and isolated execution on your own cloud. Built by the ZenML team.",
 } as const;
 
 /**
@@ -30,7 +30,7 @@ export const PRODUCT_KITARU_MARKDOWN = {
   license: KITARU_LICENSE,
   summary: [
     "Kitaru is the open agent runtime from ZenML. The core pitch: ask what-if about your agent's real runs. Change one thing, replay the run, and see what would have happened. No production reruns.",
-    "It records every model and tool call as a durable checkpoint, then replays from any boundary with one thing changed: a model, a tool's output, or a failed call. The override is the only difference.",
+    "It records model/tool calls and steps exposed through Kitaru primitives and adapters as durable checkpoints, then replays from an execution ID with one scoped override: a flow input, checkpoint output, invocation model, or replacement code path. The override is the only difference.",
     `It is open source under ${KITARU_LICENSE} and built for Python agents that need checkpoints, replay, wait/resume, isolated execution, artifacts, and versioned deployments on your own cloud.`,
     "You keep the agent harness you already chose: PydanticAI, OpenAI Agents SDK, Claude Agent SDK, LangGraph, or plain Python. Kitaru records and replays the run underneath it with a small set of Python primitives.",
     "Durable execution is the foundation, not the pitch. The same checkpoints that make replay faithful also resume a run from the boundary that broke, so a crash at hour 11 does not mean restarting from hour 1.",

--- a/src/lib/productKitaru.ts
+++ b/src/lib/productKitaru.ts
@@ -1,4 +1,5 @@
-export const KITARU_INSTALL_CMD = "uv add kitaru && uv run kitaru init";
+export const KITARU_INSTALL_CMD =
+  "uv init --bare && uv add kitaru && uv run kitaru init";
 export const KITARU_LICENSE = "Apache 2.0";
 
 export const KITARU_LINKS = {
@@ -13,7 +14,7 @@ export const KITARU_LINKS = {
 export const PRODUCT_KITARU_SEO = {
   title: "Kitaru: ask what-if about your agent's real runs | ZenML",
   description:
-    "Open-source runtime that records model/tool calls and steps exposed through Kitaru primitives and adapters as replayable checkpoints. Replay a real execution with one scoped override: a model, a checkpoint output, or replacement code for a flaky tool. See what would have happened, with no production reruns. Durable checkpoints, wait/resume, and isolated execution on your own cloud. Built by the ZenML team.",
+    "Open-source runtime that records model/tool calls and steps exposed through Kitaru primitives and adapters as replayable checkpoints. Replay a real execution with one scoped override: a flow input, a model, or a checkpoint result override. See what would have happened, with no production reruns. Durable checkpoints, wait/resume, and isolated execution on your own cloud. Built by the ZenML team.",
 } as const;
 
 /**
@@ -30,7 +31,7 @@ export const PRODUCT_KITARU_MARKDOWN = {
   license: KITARU_LICENSE,
   summary: [
     "Kitaru is the open agent runtime from ZenML. The core pitch: ask what-if about your agent's real runs. Change one thing, replay the run, and see what would have happened. No production reruns.",
-    "It records model/tool calls and steps exposed through Kitaru primitives and adapters as durable checkpoints, then replays from an execution ID with one scoped override: a flow input, checkpoint output, invocation model, or replacement code path. The override is the only difference.",
+    "It records model/tool calls and steps exposed through Kitaru primitives and adapters as durable checkpoints, then replays from an execution ID with one scoped override: a flow input, checkpoint result override, invocation model, or test-mode flow input. The override is the only difference.",
     `It is open source under ${KITARU_LICENSE} and built for Python agents that need checkpoints, replay, wait/resume, isolated execution, artifacts, and versioned deployments on your own cloud.`,
     "You keep the agent harness you already chose: PydanticAI, OpenAI Agents SDK, Claude Agent SDK, LangGraph, or plain Python. Kitaru records and replays the run underneath it with a small set of Python primitives.",
     "Durable execution is the foundation, not the pitch. The same checkpoints that make replay faithful also resume a run from the boundary that broke, so a crash at hour 11 does not mean restarting from hour 1.",


### PR DESCRIPTION
## Summary

Updates the Kitaru marketing surfaces so the public copy matches the replay API visitors can use today, while keeping the page visually readable.

- Keeps public replay snippets on the shipped `from_` + `overrides={"checkpoint.<selector>": value}` shape, with normal keyword flow inputs such as `model="fast"` / `model="glm-5.4"` where the replayed flow accepts them.
- Uses the shipped run-handle pattern: keep the object returned by `.run(...)`, call `.wait()` separately, and replay with `handle.exec_id` / `source.exec_id`.
- Removes unreleased public-page keywords such as `at`, `invocation_overrides`, `checkpoint_overrides`, `skip`, and `raise_` from the audited Kitaru landing snippets.
- Removes unreleased `kitaru.diff(...)` / `kitaru.diff_matrix(...)` helper calls from copy-pastable snippets; the page now uses shipped execution metadata such as `llm_usage_summary` and keeps “diff” as the visual/product concept.
- Fixes the hero code panel so replay calls are split across multiple lines instead of forcing horizontal scrolling.
- Restores the five “same move” scenario cards — fail, mock, degrade, drop, swap — without letting the code badges push the row sideways.
- Keeps the what-if workflow cards inside the page width and shortens the code badge that was making the middle card expand.
- Restores the code-showcase layout as code on the left and hover explanations on the right, with normal line spacing and aligned container tops.
- Updates the shared install chip to a fresh-directory-safe `uv init --bare && uv add kitaru && uv run kitaru init`, while preserving Claude Agent SDK naming and broader claim-softening from the first commit.

## Reviewer Notes

The important story here is that there are two Kitaru realities in play:

1. The SDK overhaul branch has been exploring a more explicit scoped-override API and diff helpers.
2. The public client on `develop` still exposes replay as `replay(exec_id, *, from_, overrides=None, **flow_inputs)`, and does not export module-level `kitaru.diff` helpers yet.

The website should not hand visitors a snippet that fails the moment they copy it. So this PR now teaches the shipped shape: `.run(...)` returns the execution handle, `.wait()` waits for the result, replay uses that handle’s `exec_id`, ordinary flow inputs like `model` can change a replay, checkpoint outputs can be replaced through the `overrides` map, and returned execution metadata/checkpoints/artifacts provide the evidence.

For the visual fixes, the concrete failure mode was simple: long code strings were behaving like rigid metal rods inside flexible cards. They forced horizontal scrolling in the hero, pushed workflow cards off the screen, and made the code showcase abandon the old code-left / explanation-right composition. The fix is to make code examples taller and shorter: explicit line breaks for real snippets, smaller/shorter code badges for tiny cards, responsive scenario cards, normal `<pre>` line spacing in the dark code showcase, and aligned code/annotation container tops.

### Reproduction

1. Run the site locally:
   ```bash
   pnpm dev
   ```
2. Open `http://localhost:4321/product/kitaru`.
3. Check the visible Kitaru replay examples:
   - hero replay panel keeps `source = support_agent.run(ticket)`, calls `result = source.wait()`, then replays through `client.executions.replay(source.exec_id, ...)`;
   - hero continuation lines are indented, long replay calls are split, and narrow panels can scroll the code area instead of clipping it;
   - scenario strip shows five cards: fail, mock, degrade, drop, swap;
   - “What-if workflow” cards stay inside the page width;
   - “See the code” is again two-column: code left, explanation cards right, with normal Python line spacing and aligned top edges;
   - no audited landing snippet uses `at`, `invocation_overrides`, `checkpoint_overrides`, `skip`, `raise_`, `kitaru.diff(...)`, `kitaru.diff_matrix(...)`, or `exec.exec_id` after `.wait()`.
4. Spot-check the hero/get-started install chip and a Kitaru comparison page such as `/compare/kitaru-vs-restate`; the shared install copy should be `uv init --bare && uv add kitaru && uv run kitaru init`.

Local checks run:

- `pnpm check`
- `pnpm lint`
- `git diff --check`
- `pnpm build`
- disposable empty-directory smoke test of `uv init --bare && uv add kitaru && uv run kitaru init`

Additional review loops run:

- Initial `/simplify` review pass for reuse, quality, and efficiency
- Initial Oracle review of the first-pass API/copy diff
- Follow-up browser QA with `agent-browser` on `/product/kitaru`, including overflow measurements for the hero code, scenario grid, workflow cards, and code showcase

