### PR TITLE
Fix initial preview Worker deployment

### DIFF
--- a/.github/workflows/bootstrap-worker-preview.yml
+++ b/.github/workflows/bootstrap-worker-preview.yml
@@ -89,27 +89,21 @@ jobs:
             preview_urls: false
           }' > "$bootstrap_dir/wrangler.jsonc"
 
-      - name: Upload the inert first version without activating it
-        id: upload
+      - name: Create the route-less Worker with its inert first deployment
+        id: deploy
         shell: bash
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_PREVIEW_TOKEN }}
         run: |
           set -euo pipefail
-          wrangler versions upload \
+          wrangler deploy \
             --config "$RUNNER_TEMP/worker-preview-bootstrap/wrangler.jsonc" \
-            --message "Inert route-less preview Worker bootstrap" \
+            --message "Create inert route-less preview Worker" \
             --strict \
             --tag preview-bootstrap
-          wrangler versions list \
-            --name "$WORKER_NAME" \
-            --json > "$RUNNER_TEMP/worker-versions.json"
-          jq -e 'length == 1' "$RUNNER_TEMP/worker-versions.json" > /dev/null
-          version_id="$(jq -er '.[0].id' "$RUNNER_TEMP/worker-versions.json")"
-          echo "version_id=$version_id" >> "$GITHUB_OUTPUT"
 
-      - name: Disable public Worker endpoints before activation
+      - name: Reassert that public Worker endpoints are disabled
         shell: bash
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -134,22 +128,8 @@ jobs:
             .result.enabled == false and .result.previews_enabled == false
           ' "$RUNNER_TEMP/subdomain-disabled.json" > /dev/null
 
-      - name: Activate only the verified inert version
-        id: activate
-        shell: bash
-        env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_PREVIEW_TOKEN }}
-        run: |
-          set -euo pipefail
-          wrangler versions deploy \
-            "${{ steps.upload.outputs.version_id }}@100%" \
-            --message "Activate inert private preview Worker bootstrap" \
-            --name "$WORKER_NAME" \
-            --yes
-
       - name: Verify the Worker is private, route-less, domain-less, and recorded
-        if: ${{ always() && steps.upload.outcome != 'skipped' }}
+        if: ${{ always() && steps.deploy.outcome != 'skipped' }}
         shell: bash
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/tests/config/workerPreviewControlPlane.test.ts
+++ b/tests/config/workerPreviewControlPlane.test.ts
@@ -102,13 +102,12 @@ describe("preview Worker bootstrap workflow", () => {
 
   it("uses a pinned Wrangler to deploy only an inert private placeholder", () => {
     const preparationStep = step("Prepare inert private placeholder");
-    const uploadStep = step(
-      "Upload the inert first version without activating it",
+    const deployStep = step(
+      "Create the route-less Worker with its inert first deployment",
     );
     const disableStep = step(
-      "Disable public Worker endpoints before activation",
+      "Reassert that public Worker endpoints are disabled",
     );
-    const activateStep = step("Activate only the verified inert version");
 
     expect(step("Install pinned Wrangler").run).toBe(
       "npm install --global wrangler@4.110.0",
@@ -118,23 +117,17 @@ describe("preview Worker bootstrap workflow", () => {
     expect(preparationStep.run).toContain("workers_dev: false");
     expect(preparationStep.run).toContain("preview_urls: false");
     expect(preparationStep.run).toContain("status: 503");
-    expect(uploadStep.run).toContain("wrangler versions upload");
-    expect(uploadStep.run).toContain("--strict");
-    expect(uploadStep.run).not.toContain("wrangler deploy");
+    expect(deployStep.run).toContain("wrangler deploy");
+    expect(deployStep.run).toContain("--strict");
+    expect(deployStep.run).not.toContain("wrangler versions upload");
     expect(disableStep.run).toContain(
       '\'{"enabled":false,"previews_enabled":false}\'',
     );
-    expect(activateStep.run).toContain("wrangler versions deploy");
-    expect(activateStep.run).toContain(
-      '"$' + '{{ steps.upload.outputs.version_id }}@100%"',
-    );
+    expect(bootstrapWorkflowText).not.toContain("wrangler versions deploy");
 
     const stepNames = bootstrapJob.steps.map(({ name }) => name);
-    expect(stepNames.indexOf(uploadStep.name)).toBeLessThan(
+    expect(stepNames.indexOf(deployStep.name)).toBeLessThan(
       stepNames.indexOf(disableStep.name),
-    );
-    expect(stepNames.indexOf(disableStep.name)).toBeLessThan(
-      stepNames.indexOf(activateStep.name),
     );
   });
 
@@ -144,7 +137,7 @@ describe("preview Worker bootstrap workflow", () => {
     );
 
     expect(verificationStep.if).toBe(
-      "$" + "{{ always() && steps.upload.outcome != 'skipped' }}",
+      "$" + "{{ always() && steps.deploy.outcome != 'skipped' }}",
     );
     expect(verificationStep.run).toContain(
       "/workers/scripts/$WORKER_NAME/subdomain",


### PR DESCRIPTION
## Summary

The preview Worker bootstrap can now create its first inert deployment instead of failing before Cloudflare creates the Worker. The first deployment still has `workers.dev` and version-preview URLs disabled, no routes, and no custom domain; the existing post-deployment checks prove those properties immediately afterward.

## Changes

- Use the pinned Wrangler `deploy` command for the initial Worker creation, because `versions upload` only works after a Worker already exists.
- Keep the inert `503` placeholder and reassert that public Worker endpoints are disabled.
- Update the workflow contract tests to require this first-deployment sequence and reject the unsupported version-upload path.

## What reviewers should focus on

- Whether `workers_dev: false`, `preview_urls: false`, and the absence of route/domain configuration keep the initial deployment unreachable.
- Whether the post-deployment API checks still fail closed if Cloudflare records unexpected routing or endpoint state.

## Validation

- Workflow YAML parse and `actionlint`
- `pnpm check`
- `pnpm check:tests`
- `pnpm check:surface`
- `pnpm check:alt`
- `pnpm lint`
- `pnpm test` (76 tests)
- `pnpm build`
- `pnpm smoke:dist`
- `pnpm check:islands` (4 browser interaction checks)

`pnpm check:worker` is documented but is not defined in this checkout, so it could not be run. The Cloudflare bootstrap was deliberately not rerun; this PR stops before any infrastructure mutation.
