### PR TITLE
Evolve the scenario strip into a git-tree fork diagram

### DIFF
--- a/src/components/kitaru/ScenarioStrip.astro
+++ b/src/components/kitaru/ScenarioStrip.astro
@@ -6,7 +6,8 @@ const scenarios = [
   {
     tag: "debug",
     q: "Why did it do that?",
-    outcome: "Reproduce the failure on your desk — same code, same world, every time.",
+    outcome:
+      "Reproduce the failure on your desk — same code, same world, every time.",
     stat: "10 / 10",
     statLabel: "runs reproduce it",
   },
@@ -50,7 +51,7 @@ const forks = scenarios.map((s, i) => ({
   ...s,
   dotX: checkpoints[i + 1].x,
   cardX: 40 + i * 290,
-  laneY: 100 + i * 18,
+  laneY: 100 + i * 16,
 }));
 ---
 
@@ -79,11 +80,17 @@ const forks = scenarios.map((s, i) => ({
         {forks.map((f, i) => (
           <>
             <path
-              d={`M ${f.dotX} 70 L ${f.dotX} ${f.laneY - 12} Q ${f.dotX} ${f.laneY} ${f.dotX - 12} ${f.laneY} L ${f.cardX + CARD_W / 2 + 12} ${f.laneY} Q ${f.cardX + CARD_W / 2} ${f.laneY} ${f.cardX + CARD_W / 2} ${f.laneY + 12} L ${f.cardX + CARD_W / 2} ${CARD_Y - 12}`}
+              d={`M ${f.dotX} 70 L ${f.dotX} ${f.laneY - 16} Q ${f.dotX} ${f.laneY} ${f.dotX - 16} ${f.laneY} L ${f.cardX + CARD_W / 2 + 16} ${f.laneY} Q ${f.cardX + CARD_W / 2} ${f.laneY} ${f.cardX + CARD_W / 2} ${f.laneY + 16} L ${f.cardX + CARD_W / 2} ${CARD_Y - 12}`}
               class="sd-branch"
+              pathLength="1"
+              style={`--delay: ${(0.1 + i * 0.18).toFixed(2)}s`}
             />
-            <circle cx={f.dotX} cy="62" r="6" class="sd-dot sd-dot-fork" />
-            <path d={`M ${f.cardX + CARD_W / 2 - 6} ${CARD_Y - 12} L ${f.cardX + CARD_W / 2 + 6} ${CARD_Y - 12} L ${f.cardX + CARD_W / 2} ${CARD_Y - 1} Z`} class="sd-branch-end" />
+            <circle cx={f.dotX} cy="62" r="6.5" class="sd-dot sd-dot-fork" style={`--delay: ${(0.1 + i * 0.18).toFixed(2)}s`} />
+            <path
+              d={`M ${f.cardX + CARD_W / 2 - 5} ${CARD_Y - 11} L ${f.cardX + CARD_W / 2 + 5} ${CARD_Y - 11} L ${f.cardX + CARD_W / 2} ${CARD_Y - 2} Z`}
+              class="sd-branch-end"
+              style={`--delay: ${(0.1 + i * 0.18).toFixed(2)}s`}
+            />
             <foreignObject x={f.cardX} y={CARD_Y} width={CARD_W} height="340">
               <div class="scenario-card sd-card" xmlns="http://www.w3.org/1999/xhtml">
                 <span class="scenario-move">{f.tag}</span>
@@ -286,9 +293,9 @@ const forks = scenarios.map((s, i) => ({
 
   .sd-exec-label {
     font-family: var(--font-mono);
-    font-size: 15px;
+    font-size: 13px;
     font-weight: 600;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.1em;
     text-transform: uppercase;
     fill: var(--color-muted);
   }
@@ -306,8 +313,8 @@ const forks = scenarios.map((s, i) => ({
 
   .sd-dot {
     fill: var(--color-surface);
-    stroke: var(--color-muted);
-    stroke-width: 2;
+    stroke: oklch(0.62 0.02 60 / 0.55);
+    stroke-width: 1.75;
   }
 
   .sd-dot-fork {
@@ -320,8 +327,43 @@ const forks = scenarios.map((s, i) => ({
   .sd-branch {
     fill: none;
     stroke: var(--color-accent);
-    stroke-width: 3;
+    stroke-width: 2.25;
     stroke-linecap: round;
+    stroke-dasharray: 1;
+    stroke-dashoffset: 1;
+  }
+
+  .scenario-diagram.revealed .sd-branch {
+    stroke-dashoffset: 0;
+  }
+
+  .scenario-diagram.revealed .sd-branch-end,
+  .scenario-diagram.revealed .sd-dot-fork {
+    opacity: 1;
+  }
+
+  .sd-branch-end,
+  .sd-dot-fork {
+    opacity: 0;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .sd-branch {
+      transition: stroke-dashoffset 0.8s cubic-bezier(0.4, 0, 0.2, 1) var(--delay, 0s);
+    }
+    .sd-branch-end,
+    .sd-dot-fork {
+      transition: opacity 0.4s ease calc(var(--delay, 0s) + 0.55s);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .sd-branch {
+      stroke-dashoffset: 0;
+    }
+    .sd-branch-end,
+    .sd-dot-fork {
+      opacity: 1;
+    }
   }
 
   .sd-branch-end {

--- a/src/components/kitaru/ScenarioStrip.astro
+++ b/src/components/kitaru/ScenarioStrip.astro
@@ -4,29 +4,32 @@
 // the shipped `from_` + `overrides` replay API shape.
 const scenarios = [
   {
-    move: "fail",
-    q: "Search tool times out?",
-    code: 'lookup_mode="timeout"',
+    tag: "debug",
+    q: "Why did it do that?",
+    outcome: "Reproduce the failure on your desk — same code, same world, every time.",
+    stat: "10 / 10",
+    statLabel: "runs reproduce it",
   },
   {
-    move: "mock",
-    q: "Tool returns something else?",
-    code: 'overrides={"checkpoint.lookup_order": stale_order}',
+    tag: "verify",
+    q: "Is the fix safe to merge?",
+    outcome: "Replay it against every recorded run that failed the same way.",
+    stat: "23 / 23",
+    statLabel: "pass after the fix",
   },
   {
-    move: "degrade",
-    q: "Retriever gets worse?",
-    code: 'overrides={"checkpoint.retrieve": degraded_docs}',
+    tag: "decide",
+    q: "Can we ship the cheaper model?",
+    outcome: "Same conversations, cheaper model — read the answer off a diff.",
+    stat: "\u221284%",
+    statLabel: "cost \u00b7 192/200 answers identical",
   },
   {
-    move: "drop",
-    q: "Ignore the reranker?",
-    code: 'overrides={"checkpoint.rerank": []}',
-  },
-  {
-    move: "swap",
-    q: "Run on a cheaper model?",
-    code: 'model="fast"',
+    tag: "gate",
+    q: "Did the new prompt regress?",
+    outcome: "Replay last week's traffic against the branch before it merges.",
+    stat: "0",
+    statLabel: "regressions reach production",
   },
 ] as const;
 ---
@@ -47,9 +50,13 @@ const scenarios = [
       {
         scenarios.map((s, i) => (
           <div class="scenario-card" data-reveal="fade-up" data-reveal-delay={i + 1}>
-            <span class="scenario-move">{s.move}</span>
+            <span class="scenario-move">{s.tag}</span>
             <p class="scenario-q">{s.q}</p>
-            <code class="scenario-code">{s.code}</code>
+            <p class="scenario-outcome">{s.outcome}</p>
+            <div class="scenario-stat-block">
+              <span class="scenario-stat">{s.stat}</span>
+              <span class="scenario-stat-label">{s.statLabel}</span>
+            </div>
           </div>
         ))
       }
@@ -93,7 +100,7 @@ const scenarios = [
 
   .scenario-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(min(100%, 180px), 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr));
     gap: 16px;
   }
 
@@ -132,9 +139,9 @@ const scenarios = [
 
 
   .scenario-q {
-    font-size: 1rem;
-    line-height: 1.35;
-    min-height: 2.7em;
+    font-size: 1.2rem;
+    line-height: 1.3;
+    min-height: 2.6em;
     color: var(--color-primary);
     font-weight: 600;
     letter-spacing: -0.01em;
@@ -166,5 +173,41 @@ const scenarios = [
     .scenario-grid {
       grid-template-columns: 1fr;
     }
+  }
+
+  .scenario-outcome {
+    font-size: 0.92rem;
+    line-height: 1.55;
+    color: var(--color-secondary);
+    font-weight: 300;
+    margin: 0;
+    flex: 1;
+  }
+
+  .scenario-stat-block {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding-top: 14px;
+    border-top: 1px solid var(--color-border);
+  }
+
+  .scenario-stat {
+    font-family: var(--font-mono);
+    font-size: clamp(1.6rem, 2.6vw, 2.1rem);
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    color: var(--color-accent);
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .scenario-stat-label {
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-muted);
   }
 </style>

--- a/src/components/kitaru/ScenarioStrip.astro
+++ b/src/components/kitaru/ScenarioStrip.astro
@@ -32,6 +32,26 @@ const scenarios = [
     statLabel: "regressions reach production",
   },
 ] as const;
+
+/** The recorded execution's checkpoints; forks attach by index. */
+const checkpoints = [
+  { x: 90, label: "run" },
+  { x: 330, label: "lookup_order" },
+  { x: 585, label: "retrieve" },
+  { x: 840, label: "model_request" },
+  { x: 1105, label: "reply" },
+] as const;
+
+/** card layout: 4 cards across a 1200-wide viewBox, forked from checkpoints 1-4 */
+const CARD_W = 262;
+const CARD_Y = 178;
+const SPINE_Y = 62;
+const forks = scenarios.map((s, i) => ({
+  ...s,
+  dotX: checkpoints[i + 1].x,
+  cardX: 40 + i * 290,
+  laneY: 100 + i * 18,
+}));
 ---
 
 <section id="scenario-strip" class="scenario-section section-pad">
@@ -46,7 +66,41 @@ const scenarios = [
       </p>
     </div>
 
-    <div class="scenario-grid">
+    <div class="scenario-diagram" data-reveal>
+      <svg viewBox="0 0 1200 528" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="One recorded execution with four questions forked from its checkpoints: debug, verify, decide, and gate">
+        <text x="40" y="20" class="sd-exec-label">execution tr-8f3a91c2 · recorded</text>
+        <line x1="40" y1="62" x2="1160" y2="62" class="sd-spine" />
+        {checkpoints.map((c) => (
+          <>
+            <text x={c.x} y="42" text-anchor="middle" class="sd-cp-label">{c.label}</text>
+            <circle cx={c.x} cy="62" r="6" class="sd-dot" />
+          </>
+        ))}
+        {forks.map((f, i) => (
+          <>
+            <path
+              d={`M ${f.dotX} 70 L ${f.dotX} ${f.laneY - 12} Q ${f.dotX} ${f.laneY} ${f.dotX - 12} ${f.laneY} L ${f.cardX + CARD_W / 2 + 12} ${f.laneY} Q ${f.cardX + CARD_W / 2} ${f.laneY} ${f.cardX + CARD_W / 2} ${f.laneY + 12} L ${f.cardX + CARD_W / 2} ${CARD_Y - 12}`}
+              class="sd-branch"
+            />
+            <circle cx={f.dotX} cy="62" r="6" class="sd-dot sd-dot-fork" />
+            <path d={`M ${f.cardX + CARD_W / 2 - 6} ${CARD_Y - 12} L ${f.cardX + CARD_W / 2 + 6} ${CARD_Y - 12} L ${f.cardX + CARD_W / 2} ${CARD_Y - 1} Z`} class="sd-branch-end" />
+            <foreignObject x={f.cardX} y={CARD_Y} width={CARD_W} height="340">
+              <div class="scenario-card sd-card" xmlns="http://www.w3.org/1999/xhtml">
+                <span class="scenario-move">{f.tag}</span>
+                <p class="scenario-q">{f.q}</p>
+                <p class="scenario-outcome">{f.outcome}</p>
+                <div class="scenario-stat-block">
+                  <span class="scenario-stat">{f.stat}</span>
+                  <span class="scenario-stat-label">{f.statLabel}</span>
+                </div>
+              </div>
+            </foreignObject>
+          </>
+        ))}
+      </svg>
+    </div>
+
+    <div class="scenario-grid scenario-fallback">
       {
         scenarios.map((s, i) => (
           <div class="scenario-card" data-reveal="fade-up" data-reveal-delay={i + 1}>
@@ -73,7 +127,7 @@ const scenarios = [
 
   .scenario-head {
     max-width: 820px;
-    margin-bottom: 48px;
+    margin-bottom: 30px;
   }
 
   .scenario-title {
@@ -209,5 +263,73 @@ const scenarios = [
     letter-spacing: 0.06em;
     text-transform: uppercase;
     color: var(--color-muted);
+  }
+
+  .scenario-diagram {
+    display: none;
+  }
+
+  @media (min-width: 900px) {
+    .scenario-diagram {
+      display: block;
+    }
+    .scenario-fallback {
+      display: none;
+    }
+  }
+
+  .scenario-diagram svg {
+    width: 100%;
+    height: auto;
+    display: block;
+  }
+
+  .sd-exec-label {
+    font-family: var(--font-mono);
+    font-size: 15px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    fill: var(--color-muted);
+  }
+
+  .sd-spine {
+    stroke: var(--color-border);
+    stroke-width: 2.5;
+  }
+
+  .sd-cp-label {
+    font-family: var(--font-mono);
+    font-size: 14px;
+    fill: var(--color-secondary);
+  }
+
+  .sd-dot {
+    fill: var(--color-surface);
+    stroke: var(--color-muted);
+    stroke-width: 2;
+  }
+
+  .sd-dot-fork {
+    fill: var(--color-accent);
+    stroke: var(--color-surface);
+    stroke-width: 3;
+    r: 8;
+  }
+
+  .sd-branch {
+    fill: none;
+    stroke: var(--color-accent);
+    stroke-width: 3;
+    stroke-linecap: round;
+  }
+
+  .sd-branch-end {
+    fill: var(--color-accent);
+  }
+
+  .sd-card {
+    height: 100%;
+    box-sizing: border-box;
   }
 </style>


### PR DESCRIPTION
Evolves #158's outcome tiles into the visual the section's headline promises: one recorded execution drawn as a checkpoint spine, with the four questions (debug / verify / decide / gate) forking off specific checkpoints as git-graph branches — rounded orthogonal elbows, one lane per fork, arrowheads landing on the outcome cards.

- Branches draw in on scroll with a staggered stroke-dashoffset reveal; arrowheads and fork dots fade in as each branch lands. Fully gated on `prefers-reduced-motion` (reduced-motion users get the finished diagram instantly).
- The execution spine reuses `tr-8f3a91c2` — the same execution as the hero panel, so the page tells one continuous story.
- The outcome tiles from #158 remain as the <900px fallback (the SVG layout doesn't compress well on phones).
- **Supersedes #159**: this branch includes the biome format fix for the string that broke `pnpm lint` on main. Full `pnpm lint` (300 files) verified green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)