### PR TITLE
Give `@biomejs/biome` its own Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,19 @@ updates:
           - astro
           - '@astrojs/*'
           - wrangler
+      # Biome gets its own group so a formatter change can never hide inside a
+      # multi-package PR. Biome ships formatting changes in PATCH releases:
+      # 2.5.3 -> 2.5.4 changed how it breaks curried calls like
+      # `it.each(...)(...)`, failing `pnpm lint` on already-committed source
+      # from inside "Bump the minor-and-patch group with 4 updates" (#165) --
+      # a title naming neither the culprit nor that the diff was cosmetic.
+      #
+      # Alone, the title names the cause. The fix is always:
+      #   pnpm lint:fix && git commit -am "Reformat for Biome <version>"
+      # Check it is formatting-only with `git diff --ignore-all-space` first.
+      biome:
+        patterns:
+          - '@biomejs/biome'
       minor-and-patch:
         patterns: ['*']
         update-types:


### PR DESCRIPTION
## Summary

Follow-up from this week's Dependabot batch (#163, #164, #165). Biome ships **formatting changes in patch releases**, which fails `pnpm lint` on already-committed source. That is harmless and one command from fixed — but this week it arrived buried inside *"Bump the minor-and-patch group with 4 updates"* (#165), a title that named neither the culprit nor the fact that the diff was purely cosmetic. Working that out took a full reproduce-in-a-worktree cycle.

Giving Biome its own group makes the next occurrence self-explaining: a red lint check on a PR titled *"Bump `@biomejs/biome` from X to Y"* tells you the cause and the fix at a glance.

## What changed

One file, comment-heavy:

- `.github/dependabot.yml` — new `biome` group in the **npm** ecosystem block, matching `@biomejs/biome`, with a comment recording the concrete failure (2.5.3 → 2.5.4 re-breaking curried `it.each(...)(...)` calls) and the fix recipe (`pnpm lint:fix`, verify with `git diff --ignore-all-space`).

No source, no lockfile, no CI changes.

## What reviewers should focus on

**Group overlap is the one real risk here**, and it fails silently rather than loudly. If `@biomejs/biome` matched *both* the new `biome` group and the `minor-and-patch` catch-all, it would ship in two PRs at once — surfacing later as a lockfile conflict that reads like the bot being flaky, not like a config error.

I believe it's safe, and the evidence is empirical rather than theoretical:

- The `astro` group already coexists with `minor-and-patch: patterns: ['*']` using the same mechanism (exact names and wildcards beat the catch-all).
- This week proved it live: `wrangler` sits in the `astro` group and appeared in #164 only — it was **absent** from #165's four-package group PR.

The `biome` group uses an exact package name, the most specific pattern form, so it should behave identically.

**Worth confirming after the next scheduled run** (Tuesdays 07:00 Europe/Amsterdam): when Biome next bumps, check `@biomejs/biome` appears in exactly one PR. That's the only confirmation that really counts — a config that merely *looks* right is exactly the failure mode here.

## Alternative considered and rejected

Pinning `@biomejs/biome` to an exact version instead of `^2.5.4`. This does **nothing**: CI runs `pnpm install --frozen-lockfile` (`deploy.yml` L31, L98), so the lockfile already provides one exact version everywhere, and a Dependabot bump rewrites `package.json` and the lockfile together regardless. The caret was never the mechanism.

## Validation

- `.github/dependabot.yml` parses; groups resolve to `astro`, `biome`, `minor-and-patch` as intended.
- Config-only change — no source, content, or build behaviour touched. Full gate runs in CI on this PR.
- Batch context: all three dependency PRs merged clean beforehand (`Repo checks` green on each).

## Paths to check

None — this changes no rendered output. The observable effect is the shape of future Dependabot PRs.