### PR TITLE
Fix local production preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build && pagefind --site dist --glob '*ops-database/*.html'",
-    "preview": "astro preview",
+    "preview": "wrangler pages dev dist --compatibility-date=2026-07-15 --compatibility-flag=nodejs_compat",
     "check": "astro check --tsconfig ./tsconfig.check.json",
     "check:tests": "astro sync && tsc --noEmit -p tsconfig.tests.json",
     "check:surface": "tsx scripts/check-surface-coverage.ts",


### PR DESCRIPTION
## Summary

`pnpm preview` now starts a working Cloudflare Pages preview instead of failing immediately inside Astro. Local production previews exercise the generated Worker, API routes, redirects, and response headers through `workerd`.

## Changes

- Run the built `dist/` output with `wrangler pages dev`.
- Pin a compatibility date supported by the locked runtime and enable `nodejs_compat`, which the generated Worker requires.

## Migration context

This addresses the immediate local-preview bug in #149. It is deliberately an interim **Pages-format** preview and does not complete the Pages-to-Workers migration, checked-in Workers configuration, immutable version preview, or production-format parity gate tracked by #169 and #128.

## Reviewer focus

- Confirm the pinned local compatibility settings are appropriate until this repository gains a Wrangler configuration aligned with the remote Pages project.

## Validation

- `pnpm build`
- `pnpm lint`
- `pnpm test` (70 tests passed)
- `pnpm preview`, followed by HTTP checks:
  - `/` returned `200`
  - `/api/csp-report` returned its expected `405`
  - `/sitemap.xml` redirected to `/sitemap-index.xml` with `301`
  - `/pricing` included the configured security and `Link` headers

## Post-Deploy Monitoring & Validation

No additional production monitoring is required because this changes only the local preview command. After merge, the next maintainer using `pnpm build && pnpm preview` should see Wrangler become ready on port 8788; a startup or Worker compilation error is the rollback trigger.

Fixes #149
