### PR TITLE
Close the Kitaru page with the loop's destination

### DIFF
--- a/src/components/kitaru/Cta.astro
+++ b/src/components/kitaru/Cta.astro
@@ -17,9 +17,9 @@ import {
 
   <div class="cta-inner" data-reveal>
     <h2 class="cta-headline">
-      <span class="cta-line-problem">Change one thing. Replay the run.</span>
+      <span class="cta-line-problem">What arrives as a complaint</span>
       <br>
-      <span class="cta-line-solution">See what would have happened.</span>
+      <span class="cta-line-solution">leaves as a regression test.</span>
     </h2>
 
     <div class="cta-actions">
@@ -37,7 +37,7 @@ import {
         </a>
       </div>
     </div>
-    <p class="cta-note">Open source ({KITARU_LICENSE}). Ask what-if about a real run. No rerunning in production.</p>
+    <p class="cta-note">Open source ({KITARU_LICENSE}). Replay real runs against your real code. Nothing reruns in production.</p>
   </div>
 </section>
 


### PR DESCRIPTION
The closing CTA band on /product/kitaru still carried the pre-pivot what-if framing ("Change one thing. Replay the run. / See what would have happened."). It now states the arc the hero opens, so the page closes where it began:

> **What arrives as a complaint / leaves as a regression test.**

Note line updated to match ("Replay real runs against your real code. Nothing reruns in production."). One component, three lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)