### PR TITLE
Add blog post: Inngest vs Temporal vs Kitaru

### DIFF
--- a/src/content/blog/inngest-vs-temporal.md
+++ b/src/content/blog/inngest-vs-temporal.md
@@ -1,0 +1,351 @@
+---
+title: "Inngest vs Temporal vs Kitaru: Choosing the Right Runtime for Long-Running AI Agents"
+slug: "inngest-vs-temporal"
+draft: false
+author: "hamza-tahir"
+category: "kitaru"
+tags:
+  - "kitaru"
+  - "agents"
+  - "orchestrators"
+  - "discovery"
+date: "2026-07-07T10:17:43.582Z"
+readingTime: "18 mins"
+mainImage:
+  url: "https://assets.zenml.io/content/blog/inngest-vs-temporal/7a568628/inngest-vs-temporal.avif"
+  alt: "Inngest vs Temporal vs Kitaru comparison for long-running AI agents"
+seo:
+  title: "Inngest vs Temporal vs Kitaru: Runtime for Long-Running AI Agents - ZenML Blog"
+  description: "A practical comparison of Inngest, Temporal, and Kitaru for long-running AI agents, covering recovery, self-hosting, HITL waits, and what each one really costs."
+  canonical: "https://www.zenml.io/blog/inngest-vs-temporal"
+  ogImage: "https://assets.zenml.io/content/blog/inngest-vs-temporal/427b19a6/inngest-vs-temporal.jpg"
+---
+
+In a 40-minute run, your AI agent can make a dozen API calls, search across tools, wait for your approval, write files, and still somehow manage to fail on the final step. Restart from zero, and you pay for every one of those calls again. Inngest, Temporal, and Kitaru exist so you never have to.
+
+All three keep long-running work alive through crashes and retries. None is a drop-in for the others, because each starts from a different mental model:
+
+- Inngest starts from events and functions
+- Temporal from workflows and activities
+- Kitaru from the agent flows and replayable checkpoints
+
+This article compares Inngest vs Temporal vs Kitaru so you can match the runtime to the shape of your workload rather than to a feature checklist.
+
+## Inngest vs Temporal vs Kitaru: Key Takeaways
+
+- **[Inngest](https://www.inngest.com/):** An event-driven, durable execution platform for TypeScript, Python, and Go. It’s best if you already think in events, background jobs, webhooks, crons, and app-side workflows. It gives you durable functions with steps, retries, sleeps, and event waits without asking you to run queues yourself.
+- **[Temporal](https://temporal.io/):** A deterministic, durable workflow engine. It’s best when you need a mature orchestration platform with strong recovery guarantees. The workflow and activity model handles complex processes well, though workflow code has to obey deterministic execution rules, which usually means restructuring what you already have.
+- **[Kitaru](https://www.zenml.io/product/kitaru):** A replayable runtime layer purpose-built for Python agent runs. It sits under your existing agent stack and records everything as replayable checkpoints. That way, failed or error-prone runs can resume from the last saved step without starting over.
+
+## What Problems are These Tools Actually Solving?
+
+Let’s say you’re running a month-long workflow. When something goes wrong in the last few steps, would you prefer restarting from zero or letting it auto-recover and resume from the point it failed?
+
+That's the problem these tools are trying to solve. They keep your workflow alive, recover it after failures, and avoid repeating expensive model calls or tool executions that have already succeeded.
+
+### Inngest’s Model: Durable Event-Driven Functions
+
+Inngest functions are triggered by events, cron schedules, or webhook events. A function can also invoke another Inngest function from inside a step using `step.invoke()`, but that is a step method rather than a trigger type.
+
+### Temporal’s Model: Deterministic Durable Workflows
+
+Temporal is built around deterministic workflows. A workflow defines the process as code. Activities handle the external work like API calls, database reads, LLM calls and can fail and retry independently. Temporal records everything that happens as Event History, and replays that history to rebuild a workflow's state after a failure.
+
+### Kitaru’s Model: Replayable Agent Checkpoints
+
+Kitaru starts with the agent run. It does not ask you to first turn the agent into a business workflow or event function. It simply wraps Python agents, records the flow as checkpoints, and lets you replay anytime from any saved checkpoint.
+
+## Comparing Inngest, Temporal, and Kitaru features
+
+Before we deep dive into feature comparison, here’s a quick table summarizing how each tool weighs against others:
+
+| **Feature** | **Inngest** | **Temporal** | **Kitaru** |
+| --- | --- | --- | --- |
+| **Core architecture** | Durable event-driven functions | Deterministic durable workflows | Replayable Python agent checkpoints |
+| **Best starting point** | App events, crons, webhooks, jobs | Backend processes with workflow and activity boundaries | Existing Python agents |
+| **Recovery unit** | Step | Event history and activity result | Agent checkpoint |
+| **Waiting model** | Sleep, wait for event, signals | Timers, signals, updates | `wait()`, resume, HITL |
+| **Infra model** | Hosted Inngest or self-hosted server | Temporal Cloud or self-hosted Temporal Service | Self-hosted agent runtime |
+| **Main tradeoff** | Event and step model shapes your code | Deterministic rules shape your workflow code | Python agent focus, not broad workflow coverage |
+| **Best fit** | Product teams with event-heavy apps | Platform teams with deep workflow needs | AI teams with long-running Python agents |
+
+### Feature 1. Core Architecture: Event-Driven Functions vs Workflows vs Agent Replay
+
+The architecture is where the three stop being interchangeable, so start here.
+
+#### Kitaru
+
+![Kitaru self-hosted agent runtime architecture](https://assets.zenml.io/content/blog/inngest-vs-temporal/0bcd9144/image2.avif)
+
+Kitaru is a self-hosted, agent runtime. Unlike a general workflow engine that asks you to define a process, Kitaru starts from the agent run itself. Your agent can plan, call an LLM, use tools, wait for a person, and continue without being forced into a fixed graph first.
+
+Kitaru is framework-agnostic and runs under the harness your team already chose - you keep your SDK, prompts, tools, and model. Our platform also records model and tool calls, waits, and checkpointed Python steps as replayable checkpoints.
+
+Agents are non-deterministic by nature, and Kitaru's replay model accepts that. Temporal recovers by re-running your workflow code and matching it against recorded event history, which is why that code must be deterministic. Kitaru recovers by returning the persisted output of each checkpoint, so the code between checkpoints is free to branch, retry, or call an LLM differently on every run.
+
+Against Inngest, the difference is where the workload begins. Inngest starts from events. Kitaru starts from a long-running agent that needs to survive.
+
+See how [Kitaru compares to Temporal](https://www.zenml.io/compare/kitaru-vs-temporal).
+
+#### Inngest
+
+```tsx
+export default inngest.createFunction(
+  {
+    id: "import-product-images",
+    triggers: { event: "shop/product.imported" },
+  },
+  async ({ event, step }) => {
+    const uploadedImageURLs = await step.run("copy-images-to-s3", async () => {
+      return copyAllImagesToS3(event.data.imageURLs);
+    });
+  }
+);
+```
+
+In Inngest, you create a function, choose what triggers it, and split the work into individual steps. A trigger can be an event, a scheduled job, a webhook, or another function call.
+
+This mental model syncs well with app-based workflows because most product logic already starts with an event, like when a user signs up, a ticket is created, or a payment succeeds.
+
+Those events start functions, and each function can run across multiple steps while Inngest manages retries and state behind the scenes.
+
+For AI workflows, Inngest works best when the agent’s work maps naturally to an event-driven flow. For instance, an LLM call can run inside `step.run()`, the function can pause while waiting for user input or an event, and continue when the next event arrives.
+
+See how [Kitaru compares to Inngest](https://www.zenml.io/compare/kitaru-vs-inngest).
+
+#### Temporal
+
+```python
+@workflow.defn
+class AgentWorkflow:
+    @workflow.run
+    async def run(self, goal: str) -> str:
+        messages = [{"role": "user", "content": goal}]
+        while True: # Agent loops until it decides it's done
+            # LLM calls automatically retry on failure
+            response = await workflow.execute_activity(
+                call_llm, args=[messages, tools],
+                start_to_close_timeout=timedelta(seconds=60))
+
+            if not response.tool_calls: return response.content  # Agent is done
+
+            # Tool execution is durable - survives crashes
+            result = await workflow.execute_activity(
+                run_tool, args=[response.tool_call],
+                start_to_close_timeout=timedelta(minutes=5))
+
+            # Add LLM response and Tool result to the agent context
+            messages.append(response.message)
+            messages.append({"role": "tool", "content": result})
+```
+
+[Temporal’s](https://www.zenml.io/blog/temporal-alternatives) core architecture is built around durable workflows that can continue running even when workers fail or processes restart.
+
+At the center of its architecture is the workflow, which defines the overall execution logic, while activities handle non-deterministic operations like API calls, file I/O, or LLM requests.
+
+Workers poll task queues and execute workflows and activities. In the backend, the Temporal service stores the workflow's event history. If something goes wrong, Temporal uses that event history to rebuild the workflow state and continue execution from where it left off.
+
+This architecture gives Temporal strong reliability guarantees. However, the tradeoff is determinism.
+
+During replay, the workflow code must produce the same decision sequence every time. Any direct time calls, random numbers, or network calls outside of activities can break replay, which is why Temporal expects these operations to be moved into activities instead.
+
+Overall, it’s a powerful model for production workloads, but it requires you to structure agent code around Temporal's workflow and activity pattern.
+
+**Verdict:** Match the architecture to your unit of work. If the unit is an app event, Inngest's function-and-step model will feel native. If it is a business process with strict recovery guarantees, Temporal's workflow-and-activity split earns its learning curve. If it is a Python agent run, Kitaru wraps what you already have instead of asking you to re-architect it.
+
+### Feature 2: Durable Execution, Retry, and Failure Recovery
+
+With AI agents, crashes are inevitable. What matters is whether your runtime starts from the beginning every time or recovers from the last meaningful point.
+
+#### Kitaru
+
+![Kitaru resuming an agent from the last replayable checkpoint](https://assets.zenml.io/content/blog/inngest-vs-temporal/791f188a/image9.avif)
+
+Kitaru’s recovery model is built around replayable checkpoints. A checkpoint can be a model call, a tool call, or any Python step you mark. Each one is a save point. When a step fails, the agent resumes from the last save point instead of the starting line.
+
+Let's say an agent crashes after expensive research or a pricey tool call. Because you’ve saved this step or call as a checkpoint, you don’t need to restart the run and pay for the same LLM call twice. The agent can replay from the saved point and continue.
+
+Kitaru also stores the context around the checkpoint - any outputs, wait and resume state, replay context, and adapter metadata. It tracks artifacts and execution history too, so you can inspect what happened before you resume or replay the agent.
+
+#### Inngest
+
+![Inngest breaking a function into recoverable steps](https://assets.zenml.io/content/blog/inngest-vs-temporal/9dd3338c/image3.avif)
+
+[Source](https://www.inngest.com/docs/setup/checkpointing)
+
+Inngest lets you break a function into smaller units called ‘steps.’ Each step becomes its own recovery point, so a function can:
+
+- Pause without holding compute
+- Recover individual work units after errors
+- Compose multi-step workflows from TypeScript, Python, or Go code
+
+The core building block is `step.run()`. You wrap the work that should be retried or recovered inside a step. If that step fails, Inngest retries that particular step instead of restarting the whole function.
+
+Suppose a support workflow is triggered to classify a ticket, generate an AI summary, pause for your approval, and then send a response. If the final response call fails, you don’t need to reapprove the message. The workflow will recover from the failed response step without restarting the full pipeline.
+
+This runtime model is best if you’re building an app. However, you’d need to split the product logic into Inngest steps. For event-heavy apps, that’s not a big thing. The catch for agents is that Inngest wants the work expressed as named steps and resumption routed through events. That fits app logic well. It fits an agent whose next tool call is decided at runtime less naturally, because you end up translating an emergent loop into a step vocabulary the runtime can memoize.
+
+#### Temporal
+
+![Temporal workflow event history used to rebuild state after a failure](https://assets.zenml.io/content/blog/inngest-vs-temporal/f01c4e5c/image1.avif)
+
+[Source](https://docs.temporal.io/workflow-execution/event)
+
+Temporal records workflow progress in event history. When a worker crashes, another worker can replay the workflow code from the beginning and use recorded events to rebuild state.
+
+However, on recovery, it does not redo completed Activities. Their recorded results are returned from event history. Failed activities may still retry based on your workflow policy.
+
+To make this work, Temporal separates workflow logic from activities. Your workflow defines the process, while activities handle side effects like API requests, database operations, sending emails, file I/O, or LLM calls.
+
+This separation is core to Temporal's architecture. While activity code can be non-deterministic, workflow code must always produce the same result when it’s replayed.
+
+The result is a clean and reliable architecture, but it also asks you to reshape existing agent code around Temporal's workflow model. It can also feel heavy for teams that already have agent code and just need runtime recovery.
+
+**Verdict:** All three recover without redoing finished work, so judge them on where recovery lives. Temporal owns it at the platform level through event history. Inngest scopes it to the step you wrapped. Kitaru scopes it to the checkpoint inside an agent run. Pick the one whose recovery unit maps onto your actual failure stories with the least translation.
+
+### Feature 3: Infrastructure, Self-Hosting, and Lock-In
+
+#### Kitaru
+
+Kitaru treats infrastructure as a swappable "stack" rather than a fixed home for your agent. A stack bundles the execution target (local, Kubernetes, SageMaker, Vertex AI, or AzureML), the state store (a SQL database you own), and the artifact store (your own S3, GCS, or Azure Blob bucket). You write and checkpoint the agent once, then point it at a different stack with a CLI command or an environment variable, and the agent code does not change.
+
+Because Kitaru is self-hosted and Apache 2.0, the durability layer never leaves your environment. There is no mandatory SaaS control plane sitting in the path of your agent's data, so you keep your own cloud accounts, buckets, and clusters. It runs as a single server plus a SQL database, which is far lighter to operate than a multi-service cluster, and each run executes in its own ephemeral container scheduled by an orchestrator rather than on long-lived workers you have to keep warm.
+
+#### Inngest
+
+Inngest splits cleanly along the two layers. Your functions run on your own compute in any environment, invoked either over HTTP for serverless platforms like Vercel, Lambda, or Cloudflare, or over a persistent WebSocket connection for long-running containers on Kubernetes, ECS, or Fly. That makes the compute side genuinely portable. You can move a function from Lambda to Kubernetes without touching the durability logic.
+
+The orchestration engine is the real catch, though. The queue, state store, and executor are Inngest's, and for most teams, they run on Inngest Cloud. Self-hosting arrived with Inngest 1.0 in September 2024, runs the same binary as Cloud, and has since gained Postgres support and a production Helm chart.
+
+But it launched single-node, carries no guaranteed support, and the server is source-available under SSPL (each release converts to Apache 2.0 three years later) rather than open source at the moment of release. So your compute is free to move, while the durable-execution engine is Inngest's managed service by default, with self-hosting as a newer and less battle-tested escape hatch.
+
+#### Temporal
+
+Temporal is architecturally the most infrastructure-agnostic of the three. The Temporal Service orchestrates workflow state but never runs your business logic. Your code runs on Workers you deploy on your own compute, and this stays true even on Temporal Cloud, which hosts the orchestration state and never executes your code. Workers can live on Kubernetes, VMs, serverless, or on-prem, and an application moves between self-hosted and Cloud by changing a connection config.
+
+The cost of that agnosticism is operational. Self-hosting Temporal means operating the Temporal Server’s services, including Frontend, History, Matching, and Worker, plus persistence and visibility stores. Supported persistence includes Cassandra, MySQL, and PostgreSQL, while visibility options include SQL stores, Elasticsearch, and OpenSearch depending on deployment needs.
+
+The alternative is Temporal Cloud, which removes the cluster work but is priced on usage. Temporal hands you near-total freedom over where things run, then hands you the bill for that freedom as either ops complexity or consumption fees.
+
+**Verdict:** Temporal is the most portable on paper and the most expensive to own in practice, either as a four-service cluster you operate or as consumption-billed Cloud. Inngest keeps your compute portable but routes durability through its engine, with self-hosting as a young escape hatch under a delayed-open license. Kitaru keeps both the compute and the durability layer in your own accounts under Apache 2.0, and pays for it by being Python-only and the newest of the three.
+
+### Feature 4. Pause, Wait, and HITL Workflows
+
+Modern agentic AI systems often need to stop and ask for input. For example, a coding agent may wait for approval before opening a source repo, or a finance agent may wait before sending money. Both cases need a runtime that can hold the pause without losing progress or burning compute while it waits.
+
+#### Kitaru
+
+![Kitaru pausing and resuming an agent without consuming compute while it waits](https://assets.zenml.io/content/blog/inngest-vs-temporal/b6204eb1/pause_resume_no_compute.gif)
+
+Kitaru treats waiting as part of agent execution. The runtime provides a `wait()` primitive alongside checkpoints, so waiting becomes a built-in part of the execution model instead of custom app logic.
+
+Combined with [checkpointed execution](https://www.zenml.io/blog/why-agents-need-durable-execution), an agent can safely stop for human input, a webhook, or another external event, then continue without repeating completed steps or consuming resources while idle.
+
+This is where Kitaru’s agent-first model helps. HITL is not an external pattern you bolt on later. It is built into the runtime, which makes long-running agents easier to pause, recover, and resume throughout their lifecycle.
+
+#### Inngest
+
+![Inngest pausing a function with step.sleep and waiting for events](https://assets.zenml.io/content/blog/inngest-vs-temporal/febcfea4/image6.avif)
+
+In Inngest, you can use `step.sleep()` to pause execution for a fixed duration or `step.sleepUntil()` to resume at a specific date and time. These pauses can last for extended periods, even up to a year.
+
+It also supports event-based waiting. A function can pause until a matching event arrives, which makes it well suited for workflows like user onboarding, payment retries, and approval processes. Inngest also supports signals, so an external system can wake a specific paused run directly instead of broadcasting an event.
+
+You also benefit from how Inngest handles concurrency. Functions that are sleeping, waiting for an event, or paused between steps do not count toward concurrency limits. Only steps that are actively executing code count.
+
+Similar to Kitaru, Inngest’s mental model works especially well for human-in-the-loop workflows where the next action naturally arrives as an event or signal. That is common in product apps where a user response or webhook callback triggers the workflow.
+
+#### Temporal
+
+![Temporal human-in-the-loop workflow waiting for approval](https://assets.zenml.io/content/blog/inngest-vs-temporal/550c32ed/image5.avif)
+
+[Source](https://learn.temporal.io/tutorials/ai/building-durable-ai-applications/human-in-the-loop/)
+
+Temporal approaches are built into the workflow itself. It supports waiting through:
+
+- **Timers**: Scheduled delays
+- **Signals**: Receive external input
+- **Queries**: Expose the current workflow state
+- **Updates**: Modify a running workflow while returning a response
+
+With this combination, Temporal lets you build year-long active workflows. That combination supports workflows that stay active for a year, and it handles approval gates well, whether the approver is a manager or a compliance team.
+
+The tradeoff is that you need to model the approval state and message handlers. If your team is already using Temporal, that is expected work. But if not, Temporal introduces extra structure before the agent can wait safely.
+
+**Verdict:** All three handle long pauses without losing progress, so capability is not the deciding factor here. What differs is the assembly required. Temporal gives you the most control, but you model the approval state and message handlers yourself, which is fine if Temporal is already your platform and overhead if it is not. Inngest is low-friction when the wait is an event, signal, or webhook from your product. Sleeping, waiting, or paused runs do not count toward concurrency/capacity limits while no step code is actively executing. Kitaru assumes the pause happens mid-run inside an agent and builds `wait()` into the runtime, so there is no HITL pattern to assemble. Pick based on where your waits originate, in the app, in the business process, or inside the agent itself.
+
+## Developer Experience: How Much Do You Need to Change Your Code?
+
+There’s no one-size-fits-all scenario. Each tool requires you to change something in your code, and it’s best to know by how much:
+
+| **Tool** | **What you change** | **Developer cost** | **Best developer fit** |
+| --- | --- | --- | --- |
+| Inngest | Wrap logic in Inngest functions and steps | Low to medium | App teams already using events, serverless, or background jobs |
+| Temporal | Split workflows and activities, run workers, follow deterministic rules | Medium to high | Backend/platform teams comfortable with workflow systems |
+| Kitaru | Wrap Python agent flows with Kitaru primitives or adapters | Low for Python agents | AI teams with existing Python agent code |
+
+**For Inngest,** the developer experience is friendly when the app already thinks in events. You define functions with `createFunction`, choose triggers, and wrap work in `step.run()`. It may require reshaping agent code into named steps and events.
+
+**For Temporal,** developers need to learn the workflow/activity split. They also need workers, task queues, SDK patterns, and deterministic workflow rules. In return, they get a durable system with deep recovery semantics and years of production history.
+
+**For Kitaru,** the pitch is less code reshaping for Python agent teams. You keep the agent harness and add runtime safety under it. It’s even better when you are already using PydanticAI, OpenAI Agents SDK, Claude Agent SDK, LangGraph, or raw Python. You are not buying a new agent brain; you are adding checkpoints, replay, waits, artifacts, and run inspections around the agent you’ve already built.
+
+## Inngest vs Temporal vs Kitaru: Pricing
+
+Budgeting these tools gets tricky because they do not meter work in the same way. So here’s a real comparison for how much you actually pay for:
+
+### Kitaru
+
+Kitaru is free and open source under Apache 2.0. It gives you the core agent runtime for checkpoints, replay, and wait/resume in their own environment.
+
+When you need a managed control plane, RBAC, SSO, and support on top of the OSS runtime, ZenML Pro covers Kitaru workspaces with a Scale plan at $999 per month and a custom Enterprise tier.
+
+![Kitaru and ZenML Pro pricing](https://assets.zenml.io/content/blog/inngest-vs-temporal/b5a1857a/image4.avif)
+
+### Inngest
+
+Inngest's pricing makes more sense when you look beyond the monthly plans and focus on how work is actually executed.
+
+Costs are tied to factors like function runs, steps, concurrency, retention, and observability, so the overall value depends on how your app is structured and not the number of developers using the platform.
+
+At its core, Inngest has three base plans with different execution limits:
+
+- **Hobby:** Free
+- **Pro:** $99 per month
+- **Enterprise:** Custom pricing
+
+![Inngest pricing plans](https://assets.zenml.io/content/blog/inngest-vs-temporal/20aa0263/image7.avif)
+
+### Temporal
+
+Temporal Cloud uses a consumption-based pricing model, where costs are primarily driven by actions, storage, and the kind of support you expect.
+
+Temporal currently offers three plans:
+
+- **Essentials:** $100 per month
+- **Business:** $500 per month
+- **Enterprise:** Contact sales
+
+![Temporal Cloud pricing plans](https://assets.zenml.io/content/blog/inngest-vs-temporal/887e29a2/image8.avif)
+
+Read more about [Temporal pricing](https://www.zenml.io/blog/temporal-pricing).
+
+## Final Recommendation: Which One Should You Choose?
+
+All three tools are excellent at what they were designed to do. Your decision should come down to the type of workload you're building, how much operational complexity you're comfortable with, and whether you're orchestrating application workflows or long-running AI agents.
+
+- Choose Inngest if your workload starts from app events.
+- Choose Temporal if your workload is a serious backend workflow system.
+- Choose Kitaru if your workload starts as a Python agent.
+
+If your Python agents already call LLMs, tools, humans, and external systems, Kitaru gives them a runtime layer built around checkpoints, replay, resume, `wait()`, artifact lineage, and run inspection.
+
+Start with our open source product when you want to test it in your own environment. Move to ZenML Pro (comes with Kitaru inside) when your team needs the managed control plane, SSO, audit, and support across production agent work.
+
+Curious about how Kitaru can make your AI workflows more efficient? [Book a demo](https://www.zenml.io/book-your-demo/kitaru) with one of our engineers.
+
+**Other comparisons worth reading:**
+
+- [n8n vs Temporal](https://www.zenml.io/blog/n8n-vs-temporal)
+- [Prefect vs Temporal](https://www.zenml.io/blog/prefect-vs-temporal)
+- [Temporal vs Airflow](https://www.zenml.io/blog/temporal-vs-airflow)


### PR DESCRIPTION
## Summary

Adds a new SEO comparison blog post, **"Inngest vs Temporal vs Kitaru: Choosing the Right Runtime for Long-Running AI Agents."** It's a three-way comparison for teams picking a durable runtime for long-running AI agents, positioning Kitaru alongside Inngest and Temporal across architecture, failure recovery, self-hosting/lock-in, pause/HITL waits, developer experience, and pricing.

- **Author:** Hamza Tahir · **Publish date:** 2026-07-07
- **Category:** `kitaru` · **Tags:** `kitaru`, `agents`, `orchestrators`, `discovery`
- **Source:** local markdown draft (Tanish / GTM content)

## What changed

- New post: `src/content/blog/inngest-vs-temporal.md` (slug `inngest-vs-temporal`, ~18 min read).
- 11 images converted to AVIF and uploaded to R2 under `content/blog/inngest-vs-temporal/`; the pause/resume demo is kept as an animated GIF. Cover has both an AVIF (`mainImage.url`) and a JPEG sibling (`seo.ogImage`).
- Descriptive alt text added to every image (the draft had them all empty).
- No new tags / authors / categories — all referenced slugs already exist.

## What reviewers should focus on

- **`discovery` tag** is set so this stays off the main `/blog` listing (SEO/comparison convention) — confirm that's intended.
- **`seo.ogImage` is JPEG while `mainImage.url` is AVIF**, per the PR #73 social-card fix (LinkedIn/X/Slack reject AVIF OG cards).
- **Small copy fixes I made while publishing** (content is otherwise exactly as drafted): fixed 3 malformed bold-link bullets in Key Takeaways (`[**Inngest](url):**` → `**[Inngest](url):**`), rewrote 2 "See how Kitaru compares…" lines to use descriptive anchor text instead of raw URLs, and added one missing sentence period.
- **All internal links resolve** to existing pages: `/compare/kitaru-vs-temporal`, `/compare/kitaru-vs-inngest`, `/blog/temporal-alternatives`, `/blog/temporal-pricing`, `/blog/n8n-vs-temporal`, `/blog/prefect-vs-temporal`, `/blog/temporal-vs-airflow`, `/blog/why-agents-need-durable-execution`, `/product/kitaru`, `/book-your-demo/kitaru`.

## Validation

- `pnpm validate:content` → ✅ **PASSED** (remaining warnings are pre-existing llmops/mlops-database slug/tag issues, not this post).
- `astro build` → ✅ generates `/blog/inngest-vs-temporal.html`; verified the rendered title, canonical, `og:image` (JPEG), author, reading time, and all 12 R2 image references.
- Pre-existing / environment-only, unrelated to this post: `pnpm check` has the known `mdast` type error; `pnpm lint` has a repo-wide baseline of code-file errors; the local `pnpm build` pagefind step fails only on Windows (the single-quoted `--glob` isn't stripped by `cmd`). CI runs on Linux and is unaffected.

## Preview URLs / paths to check

- `Preview URL` + `/blog/inngest-vs-temporal`
- Confirm the cover and inline images load (including the animated pause/resume GIF), and that the social card renders with the JPEG `og:image`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
