### PR TITLE
Fix broken Slack invite link in `_redirects`

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -130,12 +130,12 @@
 /changelog/ https://docs.zenml.io/changelog 301
 
 # ── External redirects (from redirectOnly.ts) ─────────────────────
-/slack https://join.slack.com/t/zenml/shared_invite/zt-3j68xwsxy-C_GyybZPDPxKG0OwSJgwFg 301
-/slack/ https://join.slack.com/t/zenml/shared_invite/zt-3j68xwsxy-C_GyybZPDPxKG0OwSJgwFg 301
+/slack https://join.slack.com/t/zenml/shared_invite/zt-445cfmyzl-hxjO~xHWeiqfSoDmqfVwJA 301
+/slack/ https://join.slack.com/t/zenml/shared_invite/zt-445cfmyzl-hxjO~xHWeiqfSoDmqfVwJA 301
 /roadmap https://github.com/orgs/zenml-io/projects/1 301
 /roadmap/ https://github.com/orgs/zenml-io/projects/1 301
-/slack-invite https://join.slack.com/t/zenml/shared_invite/zt-3j68xwsxy-C_GyybZPDPxKG0OwSJgwFg 301
-/slack-invite/ https://join.slack.com/t/zenml/shared_invite/zt-3j68xwsxy-C_GyybZPDPxKG0OwSJgwFg 301
+/slack-invite https://join.slack.com/t/zenml/shared_invite/zt-445cfmyzl-hxjO~xHWeiqfSoDmqfVwJA 301
+/slack-invite/ https://join.slack.com/t/zenml/shared_invite/zt-445cfmyzl-hxjO~xHWeiqfSoDmqfVwJA 301
 /discussion https://github.com/zenml-io/zenml/discussions 301
 /discussion/ https://github.com/zenml-io/zenml/discussions 301
 /meet https://www.eventbrite.de/e/zenml-meet-the-community-tickets-354426688767 301


### PR DESCRIPTION
## Summary

The community Slack invite link was broken — a member emailed to report the footer Slack link wasn't working, and Hamza confirmed the invite code had been regenerated. This points all the site's Slack links at the new invite.

## What changed

- **`public/_redirects`** — updated the shared-invite code on all four rules from the expired `zt-3j68xwsxy-...` to the new `zt-445cfmyzl-hxjO~xHWeiqfSoDmqfVwJA`:
  - `/slack` and `/slack/`
  - `/slack-invite` and `/slack-invite/`

## What reviewers should focus on

- **One fix heals every link.** The footer (`Community Slack` + the social Slack icon) and ~40 blog posts all link to the *paths* `/slack` and `/slack-invite`, never the raw `join.slack.com` URL. The redirect file is the single source of truth, so this 4-line change fixes all of them at once — no per-post edits needed.
- **The `~` in the new invite code is intentional** and part of the URL Hamza supplied (`...hxjO~xHWeiqfSoDmqfVwJA`) — not a typo.
- I grepped the whole repo for both the old code and any hardcoded raw `join.slack.com` URLs — the only occurrences were these four redirect lines. Nothing else references the raw invite.

## Validation

- `grep` confirmed no remaining references to the old `zt-3j68xwsxy` code anywhere in the repo (excluding `node_modules`/`dist`).
- No build run: `public/_redirects` is a static text file copied verbatim into `dist/` and isn't parsed by any `pnpm` quality gate, so there's no generated content or hydration behavior to verify.

## Paths to check

Once the preview deploys: `Preview URL + /slack` and `Preview URL + /slack-invite` should both 301 to `https://join.slack.com/t/zenml/shared_invite/zt-445cfmyzl-hxjO~xHWeiqfSoDmqfVwJA`. The footer's Slack link should land in the ZenML Slack join page.