### PR TITLE
Hold Astro majors as a set in `dependabot.yml`, group `wrangler` with the adapter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,23 +31,39 @@ updates:
     groups:
       # Keep Astro core and its integrations together so an integration
       # major (e.g. @astrojs/preact 5) can never land ahead of the matching
-      # astro core major. The Astro 5->6 upgrade should bump astro + all
-      # @astrojs/* in a single PR.
+      # astro core major. The Astro upgrade must bump astro + all @astrojs/*
+      # in a single PR.
+      #
+      # wrangler is in this group on purpose: @astrojs/cloudflare 14 pulls in
+      # @cloudflare/vite-plugin, which asserts `wrangler ^4.110.0` at startup
+      # and hard-fails the build if it is not satisfied. wrangler must be able
+      # to move in the same PR as the adapter, so it cannot live in
+      # minor-and-patch. (This is what broke #136.)
       astro:
         patterns:
           - astro
           - '@astrojs/*'
+          - wrangler
       minor-and-patch:
         patterns: ['*']
         update-types:
           - minor
           - patch
     ignore:
-      # @astrojs/preact 5.x requires Astro 6 (Vite 7 / Node >=22.12) and
-      # breaks the build on Astro 5. Suppress the major until the Astro
-      # 5->6 migration; remove this ignore as part of that upgrade (see
-      # the Astro 5->6 tracking issue, #128).
-      - dependency-name: '@astrojs/preact'
+      # Astro 5 -> 7 is a migration, not a bump: two majors, plus Vite 6 -> 8,
+      # plus a Node floor raise. Majors for astro and its integrations are held
+      # as a SET until that work happens (#128). Astro 5.x minor/patch and
+      # security updates still flow normally.
+      #
+      # These must be ignored together, not individually. An ignore is applied
+      # BEFORE grouping, so ignoring one member of the astro group does not hold
+      # the group back -- it silently drops that member out of the group PR. The
+      # previous @astrojs/preact-only ignore did exactly that, and produced #136:
+      # a PR bumping core to Astro 7 while pinning @astrojs/preact to an
+      # Astro-5-generation 4.x. Lift this whole block as step 1 of #128.
+      - dependency-name: 'astro'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@astrojs/*'
         update-types: ['version-update:semver-major']
     cooldown:
       default-days: 7


### PR DESCRIPTION
## Summary

While clearing this week's Dependabot batch (#142 and #143 merged, #136 closed), the grouped Astro PR (#136) turned out to be unmergeable for a reason worth fixing in config rather than by hand each week: **our `ignore` rule and our `group` rule were quietly fighting each other.**

Dependabot applies `ignore` rules *before* grouping. So the `@astrojs/preact`-only ignore we added in #129 did not hold the astro group back — it silently **dropped preact out of the group PR**. The result was #136: a PR bumping `astro` 5 → 7 while pinning `@astrojs/preact` to an Astro-5-generation `4.x`. No human would ever propose that combination, and it could never go green.

## What changed

Only `.github/dependabot.yml`.

**1. Hold Astro majors as a set, not one member at a time.**

Replaced the `@astrojs/preact`-only major ignore with a pair covering `astro` and `@astrojs/*` together. Astro 5.x **minor/patch and security updates still flow normally** — only majors are held, and only until the migration in #128 happens. The rule of thumb, written into the file as a comment: *an ignore on one member of a group does not pause the group, it corrupts it.*

**2. Move `wrangler` into the `astro` group.**

`@astrojs/cloudflare` 14 pulls in `@cloudflare/vite-plugin`, which asserts its wrangler peer at startup and hard-fails:

```
The installed version of Wrangler (4.105.0) does not satisfy the peer
dependency required by @cloudflare/vite-plugin (^4.110.0).
    at assertWranglerVersion (@cloudflare/vite-plugin/dist/index.mjs:1500:77)
```

`wrangler` previously lived in `minor-and-patch`, so a grouped adapter major could never bring a compatible wrangler with it. It has to be able to move in the same PR as the adapter.

## What reviewers should focus on

- **The `wrangler` regrouping has a cosmetic side effect I chose to accept:** routine `wrangler` patch bumps will now arrive in a PR titled *"Bump the astro group"* rather than *"minor-and-patch"*. Slightly odd-looking, but correctness beats the label — and wrangler updates are **not** frozen by the new ignore (ignores key off `dependency-name`, and wrangler is not named there).
- **Group assignment depends on ordering.** A package lands in the first group whose patterns *and* update-types match. `astro` is listed first and has no `update-types` filter, so it matches every update type and `astro`/`@astrojs/*`/`wrangler` never fall through to `minor-and-patch`. If someone reorders these groups later, the grouping silently stops working.
- **The comments are deliberately long.** They exist so the next person does not re-introduce the exact ignore/group interaction bug that produced #136.

## Validation

- YAML parses; verified the parsed structure is what we intend (astro group patterns `[astro, @astrojs/*, wrangler]`; ignores `[astro, @astrojs/*]` × semver-major).
- Confirmed `dependency-name` supports `*` wildcards in `ignore` rules, so `@astrojs/*` genuinely matches mdx/cloudflare/preact/sitemap/check.
- No site code touched — no runtime surface.

## Related

- Closes the config half of #136 (closed, with the full failure analysis in the thread).
- #128 retitled **Astro 5 → 7** and rewritten: lifting this ignore block is now written in as **step 1** of that work, along with the wrangler `>=4.110.0` requirement.