### PR TITLE
Fix Kitaru nav demo links

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -13,6 +13,7 @@ import {
   NAV_CTAS,
   NAV_LINKS,
 } from "../lib/navigation";
+import { KITARU_LINKS } from "../lib/productKitaru";
 import Button from "./Button.astro";
 /**
  * Navigation — responsive navbar matching the zenml.io Webflow site.
@@ -44,6 +45,8 @@ const starsRepoKey = isKitaruSurface ? "kitaru" : "zenml";
 const starsCountText = isKitaruSurface
   ? formatStars(KITARU_FALLBACK_STARS)
   : headerStarsFallback;
+const docsCta = NAV_CTAS[0];
+const demoCta = isKitaruSurface ? KITARU_LINKS.demo : NAV_CTAS[1];
 const llmopsCaseStudyCount = await getNonDraftLlmopsDatabaseCount();
 const navDropdowns = createNavDropdowns({ llmopsCaseStudyCount });
 
@@ -401,11 +404,11 @@ const productDropdownLinks = (dropdown: (typeof navDropdowns)[number]) => {
             >{starsCountText}</span>
           </a>
         </div>
-        <Button href={NAV_CTAS[0].href} variant="secondary" size="sm">
-          {NAV_CTAS[0].label}
+        <Button href={docsCta.href} variant="secondary" size="sm">
+          {docsCta.label}
         </Button>
-        <Button href={NAV_CTAS[1].href} variant="primary" size="sm">
-          {NAV_CTAS[1].label}
+        <Button href={demoCta.href} variant="primary" size="sm">
+          {demoCta.label}
         </Button>
       </div>
 
@@ -413,7 +416,9 @@ const productDropdownLinks = (dropdown: (typeof navDropdowns)[number]) => {
       <button
         type="button"
         class="ml-auto lg:hidden rounded-md p-2 text-gray-700 hover:bg-gray-50"
-        aria-label="Toggle menu"
+        aria-label="Open menu"
+        aria-controls="mobile-navigation-menu"
+        aria-expanded="false"
         data-mobile-toggle
       >
         <svg class="h-6 w-6 block" data-icon="open" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -430,49 +435,66 @@ const productDropdownLinks = (dropdown: (typeof navDropdowns)[number]) => {
   </div>
 
   {/* Mobile menu */}
-  <div class="hidden lg:hidden" data-mobile-menu>
+  <div id="mobile-navigation-menu" class="hidden lg:hidden" data-mobile-menu>
     <div class="border-t border-gray-200 bg-white px-4 pb-6 pt-4">
       <nav class="space-y-1" role="navigation" aria-label="Mobile navigation">
         {/* Mobile dropdown sections (as accordions) */}
-        {navDropdowns.map((dropdown) => (
-          <details class="group/accordion">
-            <summary class="flex cursor-pointer items-center justify-between rounded-md px-3 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 list-none [&::-webkit-details-marker]:hidden">
-              {dropdown.label}
-              <svg class="h-4 w-4 text-gray-400 transition-transform group-open/accordion:rotate-180" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M5 7.5L10 12.5L15 7.5" />
-              </svg>
-            </summary>
-            <div class="ml-4 mt-1 space-y-3 border-l border-gray-200 pl-4 pb-2">
-              {dropdown.sections.map((section) => (
-                <div>
-                  <div class="mb-1.5 text-xs font-semibold uppercase tracking-wider text-gray-400">
-                    {section.heading}
+        {navDropdowns.map((dropdown, index) => {
+          const triggerId = `mobile-nav-accordion-trigger-${index}`;
+          const panelId = `mobile-nav-accordion-panel-${index}`;
+
+          return (
+            <div>
+              <button
+                type="button"
+                id={triggerId}
+                class="flex w-full cursor-pointer items-center justify-between rounded-md px-3 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+                aria-expanded="false"
+                aria-controls={panelId}
+                data-mobile-accordion-trigger
+              >
+                {dropdown.label}
+                <svg class="h-4 w-4 text-gray-400 transition-transform" data-mobile-accordion-icon viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M5 7.5L10 12.5L15 7.5" />
+                </svg>
+              </button>
+              <div
+                id={panelId}
+                class="ml-4 mt-1 space-y-3 border-l border-gray-200 pl-4 pb-2"
+                aria-labelledby={triggerId}
+                hidden
+              >
+                {dropdown.sections.map((section) => (
+                  <div>
+                    <div class="mb-1.5 text-xs font-semibold uppercase tracking-wider text-gray-400">
+                      {section.heading}
+                    </div>
+                    {section.links.map((link) => (
+                      <a
+                        href={link.href}
+                        class="block rounded-md px-2 py-1.5 text-sm text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+                        target={link.external ? "_blank" : undefined}
+                        rel={link.external ? "noopener noreferrer" : undefined}
+                      >
+                        {link.label}
+                      </a>
+                    ))}
                   </div>
-                  {section.links.map((link) => (
-                    <a
-                      href={link.href}
-                      class="block rounded-md px-2 py-1.5 text-sm text-gray-600 hover:bg-gray-50 hover:text-gray-900"
-                      target={link.external ? "_blank" : undefined}
-                      rel={link.external ? "noopener noreferrer" : undefined}
-                    >
-                      {link.label}
-                    </a>
-                  ))}
-                </div>
-              ))}
-              {dropdown.featured?.links?.map((link) => (
-                <a
-                  href={link.href}
-                  class="block rounded-md px-2 py-1.5 text-sm text-gray-600 hover:bg-gray-50 hover:text-gray-900"
-                  target={link.external ? "_blank" : undefined}
-                  rel={link.external ? "noopener noreferrer" : undefined}
-                >
-                  {link.label}
-                </a>
-              ))}
+                ))}
+                {dropdown.featured?.links?.map((link) => (
+                  <a
+                    href={link.href}
+                    class="block rounded-md px-2 py-1.5 text-sm text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+                    target={link.external ? "_blank" : undefined}
+                    rel={link.external ? "noopener noreferrer" : undefined}
+                  >
+                    {link.label}
+                  </a>
+                ))}
+              </div>
             </div>
-          </details>
-        ))}
+          );
+        })}
 
         {/* Mobile direct links */}
         {NAV_LINKS.map((link) => (
@@ -491,11 +513,11 @@ const productDropdownLinks = (dropdown: (typeof navDropdowns)[number]) => {
 
         {/* Mobile CTAs */}
         <div class="mt-4 flex flex-col gap-2 pt-4 border-t border-gray-200">
-          <Button href={NAV_CTAS[0].href} variant="secondary" size="md" class="w-full justify-center">
-            {NAV_CTAS[0].label}
+          <Button href={docsCta.href} variant="secondary" size="md" class="w-full justify-center">
+            {docsCta.label}
           </Button>
-          <Button href={NAV_CTAS[1].href} variant="primary" size="md" class="w-full justify-center">
-            {NAV_CTAS[1].label}
+          <Button href={demoCta.href} variant="primary" size="md" class="w-full justify-center">
+            {demoCta.label}
           </Button>
         </div>
       </nav>
@@ -522,11 +544,34 @@ const productDropdownLinks = (dropdown: (typeof navDropdowns)[number]) => {
 
   toggle?.addEventListener("click", () => {
     const isOpen = !menu?.classList.contains("hidden");
+    const willOpen = !isOpen;
     menu?.classList.toggle("hidden", isOpen);
-    openIcon?.classList.toggle("hidden", !isOpen);
-    openIcon?.classList.toggle("block", isOpen);
-    closeIcon?.classList.toggle("hidden", isOpen);
-    closeIcon?.classList.toggle("block", !isOpen);
+    toggle.setAttribute("aria-expanded", String(willOpen));
+    toggle.setAttribute("aria-label", willOpen ? "Close menu" : "Open menu");
+    openIcon?.classList.toggle("hidden", willOpen);
+    openIcon?.classList.toggle("block", !willOpen);
+    closeIcon?.classList.toggle("hidden", !willOpen);
+    closeIcon?.classList.toggle("block", willOpen);
+  });
+
+  const accordionTriggers = document.querySelectorAll(
+    "[data-mobile-accordion-trigger]"
+  ) as NodeListOf<HTMLButtonElement>;
+
+  accordionTriggers.forEach((trigger) => {
+    const panelId = trigger.getAttribute("aria-controls");
+    if (!panelId) return;
+
+    const panel = document.getElementById(panelId);
+    const icon = trigger.querySelector("[data-mobile-accordion-icon]");
+    if (!panel) return;
+
+    trigger.addEventListener("click", () => {
+      const willOpen = panel.hasAttribute("hidden");
+      panel.toggleAttribute("hidden", !willOpen);
+      trigger.setAttribute("aria-expanded", String(willOpen));
+      icon?.classList.toggle("rotate-180", willOpen);
+    });
   });
 
   // Compact dropdowns: enforce single-open-at-a-time. Adjacent panels are


### PR DESCRIPTION
## Summary

- Routes shared Kitaru-surface `Book a demo` CTAs to `/book-your-demo/kitaru`.
- Keeps non-Kitaru shared nav demo CTAs on `/book-your-demo`.
- Replaces the mobile nav dropdown rows with explicit button-controlled panels that expose `aria-expanded` / `aria-controls`.
- Adds `aria-expanded` / `aria-controls` state to the mobile hamburger menu button.

## Reviewer Notes

This fixes two issues found while dogfooding the live `kitaru.ai` frontpage, which redirects to `/product/kitaru`.

The important behavior now happens in `src/components/Navigation.astro`. That component already receives the current path from `BaseLayout`, so it can decide whether the shared navigation is being rendered on a Kitaru page. On Kitaru surfaces, the shared nav uses the existing `KITARU_LINKS.demo` target. On normal ZenML pages, it keeps the existing generic `NAV_CTAS[1]` target.

The accessibility change is also in `Navigation.astro`. Previously, the mobile menu sections were native `details` / `summary` rows. The live audit did not see those headings as usable named controls with expanded/collapsed state. They are now real buttons connected to panels by `aria-controls`; clicking a button toggles the panel `hidden` state, updates `aria-expanded`, and rotates the chevron.

If this implementation is wrong, the likely failure modes are concrete:

- A Kitaru visitor clicks the header/mobile `Book a demo` button and lands on the generic ZenML demo form instead of the Kitaru-specific form.
- A normal ZenML visitor clicks the same shared nav CTA and unexpectedly lands on the Kitaru demo form.
- A mobile screen-reader or keyboard user cannot discover or operate the `Product`, `Docs`, or `Case Studies` mobile sections as expandable controls.

### Reproduction

1. Run the site locally:

   ```bash
   pnpm dev
   ```

2. Visit `http://localhost:4321/product/kitaru` at desktop width.
   - Inspect or click the header `Book a demo` CTA.
   - Expected: it points to `/book-your-demo/kitaru`.

3. Switch to a mobile viewport on `http://localhost:4321/product/kitaru`.
   - Open the hamburger menu.
   - Expected: the mobile `Book a demo` CTA points to `/book-your-demo/kitaru`.
   - Expected: `Product`, `Docs`, and `Case Studies` are buttons with `aria-expanded="false"` initially; activating one changes it to `aria-expanded="true"` and reveals its panel.

4. Visit `http://localhost:4321/pricing`.
   - Inspect or click the shared nav `Book a demo` CTA.
   - Expected: it still points to `/book-your-demo`.

### Local checks run

- `pnpm check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm smoke:dist`
- `/simplify` review loop: reuse, quality, and efficiency reviewers over the diff; low-risk cleanup findings applied.
- Oracle review: no P0/P1/P2 findings or blockers.
