### PR TITLE
Add trusted Worker artifact workflow

### DIFF
--- a/.github/trusted/worker-artifact-workflow.yml
+++ b/.github/trusted/worker-artifact-workflow.yml
@@ -1,0 +1,119 @@
+name: Website CI and Worker Artifact
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  repo-check:
+    name: Repo checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.0
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.0
+        with:
+          version: 10
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Astro and TypeScript checks
+        run: pnpm check
+
+      - name: Type-check tests and smoke scripts
+        run: pnpm check:tests
+
+      - name: Check surface coverage
+        run: pnpm check:surface
+
+      - name: Check image alt-text coverage
+        run: pnpm check:alt
+
+      - name: Run Biome lint
+        run: pnpm lint
+
+      - name: Run unit tests
+        run: pnpm test
+
+      - name: Build site
+        run: pnpm build
+
+      - name: Smoke test built site output
+        run: pnpm smoke:dist
+
+      - name: Check production-format Worker runtime
+        run: pnpm check:worker
+
+      # The headless shell is roughly half the download of full Chromium. Note that
+      # `playwright` is deliberately NOT in pnpm.onlyBuiltDependencies, so the
+      # browser is fetched only here rather than on every pnpm install.
+      - name: Install Chromium for island hydration check
+        run: pnpm exec playwright install --with-deps chromium-headless-shell
+
+      # This runs last so failures in cheaper checks stop before the browser work.
+      - name: Check island hydration
+        run: pnpm check:islands
+
+      - name: Package the validated Worker artifact
+        shell: bash
+        env:
+          BUILD_COMMIT: ${{ github.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_ID: ${{ github.run_id }}
+          SOURCE_BRANCH: ${{ github.head_ref || github.ref_name }}
+          SOURCE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          tar -C dist -czf worker-dist.tar.gz .
+          sha256sum worker-dist.tar.gz > worker-dist.sha256
+          jq -n \
+            --arg artifact_sha256 "$(cut -d ' ' -f 1 worker-dist.sha256)" \
+            --arg build_commit "$BUILD_COMMIT" \
+            --arg event_name "$EVENT_NAME" \
+            --arg lockfile_sha256 "$(sha256sum pnpm-lock.yaml | cut -d ' ' -f 1)" \
+            --arg run_attempt "$RUN_ATTEMPT" \
+            --arg run_id "$RUN_ID" \
+            --arg source_branch "$SOURCE_BRANCH" \
+            --arg source_commit "$SOURCE_COMMIT" \
+            --slurpfile config wrangler.jsonc \
+            '{
+              artifact_sha256: $artifact_sha256,
+              build_commit: $build_commit,
+              compatibility_date: $config[0].compatibility_date,
+              compatibility_flags: $config[0].compatibility_flags,
+              event_name: $event_name,
+              lockfile_sha256: $lockfile_sha256,
+              required_secrets: $config[0].secrets.required,
+              run_attempt: $run_attempt,
+              run_id: $run_id,
+              source_branch: $source_branch,
+              source_commit: $source_commit
+            }' > worker-manifest.json
+
+      - name: Publish the validated Worker artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: worker-dist
+          path: |
+            worker-dist.tar.gz
+            worker-dist.sha256
+            worker-manifest.json
+            wrangler.jsonc
+          compression-level: 0
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/upload-worker-preview.yml
+++ b/.github/workflows/upload-worker-preview.yml
@@ -163,7 +163,7 @@ jobs:
           )"
           trusted_workflow_blob="$(
             gh api \
-              "repos/$GITHUB_REPOSITORY/contents/.github/trusted/worker-artifact-workflow.yml?ref=main" \
+              "repos/$GITHUB_REPOSITORY/contents/.github/trusted/worker-artifact-workflow.yml?ref=$GITHUB_SHA" \
               --jq .sha
           )"
           if [ "$source_workflow_blob" != "$trusted_workflow_blob" ]; then
@@ -361,7 +361,7 @@ jobs:
           )"
           trusted_workflow_blob="$(
             gh api \
-              "repos/$GITHUB_REPOSITORY/contents/.github/trusted/worker-artifact-workflow.yml?ref=main" \
+              "repos/$GITHUB_REPOSITORY/contents/.github/trusted/worker-artifact-workflow.yml?ref=$GITHUB_SHA" \
               --jq .sha
           )"
           if [ "$source_workflow_blob" != "$trusted_workflow_blob" ]; then

--- a/.github/workflows/upload-worker-preview.yml
+++ b/.github/workflows/upload-worker-preview.yml
@@ -124,6 +124,7 @@ jobs:
         shell: bash
         env:
           ARTIFACT_SHA256: ${{ inputs.artifact_sha256 }}
+          GH_TOKEN: ${{ github.token }}
           SOURCE_BRANCH: ${{ inputs.source_branch }}
           SOURCE_COMMIT: ${{ inputs.source_commit }}
           SOURCE_RUN_ID: ${{ inputs.source_run_id }}
@@ -147,6 +148,28 @@ jobs:
               (.required_secrets | sort) ==
                 (["SEGMENT_FORMS_WRITE_KEY", "TURNSTILE_SECRET_KEY"] | sort)
             ' worker-manifest.json > /dev/null
+          build_commit="$(
+            jq -er .merge_commit_sha "$RUNNER_TEMP/source-pr.json"
+          )"
+          [[ "$build_commit" =~ ^[0-9a-f]{40}$ ]]
+          jq -e \
+            --arg build_commit "$build_commit" '
+              .build_commit == $build_commit
+            ' worker-manifest.json > /dev/null
+          source_workflow_blob="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/contents/.github/workflows/deploy.yml?ref=$build_commit" \
+              --jq .sha
+          )"
+          trusted_workflow_blob="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/contents/.github/trusted/worker-artifact-workflow.yml?ref=main" \
+              --jq .sha
+          )"
+          if [ "$source_workflow_blob" != "$trusted_workflow_blob" ]; then
+            echo "Source run did not use the reviewed artifact workflow definition." >&2
+            exit 1
+          fi
 
       - name: Reject an unsafe Worker artifact
         shell: bash
@@ -307,6 +330,10 @@ jobs:
         run: |
           set -euo pipefail
           cd candidate
+          build_commit="$(
+            jq -er .merge_commit_sha "$RUNNER_TEMP/source-pr.json"
+          )"
+          [[ "$build_commit" =~ ^[0-9a-f]{40}$ ]]
 
           # Close the time-of-check gap before the privileged upload. A push to
           # the PR after the first check must invalidate this dispatch.
@@ -327,18 +354,20 @@ jobs:
               .head_sha == $commit and
               any(.pull_requests[]?; .number == $pr)
             ' "$RUNNER_TEMP/source-run-before-upload.json" > /dev/null
-          gh api \
-            "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
-            > "$RUNNER_TEMP/source-pr-before-upload.json"
-          jq -e \
-            --arg branch "$SOURCE_BRANCH" \
-            --arg commit "$SOURCE_COMMIT" \
-            --arg repository "$GITHUB_REPOSITORY" '
-              .state == "open" and
-              .head.repo.full_name == $repository and
-              .head.ref == $branch and
-              .head.sha == $commit
-            ' "$RUNNER_TEMP/source-pr-before-upload.json" > /dev/null
+          source_workflow_blob="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/contents/.github/workflows/deploy.yml?ref=$build_commit" \
+              --jq .sha
+          )"
+          trusted_workflow_blob="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/contents/.github/trusted/worker-artifact-workflow.yml?ref=main" \
+              --jq .sha
+          )"
+          if [ "$source_workflow_blob" != "$trusted_workflow_blob" ]; then
+            echo "Source run no longer matches the reviewed artifact workflow definition." >&2
+            exit 1
+          fi
 
           secrets_file="$RUNNER_TEMP/worker-preview-secrets.env"
           output_file="$RUNNER_TEMP/wrangler-preview-output.jsonl"
@@ -351,6 +380,22 @@ jobs:
           export WRANGLER_OUTPUT_FILE_PATH="$output_file"
           artifact_sha256="$(jq -r .artifact_sha256 worker-manifest.json)"
           version_message="source_commit=$SOURCE_COMMIT source_branch=$SOURCE_BRANCH source_run_id=$SOURCE_RUN_ID artifact_sha256=$artifact_sha256"
+
+          gh api \
+            "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
+            > "$RUNNER_TEMP/source-pr-before-upload.json"
+          jq -e \
+            --arg branch "$SOURCE_BRANCH" \
+            --arg build_commit "$build_commit" \
+            --arg commit "$SOURCE_COMMIT" \
+            --arg repository "$GITHUB_REPOSITORY" '
+              .state == "open" and
+              .head.repo.full_name == $repository and
+              .head.ref == $branch and
+              .head.sha == $commit and
+              .merge_commit_sha == $build_commit
+            ' "$RUNNER_TEMP/source-pr-before-upload.json" > /dev/null
+
           wrangler versions upload \
             --config upload-wrangler.json \
             --secrets-file "$secrets_file" \

--- a/tests/config/workerPreviewControlPlane.test.ts
+++ b/tests/config/workerPreviewControlPlane.test.ts
@@ -287,6 +287,9 @@ function expectReviewedArtifactWorkflowGuard(run: string | undefined): void {
     "contents/.github/workflows/deploy.yml?ref=$build_commit",
   );
   expect(run).toContain(
+    "contents/.github/trusted/worker-artifact-workflow.yml?ref=$GITHUB_SHA",
+  );
+  expect(run).not.toContain(
     "contents/.github/trusted/worker-artifact-workflow.yml?ref=main",
   );
   expect(run).toContain(
@@ -474,7 +477,7 @@ describe("preview Worker upload workflow", () => {
     expectReviewedArtifactWorkflowGuard(uploadVersionStep.run);
     const trustedWorkflowIndex =
       uploadVersionStep.run?.indexOf(
-        "contents/.github/trusted/worker-artifact-workflow.yml?ref=main",
+        "contents/.github/trusted/worker-artifact-workflow.yml?ref=$GITHUB_SHA",
       ) ?? -1;
     const prHeadRecheckIndex =
       uploadVersionStep.run?.indexOf(

--- a/tests/config/workerPreviewControlPlane.test.ts
+++ b/tests/config/workerPreviewControlPlane.test.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
@@ -265,6 +266,10 @@ const uploadWorkflowText = readFileSync(
   ".github/workflows/upload-worker-preview.yml",
   "utf8",
 );
+const trustedArtifactWorkflowText = readFileSync(
+  ".github/trusted/worker-artifact-workflow.yml",
+  "utf8",
+);
 const uploadWorkflow = parse(uploadWorkflowText) as ManualPreviewWorkflow;
 const uploadJob = uploadWorkflow.jobs.upload;
 const uploadSteps = Object.fromEntries(
@@ -275,6 +280,18 @@ function uploadStep(name: string): WorkflowStep {
   const workflowStep = uploadSteps[name];
   expect(workflowStep, `missing upload workflow step: ${name}`).toBeDefined();
   return workflowStep;
+}
+
+function expectReviewedArtifactWorkflowGuard(run: string | undefined): void {
+  expect(run).toContain(
+    "contents/.github/workflows/deploy.yml?ref=$build_commit",
+  );
+  expect(run).toContain(
+    "contents/.github/trusted/worker-artifact-workflow.yml?ref=main",
+  );
+  expect(run).toContain(
+    'if [ "$source_workflow_blob" != "$trusted_workflow_blob" ]; then',
+  );
 }
 
 describe("preview Worker upload workflow", () => {
@@ -344,6 +361,30 @@ describe("preview Worker upload workflow", () => {
     }
   });
 
+  it("pins the reviewed artifact producer without enabling it on main", () => {
+    // PR #171 at ef4597c209795f2145d7722aff617d64b1a6d213.
+    const gitBlobSha = createHash("sha1")
+      .update(
+        `blob ${Buffer.byteLength(trustedArtifactWorkflowText)}\0${trustedArtifactWorkflowText}`,
+      )
+      .digest("hex");
+
+    expect(gitBlobSha).toBe("e312055b4e72f7142b7ac4e854f0577df08411d4");
+    expect(trustedArtifactWorkflowText).toContain(
+      "name: Website CI and Worker Artifact",
+    );
+    expect(trustedArtifactWorkflowText).toContain(
+      "Package the validated Worker artifact",
+    );
+    expect(trustedArtifactWorkflowText).toContain(
+      "Publish the validated Worker artifact",
+    );
+    expect(trustedArtifactWorkflowText).not.toContain(
+      "cloudflare/wrangler-action@",
+    );
+    expect(trustedArtifactWorkflowText).not.toContain("CLOUDFLARE_API_TOKEN");
+  });
+
   it("downloads and verifies only the named run artifact", () => {
     const downloadStep = uploadStep("Download the exact CI artifact");
     const provenanceStep = uploadStep(
@@ -369,6 +410,11 @@ describe("preview Worker upload workflow", () => {
     expect(provenanceStep.run).toContain(".source_branch == $branch");
     expect(provenanceStep.run).toContain(".source_commit == $commit");
     expect(provenanceStep.run).toContain(".run_id == $run_id");
+    expect(provenanceStep.run).toContain(
+      'jq -er .merge_commit_sha "$RUNNER_TEMP/source-pr.json"',
+    );
+    expect(provenanceStep.run).toContain(".build_commit == $build_commit");
+    expectReviewedArtifactWorkflowGuard(provenanceStep.run);
     expect(safetyStep.run).toContain("tar -tzf worker-dist.tar.gz");
     expect(safetyStep.run).toContain("tar -tvzf worker-dist.tar.gz");
     expect(safetyStep.run).toContain(
@@ -422,6 +468,23 @@ describe("preview Worker upload workflow", () => {
     expect(uploadVersionStep.run).toContain("source-run-before-upload.json");
     expect(uploadVersionStep.run).toContain("source-pr-before-upload.json");
     expect(uploadVersionStep.run).toContain(".head.sha == $commit");
+    expect(uploadVersionStep.run).toContain(
+      ".merge_commit_sha == $build_commit",
+    );
+    expectReviewedArtifactWorkflowGuard(uploadVersionStep.run);
+    const trustedWorkflowIndex =
+      uploadVersionStep.run?.indexOf(
+        "contents/.github/trusted/worker-artifact-workflow.yml?ref=main",
+      ) ?? -1;
+    const prHeadRecheckIndex =
+      uploadVersionStep.run?.indexOf(
+        "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER",
+      ) ?? -1;
+    const uploadIndex =
+      uploadVersionStep.run?.indexOf("wrangler versions upload") ?? -1;
+    expect(trustedWorkflowIndex).toBeGreaterThan(-1);
+    expect(prHeadRecheckIndex).toBeGreaterThan(trustedWorkflowIndex);
+    expect(uploadIndex).toBeGreaterThan(prHeadRecheckIndex);
     expect(uploadVersionStep.run).toContain("--secrets-file");
     expect(uploadVersionStep.run).not.toContain("--preview-alias");
     expect(uploadWorkflowText).not.toContain("--preview-alias");


### PR DESCRIPTION
## Summary

PR #171 produced a valid Worker artifact, but the manual preview uploader could not prove that its artifact-producing workflow matched a definition already trusted on `main`. This establishes that trust without enabling the new deployment workflow: the reviewed definition is stored outside GitHub's executable workflow directory, and upload remains manual, inactive, private, and route-less.

## Changes

- Pin the reviewed PR #171 artifact producer as an inert Git blob on `main`.
- Bind the artifact's build commit to GitHub's current synthetic PR merge commit, then require the executed workflow blob to match the trusted blob exactly.
- Repeat the run, workflow, PR head, and merge-commit checks immediately before upload so a changed PR fails closed.
- Cover the exact trusted blob, both comparison gates, and final-check ordering with regression tests.

## What reviewers should focus on

- Whether `.github/trusted/worker-artifact-workflow.yml` is clearly inert while remaining byte-identical to PR #171's artifact producer.
- Whether the GitHub-supplied merge commit and repeated blob/head checks provide the intended trust and race boundaries.

Related: #171

## Validation

- `pnpm check:tests`
- `pnpm lint`
- `pnpm test` — 86 tests passed
- `actionlint .github/workflows/upload-worker-preview.yml .github/trusted/worker-artifact-workflow.yml`
- Read-only live check confirmed that PR #171's artifact build commit equals its current GitHub merge commit, and that the executed and trusted workflow Git blobs both equal `e312055b4e72f7142b7ac4e854f0577df08411d4`.
- Correctness, reliability, and test-fidelity review passes completed with no remaining finding in this inactive-upload scope.

## Post-Deploy Monitoring & Validation

No automatic production or runtime monitoring is required because merging this PR does not dispatch an upload, activate a Worker, change a route, alter DNS, or move traffic.

At merge and before the later inactive-upload checkpoint, the merge operator should confirm `Repo checks` is green and re-run the read-only PR head, merge-commit, artifact digest, and workflow-blob comparisons. Any mismatch is a stop signal: do not dispatch the uploader, and revert or correct the trust reference before proceeding.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
