### PR TITLE
Update ZenDPA link in privacy policy

### DIFF
--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -49,7 +49,7 @@ import ContentLayout from "../layouts/ContentLayout.astro";
     <li>Business Transaction Recipients: such as counterparties and others assisting with a merger, acquisition, financing, reorganization, bankruptcy, receivership, dissolution, asset sale, or similar transaction, and with a successor or affiliate as part of or following that transaction.</li>
     <li>Government Authorities: we do not volunteer your personal information to government authorities or regulators, but we may disclose your personal information where required to do so for the Compliance and Protection purposes described above.</li>
   </ul>
-  <p>The specifications pertaining to the aforementioned matters are further detailed within our data processing agreement (<a href="https://zendpa.com/t/zenml/request/new">https://zendpa.com/t/zenml/request/new</a>):</p>
+  <p>The specifications pertaining to the aforementioned matters are further detailed within our data processing agreement (<a href="https://security.zenml.io/resources?s=70yvkxmq3vwozebu0jga1i&name=zen-ml-data-processing-agreement.pdf">https://security.zenml.io/resources?s=70yvkxmq3vwozebu0jga1i&name=zen-ml-data-processing-agreement.pdf</a>):</p>
   <ul>
     <li>Sharing information with third parties</li>
     <li>Data Subject rights</li>


### PR DESCRIPTION
## Summary
- Points the data processing agreement link on `/privacy-policy` at the new `security.zenml.io` resources portal instead of the retired `zendpa.com` request form.

## What changed
- `src/pages/privacy-policy.astro` — section 4 ("Personal Information Sharing"): swapped the anchor href/text from `https://zendpa.com/t/zenml/request/new` to `https://security.zenml.io/resources?s=70yvkxmq3vwozebu0jga1i&name=zen-ml-data-processing-agreement.pdf`.

## What reviewers should focus on
- Single-line content swap, no logic/schema/analytics changes. Low risk.

## Validation
- `pnpm check:surface`, `pnpm check:alt`, `pnpm check`, `pnpm check:tests`, `pnpm lint`, `pnpm test` (70/70) all pass.
- `pnpm build`: could not run to completion in this local checkout — the repo lives at a path containing spaces (iCloud Drive sync location), which causes Astro's static-route prerendering step to silently emit 0 pages. This is a pre-existing local-environment issue, unrelated to this change (reproduces on `main` at the same path). Verified instead by building the identical commit in a clean path-without-spaces worktree: full site (2000+ pages) built successfully, `pagefind` indexed normally, and the generated `privacy-policy.html` contains the updated link.
- Manually reviewed the rendered page locally via `astro dev` and confirmed the new URL renders correctly in the anchor.

## Preview URL / paths to check
- `/privacy-policy` — section 4, the data processing agreement link.