### PR TITLE
Harden form input validation

### DIFF
--- a/src/lib/formValidation.ts
+++ b/src/lib/formValidation.ts
@@ -14,32 +14,56 @@ export type FormType =
 interface FieldRule {
   required?: boolean;
   pattern?: RegExp;
+  maxLength?: number;
+  disallowedPattern?: RegExp;
   message: string;
+  invalidMessage?: string;
 }
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const URL_RE = /^https?:\/\/.+/;
+// biome-ignore lint/suspicious/noControlCharactersInRegex: Plain-text CRM fields must reject ASCII control characters.
+const UNSAFE_PLAIN_TEXT_RE = /[<>\u0000-\u001f\u007f]/;
+
+const FULL_NAME_RULE: FieldRule = {
+  required: true,
+  maxLength: 100,
+  disallowedPattern: UNSAFE_PLAIN_TEXT_RE,
+  message: "Full name is required",
+  invalidMessage:
+    "Full name must be 100 characters or fewer and cannot contain HTML or line breaks",
+};
+
+const OPTIONAL_COMPANY_RULE: FieldRule = {
+  maxLength: 200,
+  disallowedPattern: UNSAFE_PLAIN_TEXT_RE,
+  message: "Company or organization name is invalid",
+  invalidMessage:
+    "Company or organization name must be 200 characters or fewer and cannot contain HTML or line breaks",
+};
 
 /** Per-form field validation rules. */
 export const FORM_RULES: Record<FormType, Record<string, FieldRule>> = {
   "demo-request": {
-    fullName: { required: true, message: "Full name is required" },
+    fullName: FULL_NAME_RULE,
     email: {
       required: true,
       pattern: EMAIL_RE,
       message: "Valid work email is required",
     },
+    company: OPTIONAL_COMPANY_RULE,
   },
   whitepaper: {
-    fullName: { required: true, message: "Full name is required" },
+    fullName: FULL_NAME_RULE,
     email: {
       required: true,
       pattern: EMAIL_RE,
       message: "Valid work email is required",
     },
+    company: OPTIONAL_COMPANY_RULE,
   },
   "brick-manual": {
-    fullName: { required: true, message: "Full name is required" },
+    fullName: FULL_NAME_RULE,
     email: {
       required: true,
       pattern: EMAIL_RE,
@@ -47,7 +71,7 @@ export const FORM_RULES: Record<FormType, Record<string, FieldRule>> = {
     },
   },
   "startup-academic": {
-    fullName: { required: true, message: "Full name is required" },
+    fullName: FULL_NAME_RULE,
     email: {
       required: true,
       pattern: EMAIL_RE,
@@ -58,7 +82,11 @@ export const FORM_RULES: Record<FormType, Record<string, FieldRule>> = {
       pattern: URL_RE,
       message: "LinkedIn URL is required",
     },
-    company: { required: true, message: "Organization name is required" },
+    company: {
+      ...OPTIONAL_COMPANY_RULE,
+      required: true,
+      message: "Organization name is required",
+    },
     role: { required: true, message: "Please select a role" },
   },
 };
@@ -79,9 +107,16 @@ export function validateForm(
   const errors: Record<string, string> = {};
 
   for (const [field, rule] of Object.entries(rules)) {
-    const value = (data[field] ?? "").trim();
+    const rawValue = data[field] ?? "";
+    const value = rawValue.trim();
     if (rule.required && !value) {
       errors[field] = rule.message;
+    } else if (
+      value &&
+      ((rule.maxLength !== undefined && rawValue.length > rule.maxLength) ||
+        rule.disallowedPattern?.test(rawValue))
+    ) {
+      errors[field] = rule.invalidMessage ?? rule.message;
     } else if (value && rule.pattern && !rule.pattern.test(value)) {
       errors[field] = rule.message;
     }

--- a/src/lib/formValidation.ts
+++ b/src/lib/formValidation.ts
@@ -5,6 +5,8 @@
  * the Cloudflare Pages Function (server-side).
  */
 
+import { JOB_TITLE_OPTIONS, STARTUP_ROLE_OPTIONS } from "./formConstants";
+
 export type FormType =
   | "demo-request"
   | "whitepaper"
@@ -16,14 +18,41 @@ interface FieldRule {
   pattern?: RegExp;
   maxLength?: number;
   disallowedPattern?: RegExp;
+  allowedValues?: readonly string[];
+  validate?: (value: string) => boolean;
   message: string;
   invalidMessage?: string;
 }
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const URL_RE = /^https?:\/\/.+/;
 // biome-ignore lint/suspicious/noControlCharactersInRegex: Plain-text CRM fields must reject ASCII control characters.
 const UNSAFE_PLAIN_TEXT_RE = /[<>\u0000-\u001f\u007f]/;
+const JOB_TITLE_VALUES = JOB_TITLE_OPTIONS.map(({ value }) => value);
+const STARTUP_ROLE_VALUES = STARTUP_ROLE_OPTIONS.map(({ value }) => value);
+
+function isLinkedInProfileUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    const hostname = url.hostname.toLowerCase();
+    const isLinkedInHost =
+      hostname === "linkedin.com" ||
+      hostname === "www.linkedin.com" ||
+      /^[a-z]{2,3}\.linkedin\.com$/.test(hostname);
+    const pathParts = url.pathname.split("/").filter(Boolean);
+
+    return (
+      url.protocol === "https:" &&
+      !url.username &&
+      !url.password &&
+      !url.port &&
+      isLinkedInHost &&
+      pathParts[0] === "in" &&
+      Boolean(pathParts[1])
+    );
+  } catch {
+    return false;
+  }
+}
 
 const FULL_NAME_RULE: FieldRule = {
   required: true,
@@ -52,6 +81,10 @@ export const FORM_RULES: Record<FormType, Record<string, FieldRule>> = {
       message: "Valid work email is required",
     },
     company: OPTIONAL_COMPANY_RULE,
+    jobTitle: {
+      allowedValues: JOB_TITLE_VALUES,
+      message: "Please select a valid job title",
+    },
   },
   whitepaper: {
     fullName: FULL_NAME_RULE,
@@ -61,6 +94,10 @@ export const FORM_RULES: Record<FormType, Record<string, FieldRule>> = {
       message: "Valid work email is required",
     },
     company: OPTIONAL_COMPANY_RULE,
+    jobTitle: {
+      allowedValues: JOB_TITLE_VALUES,
+      message: "Please select a valid job title",
+    },
   },
   "brick-manual": {
     fullName: FULL_NAME_RULE,
@@ -79,15 +116,23 @@ export const FORM_RULES: Record<FormType, Record<string, FieldRule>> = {
     },
     linkedin: {
       required: true,
-      pattern: URL_RE,
+      maxLength: 500,
+      disallowedPattern: UNSAFE_PLAIN_TEXT_RE,
+      validate: isLinkedInProfileUrl,
       message: "LinkedIn URL is required",
+      invalidMessage: "Valid LinkedIn profile URL is required",
     },
     company: {
       ...OPTIONAL_COMPANY_RULE,
       required: true,
       message: "Organization name is required",
     },
-    role: { required: true, message: "Please select a role" },
+    role: {
+      required: true,
+      allowedValues: STARTUP_ROLE_VALUES,
+      message: "Please select a role",
+      invalidMessage: "Please select a valid role",
+    },
   },
 };
 
@@ -115,6 +160,12 @@ export function validateForm(
       value &&
       ((rule.maxLength !== undefined && rawValue.length > rule.maxLength) ||
         rule.disallowedPattern?.test(rawValue))
+    ) {
+      errors[field] = rule.invalidMessage ?? rule.message;
+    } else if (
+      value &&
+      ((rule.allowedValues && !rule.allowedValues.includes(value)) ||
+        (rule.validate && !rule.validate(value)))
     ) {
       errors[field] = rule.invalidMessage ?? rule.message;
     } else if (value && rule.pattern && !rule.pattern.test(value)) {

--- a/src/pages/api/forms/[formType].ts
+++ b/src/pages/api/forms/[formType].ts
@@ -22,7 +22,7 @@ const VALID_FORM_TYPES = new Set<FormType>(
   Object.keys(FORM_RULES) as FormType[],
 );
 
-/** Fields excluded from the Segment track payload (sensitive or irrelevant for CRM). */
+/** Non-content fields omitted from submission metadata logs. */
 const EXCLUDED_FIELDS = new Set(["cf-turnstile-response", "privacy"]);
 
 /** Per-form trait fields sent in the identify call. */
@@ -31,6 +31,14 @@ const IDENTIFY_TRAITS: Record<FormType, string[]> = {
   whitepaper: ["fullName", "email"],
   "brick-manual": ["fullName", "email"],
   "startup-academic": ["fullName", "email", "company"],
+};
+
+/** Per-form fields allowed in the Segment track payload. */
+const TRACK_PROPERTIES: Record<FormType, string[]> = {
+  "demo-request": ["fullName", "email", "company", "jobTitle"],
+  whitepaper: ["fullName", "email", "company", "jobTitle"],
+  "brick-manual": ["fullName", "email"],
+  "startup-academic": ["fullName", "email", "linkedin", "company", "role"],
 };
 
 function jsonResponse(data: unknown, status = 200): Response {
@@ -157,10 +165,11 @@ export async function POST(context: APIContext): Promise<Response> {
       if (val) traits[field === "fullName" ? "name" : field] = val;
     }
 
-    // Build properties for track (all validated fields minus excluded ones)
+    // Build properties for track from the fields explicitly supported by this form.
     const properties: Record<string, string> = { formType };
-    for (const [key, val] of Object.entries(data)) {
-      if (!EXCLUDED_FIELDS.has(key)) properties[key] = val;
+    for (const field of TRACK_PROPERTIES[typedFormType]) {
+      const val = (data[field] ?? "").trim();
+      if (val) properties[field] = val;
     }
 
     const identifyCall = segmentCall("identify", segmentKey, {

--- a/tests/api/forms.test.ts
+++ b/tests/api/forms.test.ts
@@ -142,6 +142,30 @@ describe("form API route", () => {
     expect(waitUntil).not.toHaveBeenCalled();
   });
 
+  it("rejects a forged allowlisted job title before scheduling outbound calls", async () => {
+    const waitUntil = vi.fn();
+    const response = await POST(
+      makeContext({
+        formType: "demo-request",
+        request: formRequest({
+          fullName: "Ada Lovelace",
+          email: "ada@example.com",
+          jobTitle: '<a href="https://evil.example">Click here</a>',
+          privacy: "on",
+        }),
+        env: { SEGMENT_FORMS_WRITE_KEY: "segment-key" },
+        waitUntil,
+      }),
+    );
+
+    expect(response.status).toBe(422);
+    await expect(responseJson(response)).resolves.toEqual({
+      success: false,
+      errors: { jobTitle: "Please select a valid job title" },
+    });
+    expect(waitUntil).not.toHaveBeenCalled();
+  });
+
   it("requires a Turnstile token when a secret key is configured", async () => {
     const response = await POST(
       makeContext({
@@ -288,6 +312,7 @@ describe("form API route", () => {
           fullName: "Ada Lovelace",
           email: "ada@example.com",
           company: "Analytical Engines Ltd",
+          jobTitle: "Data Scientist",
           unexpected: "must not reach Segment",
           privacy: "on",
           "cf-turnstile-response": "token",
@@ -337,6 +362,7 @@ describe("form API route", () => {
       fullName: "Ada Lovelace",
       email: "ada@example.com",
       company: "Analytical Engines Ltd",
+      jobTitle: "Data Scientist",
     });
     expect(trackBody.properties).not.toHaveProperty("privacy");
     expect(trackBody.properties).not.toHaveProperty("cf-turnstile-response");

--- a/tests/api/forms.test.ts
+++ b/tests/api/forms.test.ts
@@ -113,6 +113,35 @@ describe("form API route", () => {
     });
   });
 
+  it("rejects unsafe booking fields before scheduling outbound calls", async () => {
+    const waitUntil = vi.fn();
+    const response = await POST(
+      makeContext({
+        formType: "demo-request",
+        request: formRequest({
+          fullName: '<a href="https://evil.example">Click here</a>',
+          email: "ada@example.com",
+          company: "Analytical\nEngines",
+          privacy: "on",
+        }),
+        env: { SEGMENT_FORMS_WRITE_KEY: "segment-key" },
+        waitUntil,
+      }),
+    );
+
+    expect(response.status).toBe(422);
+    await expect(responseJson(response)).resolves.toEqual({
+      success: false,
+      errors: {
+        fullName:
+          "Full name must be 100 characters or fewer and cannot contain HTML or line breaks",
+        company:
+          "Company or organization name must be 200 characters or fewer and cannot contain HTML or line breaks",
+      },
+    });
+    expect(waitUntil).not.toHaveBeenCalled();
+  });
+
   it("requires a Turnstile token when a secret key is configured", async () => {
     const response = await POST(
       makeContext({
@@ -259,6 +288,7 @@ describe("form API route", () => {
           fullName: "Ada Lovelace",
           email: "ada@example.com",
           company: "Analytical Engines Ltd",
+          unexpected: "must not reach Segment",
           privacy: "on",
           "cf-turnstile-response": "token",
         }),
@@ -310,5 +340,6 @@ describe("form API route", () => {
     });
     expect(trackBody.properties).not.toHaveProperty("privacy");
     expect(trackBody.properties).not.toHaveProperty("cf-turnstile-response");
+    expect(trackBody.properties).not.toHaveProperty("unexpected");
   });
 });

--- a/tests/lib/formValidation.test.ts
+++ b/tests/lib/formValidation.test.ts
@@ -113,6 +113,70 @@ describe("validateForm", () => {
     ).toEqual({ valid: true, errors: {} });
   });
 
+  it.each(
+    configuredFormTypes,
+  )("rejects HTML, line breaks, control characters, and oversized full names for %s", (formType) => {
+    const validData = formValidationCases[formType].validData;
+    const unsafeNames = [
+      '<a href="https://evil.example">Click here</a>',
+      "Ada\nLovelace",
+      "Ada Lovelace\r\n",
+      "Ada\u0000Lovelace",
+      "A".repeat(101),
+    ];
+
+    for (const fullName of unsafeNames) {
+      expect(validateForm(formType, { ...validData, fullName }).errors).toEqual(
+        {
+          fullName:
+            "Full name must be 100 characters or fewer and cannot contain HTML or line breaks",
+        },
+      );
+    }
+  });
+
+  it.each([
+    "demo-request",
+    "whitepaper",
+    "startup-academic",
+  ] as const)("rejects HTML, line breaks, control characters, and oversized company names for %s", (formType) => {
+    const validData = formValidationCases[formType].validData;
+    const unsafeCompanies = [
+      '<a href="https://evil.example">Click here</a>',
+      "Analytical\nEngines",
+      "Analytical Engines\r\n",
+      "Analytical\u0000Engines",
+      "A".repeat(201),
+    ];
+
+    for (const company of unsafeCompanies) {
+      expect(validateForm(formType, { ...validData, company }).errors).toEqual({
+        company:
+          "Company or organization name must be 200 characters or fewer and cannot contain HTML or line breaks",
+      });
+    }
+  });
+
+  it("accepts ordinary Unicode and punctuation in names and companies", () => {
+    expect(
+      validateForm("demo-request", {
+        fullName: "María O'Connor-Sørensen",
+        email: "maria@example.com",
+        company: "München AI GmbH & Co. KG",
+      }),
+    ).toEqual({ valid: true, errors: {} });
+  });
+
+  it("accepts names and companies at their maximum lengths", () => {
+    expect(
+      validateForm("demo-request", {
+        fullName: "A".repeat(100),
+        email: "ada@example.com",
+        company: "B".repeat(200),
+      }),
+    ).toEqual({ valid: true, errors: {} });
+  });
+
   it("rejects startup academic LinkedIn URLs without an http scheme", () => {
     expect(
       validateForm("startup-academic", {

--- a/tests/lib/formValidation.test.ts
+++ b/tests/lib/formValidation.test.ts
@@ -16,6 +16,7 @@ const formValidationCases = {
     validData: {
       fullName: "Dorothy Vaughan",
       email: "dorothy@example.com",
+      jobTitle: "Data Scientist",
     },
     invalidData: {
       email: "not-an-email",
@@ -29,6 +30,7 @@ const formValidationCases = {
     validData: {
       fullName: "Grace Hopper",
       email: "grace@example.com",
+      jobTitle: "Other",
     },
     invalidData: {
       email: "not-an-email",
@@ -57,7 +59,7 @@ const formValidationCases = {
       email: "mary@example.com",
       linkedin: "https://linkedin.com/in/mary",
       company: "NASA",
-      role: "startup",
+      role: "founder-co-founder",
     },
     invalidData: {
       email: "not-an-email",
@@ -66,7 +68,7 @@ const formValidationCases = {
     expectedErrors: {
       fullName: "Full name is required",
       email: "Valid email is required",
-      linkedin: "LinkedIn URL is required",
+      linkedin: "Valid LinkedIn profile URL is required",
       company: "Organization name is required",
       role: "Please select a role",
     },
@@ -177,16 +179,61 @@ describe("validateForm", () => {
     ).toEqual({ valid: true, errors: {} });
   });
 
-  it("rejects startup academic LinkedIn URLs without an http scheme", () => {
+  it("rejects startup academic LinkedIn URLs without an https scheme", () => {
     expect(
       validateForm("startup-academic", {
         fullName: "Katherine Johnson",
         email: "katherine@example.com",
         linkedin: "linkedin.com/in/katherine",
         company: "NASA",
-        role: "academic",
+        role: "researcher-scientist",
       }).errors,
-    ).toEqual({ linkedin: "LinkedIn URL is required" });
+    ).toEqual({ linkedin: "Valid LinkedIn profile URL is required" });
+  });
+
+  it.each([
+    "demo-request",
+    "whitepaper",
+  ] as const)("rejects job titles outside the configured options for %s", (formType) => {
+    expect(
+      validateForm(formType, {
+        ...formValidationCases[formType].validData,
+        jobTitle: '<a href="https://evil.example">Click here</a>',
+      }).errors,
+    ).toEqual({ jobTitle: "Please select a valid job title" });
+  });
+
+  it("rejects startup roles outside the configured options", () => {
+    expect(
+      validateForm("startup-academic", {
+        ...formValidationCases["startup-academic"].validData,
+        role: '<a href="https://evil.example">Click here</a>',
+      }).errors,
+    ).toEqual({ role: "Please select a valid role" });
+  });
+
+  it.each([
+    "https://evil.example/in/mary",
+    "https://linkedin.com.evil.example/in/mary",
+    "https://linkedin.com/company/zenml",
+    "https://linkedin.com/in/<script>",
+    "https://linkedin.com/in/mary\nmalicious",
+  ])("rejects unsafe or non-profile LinkedIn URL %s", (linkedin) => {
+    expect(
+      validateForm("startup-academic", {
+        ...formValidationCases["startup-academic"].validData,
+        linkedin,
+      }).errors,
+    ).toEqual({ linkedin: "Valid LinkedIn profile URL is required" });
+  });
+
+  it("accepts a canonical www LinkedIn profile URL", () => {
+    expect(
+      validateForm("startup-academic", {
+        ...formValidationCases["startup-academic"].validData,
+        linkedin: "https://www.linkedin.com/in/mary-jackson/",
+      }),
+    ).toEqual({ valid: true, errors: {} });
   });
 
   it("uses the brick manual email validation message", () => {


### PR DESCRIPTION
## Summary

User-controlled values submitted through our forms can no longer carry HTML-like markup or control characters into booking invitations and CRM destinations. The shared client/server validator rejects angle brackets, ASCII control characters, and excessive lengths while preserving ordinary Unicode names and punctuation.

Segment tracking uses an explicit allowlist for each form type, so unexpected submitted fields are not forwarded downstream. Every allowlisted field is now validated before forwarding: job titles and roles must match the UI's configured options, and LinkedIn profiles require an HTTPS LinkedIn host with an `/in/...` path. This is a defense-in-depth mitigation for the upstream Cal.com notification issue.

Related: calcom/cal.diy#21668

## Reviewer focus

- The 100-character name and 200-character company limits, including exact-boundary behavior.
- Select values are derived from the same option constants used by the UI.
- LinkedIn URL validation accepts profile URLs while rejecting lookalike hosts, non-profile paths, credentials, ports, and unsafe characters.

## Validation

- `pnpm check`
- `pnpm check:tests`
- `pnpm check:surface`
- `pnpm check:alt`
- `pnpm lint`
- `pnpm test` (70 tests passed)
- `pnpm build`
- `pnpm smoke:dist`
- `pnpm check:islands` (4 browser hydration checks passed)

## Post-Deploy Monitoring & Validation

- For the first 24 hours, the website maintainer should monitor Cloudflare request logs for `/api/forms/*` responses with status `422` and search application logs for `[form:demo-request] submission received`.
- Healthy behavior: ordinary form submissions continue succeeding, unsafe payloads receive `422`, and Segment `Form Submitted` event volume remains near its existing baseline.
- Failure signal: a material rise in validation errors or drop in successful demo submissions after deployment. If that occurs, revert this commit while reviewing rejected payload samples for a legitimate input pattern the rules missed.
