### PR TITLE
Add GTM Engineer - San Francisco open position

### DIFF
--- a/src/lib/company.ts
+++ b/src/lib/company.ts
@@ -94,11 +94,6 @@ export const COMPANY_VALUES = [
 // ---------------------------------------------------------------------------
 export const OPEN_POSITIONS = [
   {
-    title: "GTM Engineer - ZenML/Kitaru (f/m/d)",
-    type: "Full-time",
-    href: "https://zenml.notion.site/GTM-Engineer-ZenML-Kitaru-f-m-d-372f8dff253880e586daeebc8f360a29",
-  },
-  {
     title: "GTM Engineer - San Francisco",
     type: "Full-time",
     href: "https://zenml.notion.site/GTM-Engineer-San-Francisco-3a3f8dff25388093a9cdd9efc71f30d2",

--- a/src/lib/company.ts
+++ b/src/lib/company.ts
@@ -98,4 +98,9 @@ export const OPEN_POSITIONS = [
     type: "Full-time",
     href: "https://zenml.notion.site/GTM-Engineer-ZenML-Kitaru-f-m-d-372f8dff253880e586daeebc8f360a29",
   },
+  {
+    title: "GTM Engineer - San Francisco",
+    type: "Full-time",
+    href: "https://zenml.notion.site/GTM-Engineer-San-Francisco-3a3f8dff25388093a9cdd9efc71f30d2",
+  },
 ] as const;


### PR DESCRIPTION
## Summary

Updates the open positions list: adds the new **GTM Engineer - San Francisco** role (linking to its public Notion posting) and removes the old **GTM Engineer - ZenML/Kitaru (f/m/d)** Munich role. The list renders on both `/careers` and `/company`.

## What changed

- `src/lib/company.ts` — in `OPEN_POSITIONS`: added the San Francisco entry (`title`, `type: "Full-time"`, `href` to `zenml.notion.site`), removed the ZenML/Kitaru (f/m/d) entry. No template or layout changes; both pages render from this shared array.

## What reviewers should focus on

- Title copy is "GTM Engineer - San Francisco" (deliberately without "Founding", per Hamza) — the Notion page's H1 says "Founding GTM Engineer" but the card title matches the page name.
- Confirm the Notion link is the intended public share URL, and that removing the Munich listing is intended (the old Notion posting stays live, it's just no longer linked from the site).

## Validation

- `pnpm check`, `pnpm check:tests`, `pnpm check:surface`, `pnpm check:alt`, `pnpm lint`, `pnpm test` (76 passed) — all green locally after each change. Build/smoke/islands left to the required CI `Repo checks` job (data-only change to a shared array already exercised by both pages).

## Preview URLs / paths to check

- Preview URL + `/careers#open-positions`
- Preview URL + `/company#open-positions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)