### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:00"
+      timezone: Europe/Amsterdam
+    reviewers: [strickvl]
+    labels: [dependencies]
+    groups:
+      minor-and-patch:
+        patterns: ['*']
+        update-types:
+          - minor
+          - patch
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:00"
+      timezone: Europe/Amsterdam
+    reviewers: [strickvl]
+    labels: [dependencies]
+    groups:
+      minor-and-patch:
+        patterns: ['*']
+        update-types:
+          - minor
+          - patch
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3


### PR DESCRIPTION
## Summary
- Add Dependabot version-update config for root pnpm/npm dependencies using package-ecosystem: npm
- Add Dependabot version-update config for GitHub Actions
- Use weekly Tuesday 07:00 Europe/Amsterdam schedule, reviewer strickvl, dependencies label, grouped updates, and cooldown
- Omit target-branch so Dependabot targets the repository default branch, main

## Validation
- ruby -ryaml parsed .github/dependabot.yml successfully
- Checked that exactly github-actions and npm update entries are present
- Checked that target-branch is not present
- git diff --cached --check passed before commit