### PR TITLE
Fix preview Worker route verification

### DIFF
--- a/.github/workflows/bootstrap-worker-preview.yml
+++ b/.github/workflows/bootstrap-worker-preview.yml
@@ -149,9 +149,16 @@ jobs:
             "$api_base/workers/scripts" > "$RUNNER_TEMP/workers-after.json"
           jq -e --arg worker "$WORKER_NAME" '
             .success == true and
-            ([.result[] | select(.id == $worker)] | length == 1) and
-            ([.result[] | select(.id == $worker)][0].routes | type == "array") and
-            ([.result[] | select(.id == $worker)][0].routes | length == 0)
+            ([.result[] | select(.id == $worker)]) as $workers |
+            ($workers | length) == 1 and
+            ($workers[0] | has("routes")) and
+            (
+              $workers[0].routes == null or
+              (
+                ($workers[0].routes | type) == "array" and
+                ($workers[0].routes | length) == 0
+              )
+            )
           ' "$RUNNER_TEMP/workers-after.json" > /dev/null
 
           curl \

--- a/tests/config/workerPreviewControlPlane.test.ts
+++ b/tests/config/workerPreviewControlPlane.test.ts
@@ -145,8 +145,10 @@ describe("preview Worker bootstrap workflow", () => {
     expect(verificationStep.run).toContain(
       ".result.enabled == false and .result.previews_enabled == false",
     );
-    expect(verificationStep.run).toContain('.routes | type == "array"');
-    expect(verificationStep.run).toContain(".routes | length == 0");
+    expect(verificationStep.run).toContain('has("routes")');
+    expect(verificationStep.run).toContain(".routes == null");
+    expect(verificationStep.run).toContain(".routes | type");
+    expect(verificationStep.run).toContain(".routes | length");
     expect(verificationStep.run).not.toContain(".routes // []");
     expect(verificationStep.run).toContain("/workers/domains");
     expect(verificationStep.run).toContain(


### PR DESCRIPTION
## Summary

The preview Worker bootstrap’s final verification now recognizes Cloudflare’s explicit `routes: null` response as “no routes” without treating missing or unknown route data as safe. This turns the false-negative bootstrap result into an assertion that matches the live API while continuing to reject missing fields, non-empty route arrays, and unexpected types.

## What reviewers should focus on

- The `routes` field must still be present.
- Only `null` or an empty array is accepted.
- The existing checks for disabled public endpoints and zero custom domains are unchanged.

## Validation

- Workflow YAML parse and `actionlint`
- Safety assertion evaluated successfully against the live inert Worker record
- Authoritative `zenml.io` zone-route query returned zero routes for `zenml-io-v2-worker-preview`
- `pnpm check`
- `pnpm check:tests`
- `pnpm check:surface`
- `pnpm check:alt`
- `pnpm lint`
- `pnpm test` (76 tests)
- `pnpm build`
- `pnpm smoke:dist`
- `pnpm check:islands` (4 browser interaction checks)

The one-time bootstrap was not rerun and no Cloudflare state was changed while validating this PR.
