### PR TITLE
chore(dependabot): group `astro` + `@astrojs/*`, ignore `@astrojs/preact` major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,11 +29,26 @@ updates:
     reviewers: [strickvl]
     labels: [dependencies]
     groups:
+      # Keep Astro core and its integrations together so an integration
+      # major (e.g. @astrojs/preact 5) can never land ahead of the matching
+      # astro core major. The Astro 5->6 upgrade should bump astro + all
+      # @astrojs/* in a single PR.
+      astro:
+        patterns:
+          - astro
+          - '@astrojs/*'
       minor-and-patch:
         patterns: ['*']
         update-types:
           - minor
           - patch
+    ignore:
+      # @astrojs/preact 5.x requires Astro 6 (Vite 7 / Node >=22.12) and
+      # breaks the build on Astro 5. Suppress the major until the Astro
+      # 5->6 migration; remove this ignore as part of that upgrade (see
+      # the Astro 5->6 tracking issue, #128).
+      - dependency-name: '@astrojs/preact'
+        update-types: ['version-update:semver-major']
     cooldown:
       default-days: 7
       semver-major-days: 14


### PR DESCRIPTION
## Summary

Prevents a repeat of #122, where Dependabot proposed `@astrojs/preact` 4→5 on its own. The 5.x integration belongs to the **Astro 6** generation (needs Vite 7 / Node ≥22.12) and breaks the build on our Astro 5 (`Could not resolve "astro:preact:opts"`). Two changes to `.github/dependabot.yml` (npm ecosystem):

## What changed

- **New `astro` group** matching `astro` + `@astrojs/*`, listed before `minor-and-patch`. Astro core and its integrations now bump **together** in one PR, so an integration major can never land ahead of the matching framework major.
- **Ignore `@astrojs/preact` major** (`version-update:semver-major`) until the Astro 5→6 upgrade. The inline comment points at the tracking issue (#128); that ignore should be **removed as part of the upgrade** so preact rejoins the grouped bump.

## What reviewers should focus on

- **Group ordering:** Dependabot assigns a dependency to the *first* matching group. `astro` is listed before `minor-and-patch`, so `astro`/`@astrojs/*` (all update types) land in the `astro` PR; everything else minor/patch stays in `minor-and-patch`. Non-astro majors still get individual PRs as before.
- The `astro` group intentionally has **no `update-types` filter** — it should carry majors too, since the whole point is that Astro 6 + its integration majors travel as a set.

## Validation

- `.github/dependabot.yml` parses cleanly (pyyaml); `npm` groups = `[astro, minor-and-patch]`, ignore = `@astrojs/preact` major.

## Related

- Closes the follow-up for #122 (closed)
- Unblocked by #128 (Astro 5→6 migration) — remove the preact ignore there