### PR TITLE
Fix biome formatting in ScenarioStrip

### DIFF
--- a/src/components/kitaru/ScenarioStrip.astro
+++ b/src/components/kitaru/ScenarioStrip.astro
@@ -6,7 +6,8 @@ const scenarios = [
   {
     tag: "debug",
     q: "Why did it do that?",
-    outcome: "Reproduce the failure on your desk — same code, same world, every time.",
+    outcome:
+      "Reproduce the failure on your desk — same code, same world, every time.",
     stat: "10 / 10",
     statLabel: "runs reproduce it",
   },


### PR DESCRIPTION
#158 merged with one string literal the biome formatter wants wrapped, which fails `pnpm lint` on main. This is the `biome check --write` output for that file, nothing else. Full `pnpm lint` verified green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)