### PR TITLE
Remove Product Engineer role from careers open positions

### DIFF
--- a/src/lib/company.ts
+++ b/src/lib/company.ts
@@ -94,11 +94,6 @@ export const COMPANY_VALUES = [
 // ---------------------------------------------------------------------------
 export const OPEN_POSITIONS = [
   {
-    title: "Product Engineer - ZenML/Kitaru (f/m/d)",
-    type: "Full-time",
-    href: "https://zenml.notion.site/Product-Engineer-ZenML-Kitaru-341f8dff2538800aa826c2624894dfc8",
-  },
-  {
     title: "GTM Engineer - ZenML/Kitaru (f/m/d)",
     type: "Full-time",
     href: "https://zenml.notion.site/GTM-Engineer-ZenML-Kitaru-f-m-d-372f8dff253880e586daeebc8f360a29",


### PR DESCRIPTION
## Summary

The **Product Engineer - ZenML/Kitaru (f/m/d)** role has been filled/closed, so it should no longer appear on the site. This removes it from the careers page, leaving only the **GTM Engineer** role open.

Closes #111.

## What changed

- `src/lib/company.ts` — removed the Product Engineer entry from `OPEN_POSITIONS` (the single source of truth for open roles, shared with the `/careers` page). One 5-line object deleted; the GTM Engineer entry is untouched.

No template changes were needed: `src/pages/careers.astro` renders the open-positions list by looping over `OPEN_POSITIONS`, so removing the data entry removes the card and its outbound Notion link automatically — no dangling references.

## What reviewers should focus on

- Nothing risky here. Worth a glance: confirm we intend to keep **only** the GTM Engineer role listed (that's the one remaining entry).
- The removed Notion link (`Product-Engineer-ZenML-Kitaru-...`) was referenced in exactly one place — verified via grep across `src/` and `public/` that no other page, redirect, or component links to it.

## Validation

- `pnpm check` — 0 errors, 0 warnings (2 pre-existing hints in `CalEmbed.astro` / `clipboard.ts`, unrelated)
- `pnpm lint` — clean (293 files)
- `pnpm build` — success; grepped the generated `dist/careers.html` to confirm **0** occurrences of "Product Engineer" and the GTM Engineer card still renders

## Preview paths to check

- `Preview URL + /careers` — Open Positions section should list only the GTM Engineer role