### PR TITLE
Add safe preview Worker controls

### DIFF
--- a/.github/workflows/activate-worker-preview.yml
+++ b/.github/workflows/activate-worker-preview.yml
@@ -1,0 +1,382 @@
+name: Activate Exact Preview Worker Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_id:
+        description: Exact inactive preview Worker version ID
+        required: true
+        type: string
+      source_run_id:
+        description: CI run ID recorded on that version
+        required: true
+        type: string
+      source_branch:
+        description: Source branch recorded on that version
+        required: true
+        type: string
+      source_commit:
+        description: Source commit recorded on that version
+        required: true
+        type: string
+      artifact_sha256:
+        description: Artifact SHA-256 recorded on that version
+        required: true
+        type: string
+      self_reviewed:
+        description: I reviewed the exact version and approve only preview activation
+        required: true
+        type: boolean
+
+concurrency:
+  group: zenml-io-worker-preview
+  cancel-in-progress: false
+
+permissions: {}
+
+env:
+  WORKER_NAME: zenml-io-v2-worker-preview
+
+jobs:
+  activate:
+    name: Activate exact private preview version
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: worker-preview
+    permissions:
+      contents: read
+    steps:
+      - name: Require explicit self-review
+        if: inputs.self_reviewed != true
+        run: |
+          echo "The exact preview version and provenance must be self-reviewed." >&2
+          exit 1
+
+      - name: Validate activation identifiers
+        shell: bash
+        env:
+          ARTIFACT_SHA256: ${{ inputs.artifact_sha256 }}
+          SOURCE_BRANCH: ${{ inputs.source_branch }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          VERSION_ID: ${{ inputs.version_id }}
+        run: |
+          set -euo pipefail
+          [[ "$VERSION_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]
+          [[ "$SOURCE_RUN_ID" =~ ^[0-9]+$ ]]
+          [[ "$SOURCE_BRANCH" =~ ^[A-Za-z0-9._/-]+$ ]]
+          [[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$ARTIFACT_SHA256" =~ ^[0-9a-f]{64}$ ]]
+
+      - name: Install pinned Wrangler
+        run: npm install --global wrangler@4.110.0
+
+      - name: Verify the preview Worker is private and route-less
+        shell: bash
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_PREVIEW_TOKEN }}
+        run: |
+          set -euo pipefail
+          api_base="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID"
+          auth_header="Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+          worker_url="$api_base/workers/scripts/$WORKER_NAME"
+
+          status="$(
+            curl \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --silent \
+              --show-error \
+              --output /dev/null \
+              --write-out "%{http_code}" \
+              --header "$auth_header" \
+              "$worker_url"
+          )"
+          if [ "$status" != "200" ]; then
+            echo "Preview Worker is unavailable (HTTP $status)." >&2
+            exit 1
+          fi
+
+          curl \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --header "$auth_header" \
+            "$worker_url/subdomain" > "$RUNNER_TEMP/worker-subdomain.json"
+          jq -e '
+            .success == true and
+            .result.enabled == false and .result.previews_enabled == false
+          ' "$RUNNER_TEMP/worker-subdomain.json" > /dev/null
+
+          curl \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --header "$auth_header" \
+            "$api_base/workers/scripts" > "$RUNNER_TEMP/workers-before-activation.json"
+          jq -e --arg worker "$WORKER_NAME" '
+            .success == true and
+            ([.result[] | select(.id == $worker)]) as $workers |
+            ($workers | length) == 1 and
+            ($workers[0] | has("routes")) and
+            (
+              $workers[0].routes == null or
+              (
+                ($workers[0].routes | type) == "array" and
+                ($workers[0].routes | length) == 0
+              )
+            )
+          ' "$RUNNER_TEMP/workers-before-activation.json" > /dev/null
+
+          curl \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --header "$auth_header" \
+            "$api_base/workers/domains?service=$WORKER_NAME&per_page=100" \
+            > "$RUNNER_TEMP/worker-domains.json"
+          jq -e --arg worker "$WORKER_NAME" '
+            .success == true and
+            (.result | type) == "array" and
+            ([.result[] | select(.service == $worker)] | length == 0) and
+            .result_info.total_count == 0
+          ' "$RUNNER_TEMP/worker-domains.json" > /dev/null
+
+      - name: Inspect the exact preview version
+        shell: bash
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_PREVIEW_TOKEN }}
+          VERSION_ID: ${{ inputs.version_id }}
+        run: |
+          set -euo pipefail
+          wrangler versions view "$VERSION_ID" \
+            --name "$WORKER_NAME" \
+            --json > "$RUNNER_TEMP/version-metadata.json"
+
+      - name: Verify exact version provenance and bindings
+        shell: bash
+        env:
+          ARTIFACT_SHA256: ${{ inputs.artifact_sha256 }}
+          SOURCE_BRANCH: ${{ inputs.source_branch }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+        run: |
+          set -euo pipefail
+          jq -e '
+            [.resources.bindings[]? |
+              select(.type == "secret_text") | .name] as $names |
+            ($names | index("TURNSTILE_SECRET_KEY") != null) and
+            ($names | index("SEGMENT_FORMS_WRITE_KEY") != null)
+          ' "$RUNNER_TEMP/version-metadata.json" > /dev/null
+          message="$(
+            jq -er '.annotations["workers/message"]' \
+              "$RUNNER_TEMP/version-metadata.json"
+          )"
+          grep -Fq -- " source_commit=$SOURCE_COMMIT " <<< " $message " ||
+            { echo "Version source commit does not match." >&2; exit 1; }
+          grep -Fq -- " source_branch=$SOURCE_BRANCH " <<< " $message " ||
+            { echo "Version source branch does not match." >&2; exit 1; }
+          grep -Fq -- " source_run_id=$SOURCE_RUN_ID " <<< " $message " ||
+            { echo "Version CI run does not match." >&2; exit 1; }
+          grep -Fq -- " artifact_sha256=$ARTIFACT_SHA256 " <<< " $message " ||
+            { echo "Version artifact digest does not match." >&2; exit 1; }
+
+      - name: Capture pre-activation deployment
+        shell: bash
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_PREVIEW_TOKEN }}
+        run: |
+          set -euo pipefail
+          wrangler deployments list \
+            --name "$WORKER_NAME" \
+            --json > "$RUNNER_TEMP/previous-deployments.json"
+
+      - name: Preserve pre-activation deployment metadata
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: preview-pre-activation-${{ inputs.version_id }}
+          path: |
+            ${{ runner.temp }}/previous-deployments.json
+            ${{ runner.temp }}/version-metadata.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Record activation inputs
+        shell: bash
+        env:
+          ARTIFACT_SHA256: ${{ inputs.artifact_sha256 }}
+          INITIATOR: ${{ github.actor }}
+          SOURCE_BRANCH: ${{ inputs.source_branch }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          VERSION_ID: ${{ inputs.version_id }}
+        run: |
+          {
+            echo "## Preview Worker activation"
+            echo
+            printf -- "- Worker: \`%s\`\n" "$WORKER_NAME"
+            printf -- "- Candidate version: \`%s\`\n" "$VERSION_ID"
+            printf -- "- Source commit: \`%s\`\n" "$SOURCE_COMMIT"
+            printf -- "- Source branch: \`%s\`\n" "$SOURCE_BRANCH"
+            printf -- "- CI run: \`%s\`\n" "$SOURCE_RUN_ID"
+            printf -- "- Artifact SHA-256: \`%s\`\n" "$ARTIFACT_SHA256"
+            printf -- "- Initiator/self-reviewer: \`%s\`\n" "$INITIATOR"
+            echo
+            echo "The pre-activation deployment state is retained on this run."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Activate exact preview version
+        shell: bash
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_PREVIEW_TOKEN }}
+          VERSION_ID: ${{ inputs.version_id }}
+        run: |
+          set -euo pipefail
+          api_base="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID"
+          auth_header="Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+
+          # Repeat the public-exposure guard at the mutation boundary. The
+          # earlier check gives the operator a fast failure; this one narrows
+          # the window for an out-of-band dashboard or API change.
+          curl \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --header "$auth_header" \
+            "$api_base/workers/scripts/$WORKER_NAME/subdomain" \
+            > "$RUNNER_TEMP/worker-subdomain-before-deploy.json"
+          jq -e '
+            .success == true and
+            .result.enabled == false and .result.previews_enabled == false
+          ' "$RUNNER_TEMP/worker-subdomain-before-deploy.json" > /dev/null
+
+          curl \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --header "$auth_header" \
+            "$api_base/workers/scripts" \
+            > "$RUNNER_TEMP/workers-before-deploy.json"
+          jq -e --arg worker "$WORKER_NAME" '
+            .success == true and
+            ([.result[] | select(.id == $worker)]) as $workers |
+            ($workers | length) == 1 and
+            ($workers[0] | has("routes")) and
+            (
+              $workers[0].routes == null or
+              (
+                ($workers[0].routes | type) == "array" and
+                ($workers[0].routes | length) == 0
+              )
+            )
+          ' "$RUNNER_TEMP/workers-before-deploy.json" > /dev/null
+
+          curl \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --header "$auth_header" \
+            "$api_base/workers/domains?service=$WORKER_NAME&per_page=100" \
+            > "$RUNNER_TEMP/worker-domains-before-deploy.json"
+          jq -e --arg worker "$WORKER_NAME" '
+            .success == true and
+            (.result | type) == "array" and
+            ([.result[] | select(.service == $worker)] | length == 0) and
+            .result_info.total_count == 0
+          ' "$RUNNER_TEMP/worker-domains-before-deploy.json" > /dev/null
+
+          wrangler versions deploy "$VERSION_ID@100%" \
+            --name "$WORKER_NAME" \
+            --yes
+
+      - name: Verify exact activation and private endpoints
+        shell: bash
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_PREVIEW_TOKEN }}
+          VERSION_ID: ${{ inputs.version_id }}
+        run: |
+          set -euo pipefail
+          wrangler deployments list \
+            --name "$WORKER_NAME" \
+            --json > "$RUNNER_TEMP/deployments-after.json"
+          jq -e --arg version "$VERSION_ID" '
+            length >= 1 and
+            (
+              max_by(.created_on) as $latest |
+              ($latest.versions | length) == 1 and
+              $latest.versions[0].version_id == $version and
+              $latest.versions[0].percentage == 100
+            )
+          ' "$RUNNER_TEMP/deployments-after.json" > /dev/null
+
+          api_base="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID"
+          auth_header="Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+          curl \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --header "$auth_header" \
+            "$api_base/workers/scripts/$WORKER_NAME/subdomain" \
+            > "$RUNNER_TEMP/worker-subdomain-after.json"
+          jq -e '
+            .success == true and
+            .result.enabled == false and .result.previews_enabled == false
+          ' "$RUNNER_TEMP/worker-subdomain-after.json" > /dev/null
+
+          curl \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --header "$auth_header" \
+            "$api_base/workers/scripts" > "$RUNNER_TEMP/workers-after-activation.json"
+          jq -e --arg worker "$WORKER_NAME" '
+            .success == true and
+            ([.result[] | select(.id == $worker)]) as $workers |
+            ($workers | length) == 1 and
+            ($workers[0] | has("routes")) and
+            (
+              $workers[0].routes == null or
+              (
+                ($workers[0].routes | type) == "array" and
+                ($workers[0].routes | length) == 0
+              )
+            )
+          ' "$RUNNER_TEMP/workers-after-activation.json" > /dev/null
+
+          curl \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --header "$auth_header" \
+            "$api_base/workers/domains?service=$WORKER_NAME&per_page=100" \
+            > "$RUNNER_TEMP/worker-domains-after-activation.json"
+          jq -e --arg worker "$WORKER_NAME" '
+            .success == true and
+            (.result | type) == "array" and
+            ([.result[] | select(.service == $worker)] | length == 0) and
+            .result_info.total_count == 0
+          ' "$RUNNER_TEMP/worker-domains-after-activation.json" > /dev/null

--- a/.github/workflows/upload-worker-preview.yml
+++ b/.github/workflows/upload-worker-preview.yml
@@ -1,0 +1,449 @@
+name: Upload Exact Preview Worker Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request that produced the reviewed artifact
+        required: true
+        type: string
+      source_run_id:
+        description: Successful Website CI and Worker Artifact run ID
+        required: true
+        type: string
+      source_branch:
+        description: Exact source branch recorded by that run
+        required: true
+        type: string
+      source_commit:
+        description: Exact source commit recorded by that run
+        required: true
+        type: string
+      artifact_sha256:
+        description: Exact worker-dist.tar.gz SHA-256
+        required: true
+        type: string
+      self_reviewed:
+        description: I reviewed the exact artifact and approve only an inactive preview upload
+        required: true
+        type: boolean
+
+concurrency:
+  group: zenml-io-worker-preview
+  cancel-in-progress: false
+
+permissions: {}
+
+env:
+  WORKER_NAME: zenml-io-v2-worker-preview
+
+jobs:
+  upload:
+    name: Upload exact inactive preview version
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: worker-preview
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Require explicit self-review
+        if: inputs.self_reviewed != true
+        run: |
+          echo "The exact preview artifact must be explicitly self-reviewed." >&2
+          exit 1
+
+      - name: Validate dispatch identifiers
+        shell: bash
+        env:
+          ARTIFACT_SHA256: ${{ inputs.artifact_sha256 }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          SOURCE_BRANCH: ${{ inputs.source_branch }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+        run: |
+          set -euo pipefail
+          [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]
+          [[ "$SOURCE_RUN_ID" =~ ^[0-9]+$ ]]
+          [[ "$SOURCE_BRANCH" =~ ^[A-Za-z0-9._/-]+$ ]]
+          [[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$ARTIFACT_SHA256" =~ ^[0-9a-f]{64}$ ]]
+
+      - name: Verify the exact source run and PR head
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          SOURCE_BRANCH: ${{ inputs.source_branch }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+        run: |
+          set -euo pipefail
+          gh api \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID" \
+            > "$RUNNER_TEMP/source-run.json"
+          jq -e \
+            --arg branch "$SOURCE_BRANCH" \
+            --arg commit "$SOURCE_COMMIT" \
+            --arg path ".github/workflows/deploy.yml" \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --argjson pr "$PR_NUMBER" '
+              .conclusion == "success" and
+              .event == "pull_request" and
+              .path == $path and
+              .head_repository.full_name == $repository and
+              .head_branch == $branch and
+              .head_sha == $commit and
+              any(.pull_requests[]?; .number == $pr)
+            ' "$RUNNER_TEMP/source-run.json" > /dev/null
+
+          gh api \
+            "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
+            > "$RUNNER_TEMP/source-pr.json"
+          jq -e \
+            --arg branch "$SOURCE_BRANCH" \
+            --arg commit "$SOURCE_COMMIT" \
+            --arg repository "$GITHUB_REPOSITORY" '
+              .state == "open" and
+              .head.repo.full_name == $repository and
+              .head.ref == $branch and
+              .head.sha == $commit
+            ' "$RUNNER_TEMP/source-pr.json" > /dev/null
+
+      - name: Download the exact CI artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: worker-dist
+          path: candidate
+          run-id: ${{ inputs.source_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify artifact provenance and checksum
+        shell: bash
+        env:
+          ARTIFACT_SHA256: ${{ inputs.artifact_sha256 }}
+          SOURCE_BRANCH: ${{ inputs.source_branch }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+        run: |
+          set -euo pipefail
+          cd candidate
+          printf "%s  worker-dist.tar.gz\n" "$ARTIFACT_SHA256" \
+            > "$RUNNER_TEMP/expected-worker-dist.sha256"
+          sha256sum --check "$RUNNER_TEMP/expected-worker-dist.sha256"
+          sha256sum --check worker-dist.sha256
+          jq -e \
+            --arg artifact_sha256 "$ARTIFACT_SHA256" \
+            --arg branch "$SOURCE_BRANCH" \
+            --arg commit "$SOURCE_COMMIT" \
+            --arg run_id "$SOURCE_RUN_ID" '
+              .event_name == "pull_request" and
+              .artifact_sha256 == $artifact_sha256 and
+              .source_branch == $branch and
+              .source_commit == $commit and
+              .run_id == $run_id and
+              (.required_secrets | sort) ==
+                (["SEGMENT_FORMS_WRITE_KEY", "TURNSTILE_SECRET_KEY"] | sort)
+            ' worker-manifest.json > /dev/null
+
+      - name: Reject an unsafe Worker artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd candidate
+          tar -tzf worker-dist.tar.gz > "$RUNNER_TEMP/archive-paths.txt"
+          if grep -Eq '(^/|(^|/)\.\.(/|$))' "$RUNNER_TEMP/archive-paths.txt"; then
+            echo "Worker archive contains an unsafe path." >&2
+            exit 1
+          fi
+          tar -tvzf worker-dist.tar.gz > "$RUNNER_TEMP/archive-members.txt"
+          while read -r mode _; do
+            case "${mode:0:1}" in
+              -|d) ;;
+              *)
+                echo "Worker archive contains a link or special file." >&2
+                exit 1
+                ;;
+            esac
+          done < "$RUNNER_TEMP/archive-members.txt"
+          jq -e '
+            ((keys - [
+              "$schema", "assets", "compatibility_date",
+              "compatibility_flags", "main", "name", "preview_urls",
+              "secrets", "workers_dev"
+            ]) | length == 0) and
+            .name == "zenml-io-v2-worker" and
+            .main == "dist/_worker.js/index.js" and
+            .workers_dev == false and
+            .preview_urls == false and
+            .assets.directory == "./dist" and
+            .assets.binding == "ASSETS" and
+            (has("route") | not) and
+            (has("routes") | not) and
+            (has("build") | not)
+          ' wrangler.jsonc > /dev/null
+
+      - name: Verify the preview Worker is private and route-less
+        shell: bash
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_PREVIEW_TOKEN }}
+        run: |
+          set -euo pipefail
+          api_base="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID"
+          auth_header="Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+          worker_url="$api_base/workers/scripts/$WORKER_NAME"
+
+          status="$(
+            curl \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --silent \
+              --show-error \
+              --output /dev/null \
+              --write-out "%{http_code}" \
+              --header "$auth_header" \
+              "$worker_url"
+          )"
+          if [ "$status" != "200" ]; then
+            echo "Preview Worker is unavailable (HTTP $status)." >&2
+            exit 1
+          fi
+
+          curl \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --header "$auth_header" \
+            "$worker_url/subdomain" > "$RUNNER_TEMP/worker-subdomain.json"
+          jq -e '
+            .success == true and
+            .result.enabled == false and .result.previews_enabled == false
+          ' "$RUNNER_TEMP/worker-subdomain.json" > /dev/null
+
+          curl \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --header "$auth_header" \
+            "$api_base/workers/scripts" > "$RUNNER_TEMP/workers-before-upload.json"
+          jq -e --arg worker "$WORKER_NAME" '
+            .success == true and
+            ([.result[] | select(.id == $worker)]) as $workers |
+            ($workers | length) == 1 and
+            ($workers[0] | has("routes")) and
+            (
+              $workers[0].routes == null or
+              (
+                ($workers[0].routes | type) == "array" and
+                ($workers[0].routes | length) == 0
+              )
+            )
+          ' "$RUNNER_TEMP/workers-before-upload.json" > /dev/null
+
+          curl \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --header "$auth_header" \
+            "$api_base/workers/domains?service=$WORKER_NAME&per_page=100" \
+            > "$RUNNER_TEMP/worker-domains.json"
+          jq -e --arg worker "$WORKER_NAME" '
+            .success == true and
+            (.result | type) == "array" and
+            ([.result[] | select(.service == $worker)] | length == 0) and
+            .result_info.total_count == 0
+          ' "$RUNNER_TEMP/worker-domains.json" > /dev/null
+
+      - name: Prepare trusted preview configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd candidate
+          mkdir dist
+          tar -C dist -xzf worker-dist.tar.gz
+          jq '
+            .name = env.WORKER_NAME |
+            .workers_dev = false |
+            .preview_urls = false |
+            del(.secrets)
+          ' wrangler.jsonc > upload-wrangler.json
+
+      - name: Install pinned Wrangler
+        run: npm install --global wrangler@4.110.0
+
+      - name: Capture active deployment before upload
+        shell: bash
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_PREVIEW_TOKEN }}
+        run: |
+          set -euo pipefail
+          wrangler deployments list \
+            --name "$WORKER_NAME" \
+            --json > "$RUNNER_TEMP/deployments-before-upload.json"
+
+      - name: Upload one inactive preview version
+        id: upload
+        shell: bash
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_PREVIEW_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          SEGMENT_FORMS_WRITE_KEY: ${{ secrets.WORKERS_PREVIEW_SEGMENT_FORMS_WRITE_KEY }}
+          SOURCE_BRANCH: ${{ inputs.source_branch }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          TURNSTILE_SECRET_KEY: ${{ secrets.WORKERS_PREVIEW_TURNSTILE_SECRET_KEY }}
+        run: |
+          set -euo pipefail
+          cd candidate
+
+          # Close the time-of-check gap before the privileged upload. A push to
+          # the PR after the first check must invalidate this dispatch.
+          gh api \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID" \
+            > "$RUNNER_TEMP/source-run-before-upload.json"
+          jq -e \
+            --arg branch "$SOURCE_BRANCH" \
+            --arg commit "$SOURCE_COMMIT" \
+            --arg path ".github/workflows/deploy.yml" \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --argjson pr "$PR_NUMBER" '
+              .conclusion == "success" and
+              .event == "pull_request" and
+              .path == $path and
+              .head_repository.full_name == $repository and
+              .head_branch == $branch and
+              .head_sha == $commit and
+              any(.pull_requests[]?; .number == $pr)
+            ' "$RUNNER_TEMP/source-run-before-upload.json" > /dev/null
+          gh api \
+            "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
+            > "$RUNNER_TEMP/source-pr-before-upload.json"
+          jq -e \
+            --arg branch "$SOURCE_BRANCH" \
+            --arg commit "$SOURCE_COMMIT" \
+            --arg repository "$GITHUB_REPOSITORY" '
+              .state == "open" and
+              .head.repo.full_name == $repository and
+              .head.ref == $branch and
+              .head.sha == $commit
+            ' "$RUNNER_TEMP/source-pr-before-upload.json" > /dev/null
+
+          secrets_file="$RUNNER_TEMP/worker-preview-secrets.env"
+          output_file="$RUNNER_TEMP/wrangler-preview-output.jsonl"
+          trap 'rm -f "$secrets_file"' EXIT
+          {
+            printf 'SEGMENT_FORMS_WRITE_KEY=%s\n' "$SEGMENT_FORMS_WRITE_KEY"
+            printf 'TURNSTILE_SECRET_KEY=%s\n' "$TURNSTILE_SECRET_KEY"
+          } > "$secrets_file"
+          chmod 600 "$secrets_file"
+          export WRANGLER_OUTPUT_FILE_PATH="$output_file"
+          artifact_sha256="$(jq -r .artifact_sha256 worker-manifest.json)"
+          version_message="source_commit=$SOURCE_COMMIT source_branch=$SOURCE_BRANCH source_run_id=$SOURCE_RUN_ID artifact_sha256=$artifact_sha256"
+          wrangler versions upload \
+            --config upload-wrangler.json \
+            --secrets-file "$secrets_file" \
+            --tag preview-candidate \
+            --message "$version_message"
+          jq -s 'map(select(.type == "version-upload")) | last' \
+            "$output_file" > upload-result.json
+          version_id="$(jq -er .version_id upload-result.json)"
+          {
+            echo "version_id=$version_id"
+            echo "artifact_sha256=$artifact_sha256"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Verify uploaded version provenance and bindings
+        shell: bash
+        env:
+          ARTIFACT_SHA256: ${{ inputs.artifact_sha256 }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_PREVIEW_TOKEN }}
+          SOURCE_BRANCH: ${{ inputs.source_branch }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          VERSION_ID: ${{ steps.upload.outputs.version_id }}
+        run: |
+          set -euo pipefail
+          wrangler versions view "$VERSION_ID" \
+            --name "$WORKER_NAME" \
+            --json > "$RUNNER_TEMP/uploaded-version.json"
+          jq -e '
+            [.resources.bindings[]? |
+              select(.type == "secret_text") | .name] as $names |
+            ($names | index("TURNSTILE_SECRET_KEY") != null) and
+            ($names | index("SEGMENT_FORMS_WRITE_KEY") != null)
+          ' "$RUNNER_TEMP/uploaded-version.json" > /dev/null
+          message="$(
+            jq -er '.annotations["workers/message"]' \
+              "$RUNNER_TEMP/uploaded-version.json"
+          )"
+          grep -Fq -- " source_commit=$SOURCE_COMMIT " <<< " $message "
+          grep -Fq -- " source_branch=$SOURCE_BRANCH " <<< " $message "
+          grep -Fq -- " source_run_id=$SOURCE_RUN_ID " <<< " $message "
+          grep -Fq -- " artifact_sha256=$ARTIFACT_SHA256 " <<< " $message "
+
+          api_base="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID"
+          curl \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            "$api_base/workers/scripts/$WORKER_NAME/subdomain" \
+            > "$RUNNER_TEMP/worker-subdomain-after-upload.json"
+          jq -e '
+            .success == true and
+            .result.enabled == false and .result.previews_enabled == false
+          ' "$RUNNER_TEMP/worker-subdomain-after-upload.json" > /dev/null
+
+          wrangler deployments list \
+            --name "$WORKER_NAME" \
+            --json > "$RUNNER_TEMP/deployments-after-upload.json"
+          jq -S . "$RUNNER_TEMP/deployments-before-upload.json" \
+            > "$RUNNER_TEMP/deployments-before-upload.canonical.json"
+          jq -S . "$RUNNER_TEMP/deployments-after-upload.json" \
+            > "$RUNNER_TEMP/deployments-after-upload.canonical.json"
+          cmp \
+            "$RUNNER_TEMP/deployments-before-upload.canonical.json" \
+            "$RUNNER_TEMP/deployments-after-upload.canonical.json" ||
+            {
+              echo "The active preview deployment changed during upload." >&2
+              exit 1
+            }
+
+      - name: Record inactive preview metadata
+        shell: bash
+        env:
+          ARTIFACT_SHA256: ${{ steps.upload.outputs.artifact_sha256 }}
+          INITIATOR: ${{ github.actor }}
+          SOURCE_BRANCH: ${{ inputs.source_branch }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          VERSION_ID: ${{ steps.upload.outputs.version_id }}
+        run: |
+          {
+            echo "## Inactive preview Worker version"
+            echo
+            printf -- "- Worker: \`%s\`\n" "$WORKER_NAME"
+            printf -- "- Version: \`%s\`\n" "$VERSION_ID"
+            printf -- "- Source commit: \`%s\`\n" "$SOURCE_COMMIT"
+            printf -- "- Source branch: \`%s\`\n" "$SOURCE_BRANCH"
+            printf -- "- CI run: \`%s\`\n" "$SOURCE_RUN_ID"
+            printf -- "- Artifact SHA-256: \`%s\`\n" "$ARTIFACT_SHA256"
+            printf -- "- Initiator/self-reviewer: \`%s\`\n" "$INITIATOR"
+            echo
+            echo "The version is inactive, unrouted, and has no public preview URL."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/worker-preview-control-plane.md
+++ b/docs/worker-preview-control-plane.md
@@ -1,0 +1,184 @@
+# Preview Worker release controls
+
+This guide moves one reviewed website build onto the isolated
+`zenml-io-v2-worker-preview` Worker without exposing it to visitors. Upload,
+activation, and routing are separate actions. Completing one never authorizes
+the next.
+
+The preview Worker has no `workers.dev` address, no version preview URL, no
+custom domain, and no Worker route. Activating a version changes what the
+Worker would serve if it received traffic, but it does not send traffic to the
+Worker.
+
+## Hard boundaries
+
+The three preview workflows:
+
+- run only from trusted `main`;
+- share one lock, so they cannot change the preview Worker concurrently;
+- use only the `worker-preview` GitHub environment;
+- target only `zenml-io-v2-worker-preview`;
+- never receive the Worker-routes token;
+- never change DNS, Pages, Access, custom domains, or production;
+- never print secret values.
+
+The Cloudflare Workers token is account-scoped because Cloudflare does not
+offer per-Worker script permissions. The fixed Worker name, trusted workflow
+code, environment branch policy, and absence of route authority are therefore
+security controls, not conveniences.
+
+## Required GitHub gate before merge
+
+Before merging these credentialed workflows, verify the `worker-preview`
+environment:
+
+1. Deployment branches and tags is set to **Selected branches and tags**.
+2. Its only branch rule is exactly `main`.
+3. It has no tag or pull-request rule.
+4. Its secret names are exactly:
+   - `CLOUDFLARE_ACCOUNT_ID`
+   - `CLOUDFLARE_WORKERS_PREVIEW_TOKEN`
+   - `WORKERS_PREVIEW_SEGMENT_FORMS_WRITE_KEY`
+   - `WORKERS_PREVIEW_TURNSTILE_SECRET_KEY`
+5. Reading or changing the policy did not start a workflow.
+
+Pause if any item differs. Changing this GitHub policy is a separate external
+mutation and requires its own approval.
+
+## Build a new eligible artifact
+
+After the upload and activation workflows exist on `main`:
+
+1. Reconcile the Astro 5 migration PR with current `main`.
+2. Keep the trusted manual
+   `.github/workflows/upload-worker-preview.yml` during conflict resolution.
+   Do not restore the feature branch's older automatic `workflow_run`
+   uploader.
+3. Run the complete PR CI workflow.
+4. Download its `worker-dist` artifact.
+5. Record:
+   - pull request number;
+   - source run ID;
+   - source branch;
+   - source commit;
+   - `worker-dist.tar.gz` SHA-256 from both the checksum file and an
+     independent computation;
+   - manifest source branch, commit, run ID, and required binding names.
+6. Confirm the PR head, CI run, checksum, and manifest all agree.
+
+Any earlier artifact becomes historical evidence only. Do not upload it.
+
+## Before every Cloudflare mutation
+
+Pause and capture a timestamped read-only snapshot:
+
+1. The candidate PR head and successful CI run still match the recorded
+   identifiers.
+2. The preview Worker exists.
+3. Its `workers.dev` endpoint and version preview URLs are disabled.
+4. It has no custom domain and no Worker route.
+5. `astro-workers-staging.zenml.io` still reaches retained Pages through
+   Cloudflare Access.
+6. `zenml.io` redirects normally and `www.zenml.io` serves the production
+   site.
+7. `cloud.zenml.io`, `staging.zenml.io`, and the recorded platform-service
+   hostnames match their baseline.
+
+Stop on any unexplained difference. Do not repair drift during the same
+action.
+
+## Upload one inactive version
+
+Open **Actions → Upload Exact Preview Worker Version → Run workflow** and
+select `main`.
+
+Enter the six recorded values:
+
+- PR number;
+- source run ID;
+- source branch;
+- source commit;
+- artifact SHA-256;
+- explicit self-review confirmation.
+
+The workflow re-reads the run and pull request from GitHub, downloads only that
+run's artifact, checks its checksum and manifest, rejects unsafe archive or
+Wrangler configuration, confirms the preview Worker is private and route-less,
+and uploads one inactive version with the two non-production form secrets.
+
+The upload does not deploy the version. Its summary records the version ID and
+provenance.
+
+### Pause and verify after upload
+
+1. The workflow completed successfully.
+2. Its recorded version ID exists on
+   `zenml-io-v2-worker-preview`.
+3. The version message contains the exact source branch, commit, run ID, and
+   artifact SHA-256.
+4. Its secret binding names include `TURNSTILE_SECRET_KEY` and
+   `SEGMENT_FORMS_WRITE_KEY`; do not read or record their values.
+5. The active deployment is unchanged.
+6. Public Worker endpoints, custom domains, and routes remain absent.
+7. Production, retained Pages, staging Access, and platform-service baselines
+   remain unchanged.
+
+If upload or verification fails, assume the upload may have happened, inspect
+the Worker read-only, leave any new version inactive, and stop. Do not delete
+it or upload a replacement during the same approval.
+
+## Activate the exact preview version
+
+Activation is a second mutation. Start it only after the upload evidence has
+been reviewed and separately approved.
+
+Open **Actions → Activate Exact Preview Worker Version → Run workflow** and
+select `main`.
+
+Enter the six values recorded by the upload:
+
+- version ID;
+- source run ID;
+- source branch;
+- source commit;
+- artifact SHA-256;
+- explicit self-review confirmation.
+
+The workflow inspects that exact version, verifies its provenance and secret
+binding names, saves the current deployment metadata, and deploys only that
+version at 100 percent on the preview Worker. It then confirms the Worker still
+has no public endpoint.
+
+### Pause and verify after activation
+
+1. The workflow completed successfully.
+2. Its retained artifact contains the pre-activation deployment and inspected
+   version metadata.
+3. The newest preview deployment contains only the approved version at
+   100 percent.
+4. The preview Worker remains without public endpoints, custom domains, or
+   routes.
+5. Production, retained Pages, staging Access, and platform-service baselines
+   remain unchanged.
+
+At this point the new site code is active inside an unreachable Worker. There
+is still no browser URL for it. Attaching only
+`astro-workers-staging.zenml.io/*` is the next separate mutation and requires a
+fresh before-state, exact route review, explicit approval, and immediate
+after-state verification. That future route workflow must use the same
+`zenml-io-worker-preview` concurrency group so GitHub cannot interleave route
+attachment with upload or activation.
+
+## Rollback boundaries
+
+- **Failed inactive upload:** no traffic changed. Leave the version inactive
+  and stop.
+- **Failed or bad activation before a route exists:** the version may already
+  be active even if the run failed. Inspect the Worker read-only, keep the
+  route absent, and stop. The inert bootstrap version is not an accepted
+  serving fallback.
+- **Problem after the staging route is later attached:** remove only the exact
+  recorded staging route to restore retained Pages. Do not edit DNS or delete
+  Pages.
+- **Production:** these workflows cannot change it. Production cutover and
+  rollback use separate controls and approvals.

--- a/tests/config/workerPreviewControlPlane.test.ts
+++ b/tests/config/workerPreviewControlPlane.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
@@ -5,8 +6,11 @@ import { parse } from "yaml";
 interface WorkflowStep {
   env?: Record<string, string>;
   if?: string;
+  id?: string;
   name: string;
   run?: string;
+  uses?: string;
+  with?: Record<string, string | number>;
 }
 
 interface BootstrapWorkflow {
@@ -38,6 +42,38 @@ interface BootstrapWorkflow {
   permissions: Record<string, never>;
 }
 
+interface ManualPreviewWorkflow {
+  concurrency: {
+    "cancel-in-progress": boolean;
+    group: string;
+  };
+  env: {
+    WORKER_NAME: string;
+  };
+  jobs: Record<
+    string,
+    {
+      environment: string;
+      if: string;
+      permissions: Record<string, string>;
+      steps: WorkflowStep[];
+      "timeout-minutes": number;
+    }
+  >;
+  on: {
+    workflow_dispatch: {
+      inputs: Record<
+        string,
+        {
+          required: boolean;
+          type: string;
+        }
+      >;
+    };
+  };
+  permissions: Record<string, never>;
+}
+
 const bootstrapWorkflowText = readFileSync(
   ".github/workflows/bootstrap-worker-preview.yml",
   "utf8",
@@ -52,6 +88,43 @@ function step(name: string): WorkflowStep {
   const workflowStep = steps[name];
   expect(workflowStep, `missing workflow step: ${name}`).toBeDefined();
   return workflowStep;
+}
+
+function jqProgramWritingTo(run: string, filename: string): string {
+  const destination = `' "$RUNNER_TEMP/${filename}" > /dev/null`;
+  const destinationIndex = run.indexOf(destination);
+  expect(
+    destinationIndex,
+    `missing jq destination for ${filename}`,
+  ).toBeGreaterThan(-1);
+  const commandPrefix = run.slice(0, destinationIndex);
+  const commandIndex = commandPrefix.lastIndexOf("jq -e");
+  expect(commandIndex, `missing jq command for ${filename}`).toBeGreaterThan(
+    -1,
+  );
+  const programStart = commandPrefix.indexOf("'", commandIndex);
+  expect(programStart, `missing jq program for ${filename}`).toBeGreaterThan(
+    -1,
+  );
+  return commandPrefix.slice(programStart + 1);
+}
+
+function expectJqResult(
+  program: string,
+  input: unknown,
+  succeeds: boolean,
+  args: string[] = [],
+): void {
+  const execute = () =>
+    execFileSync("jq", ["-e", ...args, program], {
+      input: JSON.stringify(input),
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  if (succeeds) {
+    expect(execute).not.toThrow();
+  } else {
+    expect(execute).toThrow();
+  }
 }
 
 describe("preview Worker bootstrap workflow", () => {
@@ -184,6 +257,505 @@ describe("preview Worker bootstrap workflow", () => {
     for (const curlStep of curlSteps) {
       expect(curlStep.run).toContain("--connect-timeout 10");
       expect(curlStep.run).toContain("--max-time 30");
+    }
+  });
+});
+
+const uploadWorkflowText = readFileSync(
+  ".github/workflows/upload-worker-preview.yml",
+  "utf8",
+);
+const uploadWorkflow = parse(uploadWorkflowText) as ManualPreviewWorkflow;
+const uploadJob = uploadWorkflow.jobs.upload;
+const uploadSteps = Object.fromEntries(
+  uploadJob.steps.map((workflowStep) => [workflowStep.name, workflowStep]),
+);
+
+function uploadStep(name: string): WorkflowStep {
+  const workflowStep = uploadSteps[name];
+  expect(workflowStep, `missing upload workflow step: ${name}`).toBeDefined();
+  return workflowStep;
+}
+
+describe("preview Worker upload workflow", () => {
+  it("is a self-reviewed trusted-main action with exact source inputs", () => {
+    expect(Object.keys(uploadWorkflow.on)).toEqual(["workflow_dispatch"]);
+    expect(
+      Object.keys(uploadWorkflow.on.workflow_dispatch.inputs).sort(),
+    ).toEqual([
+      "artifact_sha256",
+      "pr_number",
+      "self_reviewed",
+      "source_branch",
+      "source_commit",
+      "source_run_id",
+    ]);
+    expect(
+      uploadWorkflow.on.workflow_dispatch.inputs.self_reviewed,
+    ).toMatchObject({
+      required: true,
+      type: "boolean",
+    });
+    expect(uploadWorkflow.permissions).toEqual({});
+    expect(uploadJob.if).toBe("github.ref == 'refs/heads/main'");
+    expect(uploadJob.environment).toBe("worker-preview");
+    expect(uploadJob.permissions).toEqual({
+      actions: "read",
+      contents: "read",
+      "pull-requests": "read",
+    });
+    expect(uploadJob["timeout-minutes"]).toBe(15);
+    expect(uploadWorkflow.concurrency).toEqual({
+      group: "zenml-io-worker-preview",
+      "cancel-in-progress": false,
+    });
+  });
+
+  it("validates the exact same-repository PR run and current head", () => {
+    const validationStep = uploadStep("Validate dispatch identifiers");
+    const sourceStep = uploadStep("Verify the exact source run and PR head");
+
+    expect(validationStep.run).toContain('[[ "$PR_NUMBER" =~ ^[0-9]+$ ]]');
+    expect(validationStep.run).toContain('[[ "$SOURCE_RUN_ID" =~ ^[0-9]+$ ]]');
+    expect(validationStep.run).toContain(
+      '[[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]',
+    );
+    expect(validationStep.run).toContain(
+      '[[ "$ARTIFACT_SHA256" =~ ^[0-9a-f]{64}$ ]]',
+    );
+    expect(sourceStep.run).toContain(
+      "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID",
+    );
+    expect(sourceStep.run).toContain(
+      '--arg path ".github/workflows/deploy.yml"',
+    );
+    expect(sourceStep.run).toContain(".path == $path");
+    expect(sourceStep.run).toContain(
+      ".head_repository.full_name == $repository",
+    );
+    expect(sourceStep.run).toContain(
+      "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER",
+    );
+    expect(sourceStep.run).toContain(".head.repo.full_name == $repository");
+    expect(sourceStep.run).toContain(".head.sha == $commit");
+
+    for (const workflowStep of uploadJob.steps) {
+      expect(workflowStep.run ?? "").not.toContain("${{ inputs.");
+    }
+  });
+
+  it("downloads and verifies only the named run artifact", () => {
+    const downloadStep = uploadStep("Download the exact CI artifact");
+    const provenanceStep = uploadStep(
+      "Verify artifact provenance and checksum",
+    );
+    const safetyStep = uploadStep("Reject an unsafe Worker artifact");
+
+    expect(downloadStep.uses).toBe(
+      "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
+    );
+    expect(downloadStep.with).toMatchObject({
+      name: "worker-dist",
+      path: "candidate",
+      "run-id": "$" + "{{ inputs.source_run_id }}",
+    });
+    expect(provenanceStep.run).toContain(
+      'printf "%s  worker-dist.tar.gz\\n" "$ARTIFACT_SHA256"',
+    );
+    expect(provenanceStep.run).toContain("sha256sum --check");
+    expect(provenanceStep.run).toContain(
+      ".artifact_sha256 == $artifact_sha256",
+    );
+    expect(provenanceStep.run).toContain(".source_branch == $branch");
+    expect(provenanceStep.run).toContain(".source_commit == $commit");
+    expect(provenanceStep.run).toContain(".run_id == $run_id");
+    expect(safetyStep.run).toContain("tar -tzf worker-dist.tar.gz");
+    expect(safetyStep.run).toContain("tar -tvzf worker-dist.tar.gz");
+    expect(safetyStep.run).toContain(
+      "grep -Eq '(^/|(^|/)\\.\\.(/|$))' \"$RUNNER_TEMP/archive-paths.txt\"",
+    );
+    expect(safetyStep.run).not.toContain("tar -tzf worker-dist.tar.gz |");
+    expect(safetyStep.run).toContain('has("route") | not');
+    expect(safetyStep.run).toContain('has("routes") | not');
+    expect(safetyStep.run).toContain('has("build") | not');
+  });
+
+  it("uploads one private inactive version to only the fixed preview Worker", () => {
+    const workerStep = uploadStep(
+      "Verify the preview Worker is private and route-less",
+    );
+    const configStep = uploadStep("Prepare trusted preview configuration");
+    const captureDeploymentStep = uploadStep(
+      "Capture active deployment before upload",
+    );
+    const uploadVersionStep = uploadStep("Upload one inactive preview version");
+    const verifyVersionStep = uploadStep(
+      "Verify uploaded version provenance and bindings",
+    );
+
+    expect(uploadWorkflow.env.WORKER_NAME).toBe("zenml-io-v2-worker-preview");
+    expect(
+      uploadWorkflowText.match(/zenml-io-v2-worker-preview/g),
+    ).toHaveLength(1);
+    expect(workerStep.run).toContain(
+      'worker_url="$api_base/workers/scripts/$WORKER_NAME"',
+    );
+    expect(workerStep.run).toContain('"$worker_url/subdomain"');
+    expect(workerStep.run).toContain(
+      ".result.enabled == false and .result.previews_enabled == false",
+    );
+    expect(workerStep.run).toContain('has("routes")');
+    expect(workerStep.run).toContain(
+      "/workers/domains?service=$WORKER_NAME&per_page=100",
+    );
+    expect(workerStep.run).toContain(".result_info.total_count == 0");
+    expect(configStep.run).toContain(".name = env.WORKER_NAME");
+    expect(configStep.run).toContain(".workers_dev = false");
+    expect(configStep.run).toContain(".preview_urls = false");
+    expect(uploadWorkflowText).not.toContain(".preview_urls = true");
+    expect(configStep.run).toContain("del(.secrets)");
+    expect(captureDeploymentStep.run).toContain("wrangler deployments list");
+    expect(captureDeploymentStep.run).toContain(
+      "deployments-before-upload.json",
+    );
+    expect(uploadVersionStep.run).toContain("wrangler versions upload");
+    expect(uploadVersionStep.run).toContain("source-run-before-upload.json");
+    expect(uploadVersionStep.run).toContain("source-pr-before-upload.json");
+    expect(uploadVersionStep.run).toContain(".head.sha == $commit");
+    expect(uploadVersionStep.run).toContain("--secrets-file");
+    expect(uploadVersionStep.run).not.toContain("--preview-alias");
+    expect(uploadWorkflowText).not.toContain("--preview-alias");
+    expect(uploadVersionStep.run).not.toContain("wrangler versions deploy");
+    expect(uploadVersionStep.env).toMatchObject({
+      SEGMENT_FORMS_WRITE_KEY:
+        "$" + "{{ secrets.WORKERS_PREVIEW_SEGMENT_FORMS_WRITE_KEY }}",
+      TURNSTILE_SECRET_KEY:
+        "$" + "{{ secrets.WORKERS_PREVIEW_TURNSTILE_SECRET_KEY }}",
+    });
+    expect(verifyVersionStep.run).toContain('select(.type == "secret_text")');
+    expect(verifyVersionStep.run).toContain("TURNSTILE_SECRET_KEY");
+    expect(verifyVersionStep.run).toContain("SEGMENT_FORMS_WRITE_KEY");
+    expect(verifyVersionStep.run).toContain("deployments-after-upload.json");
+    expect(verifyVersionStep.run).toContain(
+      "deployments-before-upload.canonical.json",
+    );
+    expect(verifyVersionStep.run).toContain("cmp");
+    expect(uploadWorkflowText).not.toContain(
+      "secrets.CLOUDFLARE_WORKERS_PRODUCTION_TOKEN",
+    );
+    expect(uploadWorkflowText).not.toContain("wrangler routes");
+    expect(uploadWorkflowText).not.toContain("wrangler dns");
+    expect(uploadWorkflowText).not.toContain("wrangler pages");
+    expect(uploadWorkflowText).not.toContain("wrangler delete");
+  });
+
+  it("executes the workflow privacy predicates against safe and public states", () => {
+    const workerStep = uploadStep(
+      "Verify the preview Worker is private and route-less",
+    );
+    const run = workerStep.run ?? "";
+    const subdomainProgram = jqProgramWritingTo(run, "worker-subdomain.json");
+    const routesProgram = jqProgramWritingTo(run, "workers-before-upload.json");
+    const domainsProgram = jqProgramWritingTo(run, "worker-domains.json");
+    const workerArgs = ["--arg", "worker", "zenml-io-v2-worker-preview"];
+
+    expectJqResult(
+      subdomainProgram,
+      {
+        result: { enabled: false, previews_enabled: false },
+        success: true,
+      },
+      true,
+    );
+    expectJqResult(
+      subdomainProgram,
+      {
+        result: { enabled: true, previews_enabled: false },
+        success: true,
+      },
+      false,
+    );
+
+    expectJqResult(
+      routesProgram,
+      {
+        result: [{ id: "zenml-io-v2-worker-preview", routes: [] }],
+        success: true,
+      },
+      true,
+      workerArgs,
+    );
+    expectJqResult(
+      routesProgram,
+      {
+        result: [
+          {
+            id: "zenml-io-v2-worker-preview",
+            routes: ["astro-workers-staging.zenml.io/*"],
+          },
+        ],
+        success: true,
+      },
+      false,
+      workerArgs,
+    );
+
+    expectJqResult(
+      domainsProgram,
+      {
+        result: [],
+        result_info: { total_count: 0 },
+        success: true,
+      },
+      true,
+      workerArgs,
+    );
+    expectJqResult(
+      domainsProgram,
+      {
+        result: [
+          {
+            hostname: "preview.example.com",
+            service: "zenml-io-v2-worker-preview",
+          },
+        ],
+        result_info: { total_count: 1 },
+        success: true,
+      },
+      false,
+      workerArgs,
+    );
+  });
+});
+
+const activationWorkflowText = readFileSync(
+  ".github/workflows/activate-worker-preview.yml",
+  "utf8",
+);
+const activationWorkflow = parse(
+  activationWorkflowText,
+) as ManualPreviewWorkflow;
+const activationJob = activationWorkflow.jobs.activate;
+const activationSteps = Object.fromEntries(
+  activationJob.steps.map((workflowStep) => [workflowStep.name, workflowStep]),
+);
+
+function activationStep(name: string): WorkflowStep {
+  const workflowStep = activationSteps[name];
+  expect(
+    workflowStep,
+    `missing activation workflow step: ${name}`,
+  ).toBeDefined();
+  return workflowStep;
+}
+
+describe("preview Worker activation workflow", () => {
+  it("is a self-reviewed trusted-main action with exact version inputs", () => {
+    expect(Object.keys(activationWorkflow.on)).toEqual(["workflow_dispatch"]);
+    expect(
+      Object.keys(activationWorkflow.on.workflow_dispatch.inputs).sort(),
+    ).toEqual([
+      "artifact_sha256",
+      "self_reviewed",
+      "source_branch",
+      "source_commit",
+      "source_run_id",
+      "version_id",
+    ]);
+    expect(activationWorkflow.permissions).toEqual({});
+    expect(activationJob.if).toBe("github.ref == 'refs/heads/main'");
+    expect(activationJob.environment).toBe("worker-preview");
+    expect(activationJob.permissions).toEqual({ contents: "read" });
+    expect(activationJob["timeout-minutes"]).toBe(15);
+    expect(activationWorkflow.concurrency).toEqual({
+      group: "zenml-io-worker-preview",
+      "cancel-in-progress": false,
+    });
+  });
+
+  it("validates inputs and inspects exact private-version provenance", () => {
+    const validationStep = activationStep("Validate activation identifiers");
+    const workerStep = activationStep(
+      "Verify the preview Worker is private and route-less",
+    );
+    const inspectStep = activationStep("Inspect the exact preview version");
+    const provenanceStep = activationStep(
+      "Verify exact version provenance and bindings",
+    );
+
+    expect(validationStep.run).toContain('[[ "$VERSION_ID" =~ ^[0-9a-f]{8}-');
+    expect(validationStep.run).toContain(
+      '[[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]',
+    );
+    expect(workerStep.run).toContain(
+      ".result.enabled == false and .result.previews_enabled == false",
+    );
+    expect(workerStep.run).toContain('has("routes")');
+    expect(workerStep.run).toContain(
+      "/workers/domains?service=$WORKER_NAME&per_page=100",
+    );
+    expect(workerStep.run).toContain(".result_info.total_count == 0");
+    expect(inspectStep.run).toContain('wrangler versions view "$VERSION_ID"');
+    expect(inspectStep.run).toContain('--name "$WORKER_NAME"');
+    expect(provenanceStep.run).toContain('select(.type == "secret_text")');
+    expect(provenanceStep.run).toContain("source_commit=$SOURCE_COMMIT");
+    expect(provenanceStep.run).toContain("source_branch=$SOURCE_BRANCH");
+    expect(provenanceStep.run).toContain("source_run_id=$SOURCE_RUN_ID");
+    expect(provenanceStep.run).toContain("artifact_sha256=$ARTIFACT_SHA256");
+
+    for (const workflowStep of activationJob.steps) {
+      expect(workflowStep.run ?? "").not.toContain("${{ inputs.");
+    }
+  });
+
+  it("preserves the old deployment before activating only the exact version", () => {
+    const captureStep = activationStep("Capture pre-activation deployment");
+    const preserveStep = activationStep(
+      "Preserve pre-activation deployment metadata",
+    );
+    const activateStep = activationStep("Activate exact preview version");
+    const verifyStep = activationStep(
+      "Verify exact activation and private endpoints",
+    );
+
+    expect(captureStep.run).toContain("wrangler deployments list");
+    expect(preserveStep.uses).toBe(
+      "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
+    );
+    expect(activateStep.run).toContain(
+      'wrangler versions deploy "$VERSION_ID@100%"',
+    );
+    expect(activateStep.run).toContain("worker-subdomain-before-deploy.json");
+    expect(activateStep.run).toContain("workers-before-deploy.json");
+    expect(activateStep.run).toContain("worker-domains-before-deploy.json");
+    expect(activateStep.run).toContain(
+      "/workers/domains?service=$WORKER_NAME&per_page=100",
+    );
+    expect(activateStep.run).toContain('--name "$WORKER_NAME"');
+    expect(verifyStep.run).toContain("wrangler deployments list");
+    expect(verifyStep.run).toContain("max_by(.created_on) as $latest");
+    expect(verifyStep.run).toContain(
+      "$latest.versions[0].version_id == $version",
+    );
+    expect(verifyStep.run).toContain("$latest.versions[0].percentage == 100");
+    expect(verifyStep.run).toContain(
+      ".result.enabled == false and .result.previews_enabled == false",
+    );
+    expect(verifyStep.run).toContain("workers-after-activation.json");
+    expect(verifyStep.run).toContain("worker-domains-after-activation.json");
+    expect(activationWorkflowText).not.toContain(
+      "secrets.CLOUDFLARE_WORKERS_PRODUCTION_TOKEN",
+    );
+    expect(activationWorkflowText).not.toContain("wrangler routes");
+    expect(activationWorkflowText).not.toContain("wrangler dns");
+    expect(activationWorkflowText).not.toContain("wrangler pages");
+    expect(activationWorkflowText).not.toContain("wrangler delete");
+  });
+
+  it("accepts only the newest exact 100-percent deployment", () => {
+    const verifyStep = activationStep(
+      "Verify exact activation and private endpoints",
+    );
+    const filterMatch = verifyStep.run?.match(
+      /jq -e --arg version "\$VERSION_ID" '([\s\S]*?)'\s+"\$RUNNER_TEMP\/deployments-after\.json"/,
+    );
+    expect(
+      filterMatch,
+      "missing activation deployment jq program",
+    ).toBeTruthy();
+    const filter = filterMatch?.[1] ?? "";
+    const deployments = JSON.stringify([
+      {
+        created_on: "2026-07-26T10:00:00.000Z",
+        versions: [
+          {
+            percentage: 100,
+            version_id: "00000000-0000-0000-0000-000000000000",
+          },
+        ],
+      },
+      {
+        created_on: "2026-07-27T10:00:00.000Z",
+        versions: [
+          {
+            percentage: 100,
+            version_id: "11111111-1111-1111-1111-111111111111",
+          },
+        ],
+      },
+    ]);
+    expect(
+      execFileSync(
+        "jq",
+        [
+          "-e",
+          "--arg",
+          "version",
+          "11111111-1111-1111-1111-111111111111",
+          filter,
+        ],
+        { input: deployments },
+      ).toString(),
+    ).toBe("true\n");
+    expect(() =>
+      execFileSync(
+        "jq",
+        [
+          "-e",
+          "--arg",
+          "version",
+          "00000000-0000-0000-0000-000000000000",
+          filter,
+        ],
+        { input: deployments, stdio: ["pipe", "pipe", "pipe"] },
+      ),
+    ).toThrow();
+
+    for (const rejected of [
+      [],
+      [
+        {
+          created_on: "2026-07-27T10:00:00.000Z",
+          versions: [
+            {
+              percentage: 50,
+              version_id: "11111111-1111-1111-1111-111111111111",
+            },
+            {
+              percentage: 50,
+              version_id: "22222222-2222-2222-2222-222222222222",
+            },
+          ],
+        },
+      ],
+      [
+        {
+          created_on: "2026-07-27T10:00:00.000Z",
+          versions: [
+            {
+              percentage: 99,
+              version_id: "11111111-1111-1111-1111-111111111111",
+            },
+          ],
+        },
+      ],
+    ]) {
+      expect(() =>
+        execFileSync(
+          "jq",
+          [
+            "-e",
+            "--arg",
+            "version",
+            "11111111-1111-1111-1111-111111111111",
+            filter,
+          ],
+          {
+            input: JSON.stringify(rejected),
+            stdio: ["pipe", "pipe", "pipe"],
+          },
+        ),
+      ).toThrow();
     }
   });
 });


### PR DESCRIPTION
## Summary

Add two manual, trusted-`main` controls for the isolated preview Worker:

- upload one exact, reviewed PR artifact as an inactive Worker version;
- activate one exact reviewed version at 100 percent, without attaching a route.

These workflows do not touch production, Pages, DNS, Access, custom domains, or Worker routes. Running them is a later, separately approved action.

## Changes

### Inactive upload

- Verifies the successful PR CI run, repository, workflow path, branch, commit, current PR head, artifact checksum, and manifest.
- Re-checks the run and PR head at the upload boundary.
- Rejects unsafe archives and unexpected Worker configuration.
- Uses a fixed preview Worker name, preview-only secrets, pinned Wrangler, and disabled public preview endpoints.
- Proves the active deployment did not change during upload.

### Exact activation

- Verifies the exact version, provenance annotations, and required secret bindings.
- Saves the pre-activation deployment metadata.
- Re-checks that workers.dev, preview URLs, routes, and custom domains are absent immediately before activation.
- Activates only the supplied version and verifies the newest deployment is that sole version at 100 percent.
- Re-checks all public exposure controls after activation.

### Operator safety

- Adds a plain-English runbook with pause-and-verify points, ambiguous-failure handling, and rollback boundaries.
- Adds workflow contract tests, including executable jq fixtures for deployment selection and private Worker state.

## Reviewer focus

- Confirm no command can attach a route, mutate DNS/Pages/Access, or use the production Worker token.
- Confirm upload cannot alter the active deployment.
- Confirm activation checks the newest nested Cloudflare deployment version and repeats public-exposure checks around the mutation.
- Confirm the operator guide matches the workflow behavior.

## External environment gate

Completed and verified on July 27, 2026:

- the live GitHub `worker-preview` environment allows selected branches only;
- its only deployment branch policy is the exact branch `main`;
- no wildcard or additional branch policy exists.

This external setting prevents feature-branch workflows from requesting the
preview Worker credentials.

## Validation

- `actionlint` for all three preview Worker workflows
- `pnpm check`
- `pnpm check:tests`
- `pnpm check:surface`
- `pnpm check:alt`
- `pnpm lint`
- `pnpm test` (85 tests)
- `pnpm build`
- `pnpm smoke:dist`
- `pnpm check:islands` (4 browser checks)

`pnpm check:worker` is referenced in the repository guide but is not present in the current `package.json`, so it could not be run. No site runtime code changed.

## Preview and monitoring

There is no preview URL from this PR. Upload and activation remain undispatched, and the preview Worker remains unrouted.

For any later approved dispatch:

1. Check the preview Worker has no route, custom domain, workers.dev URL, or preview URL.
2. Check production, retained Pages, staging Access, and platform-service baselines.
3. Run only one approved mutation.
4. Re-check the same state immediately afterward.
5. If the run fails or any public endpoint appears, assume the mutation may have happened, stop, keep routes absent, and reconcile state read-only before another action.
