### PR TITLE
Allow exact main artifacts in preview uploads

### DIFF
--- a/.github/workflows/upload-worker-preview.yml
+++ b/.github/workflows/upload-worker-preview.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: Pull request that produced the reviewed artifact
-        required: true
+        description: Pull request number; leave empty only for an exact current-main push artifact
+        required: false
         type: string
       source_run_id:
         description: Successful Website CI and Worker Artifact run ID
@@ -36,6 +36,26 @@ permissions: {}
 
 env:
   WORKER_NAME: zenml-io-v2-worker-preview
+  SOURCE_RUN_PREDICATE: |
+    .conclusion == "success" and
+    .path == $path and
+    .head_repository.full_name == $repository and
+    .head_branch == $branch and
+    .head_sha == $commit and
+    (
+      (
+        .event == "pull_request" and
+        ($pr | test("^[0-9]+$")) and
+        any(.pull_requests[]?; (.number | tostring) == $pr)
+      ) or
+      (
+        .event == "push" and
+        $pr == "" and
+        $branch == "main" and
+        $commit == $trusted_commit and
+        $commit == $live_main_commit
+      )
+    )
 
 jobs:
   upload:
@@ -65,13 +85,13 @@ jobs:
           SOURCE_RUN_ID: ${{ inputs.source_run_id }}
         run: |
           set -euo pipefail
-          [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]
+          [[ -z "$PR_NUMBER" || "$PR_NUMBER" =~ ^[0-9]+$ ]]
           [[ "$SOURCE_RUN_ID" =~ ^[0-9]+$ ]]
           git check-ref-format --branch "$SOURCE_BRANCH" > /dev/null
           [[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
           [[ "$ARTIFACT_SHA256" =~ ^[0-9a-f]{64}$ ]]
 
-      - name: Verify the exact source run and PR head
+      - name: Verify the exact source run and source state
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -84,33 +104,48 @@ jobs:
           gh api \
             "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID" \
             > "$RUNNER_TEMP/source-run.json"
+          live_main_commit=""
+          if [ -z "$PR_NUMBER" ]; then
+            live_main_commit="$(
+              gh api \
+                "repos/$GITHUB_REPOSITORY/git/ref/heads/main" \
+                --jq .object.sha
+            )"
+          fi
           jq -e \
             --arg branch "$SOURCE_BRANCH" \
             --arg commit "$SOURCE_COMMIT" \
+            --arg live_main_commit "$live_main_commit" \
             --arg path ".github/workflows/deploy.yml" \
+            --arg pr "$PR_NUMBER" \
             --arg repository "$GITHUB_REPOSITORY" \
-            --argjson pr "$PR_NUMBER" '
-              .conclusion == "success" and
-              .event == "pull_request" and
-              .path == $path and
-              .head_repository.full_name == $repository and
-              .head_branch == $branch and
-              .head_sha == $commit and
-              any(.pull_requests[]?; .number == $pr)
-            ' "$RUNNER_TEMP/source-run.json" > /dev/null
+            --arg trusted_commit "$GITHUB_SHA" \
+            "$SOURCE_RUN_PREDICATE" \
+            "$RUNNER_TEMP/source-run.json" > /dev/null
 
-          gh api \
-            "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
-            > "$RUNNER_TEMP/source-pr.json"
-          jq -e \
-            --arg branch "$SOURCE_BRANCH" \
-            --arg commit "$SOURCE_COMMIT" \
-            --arg repository "$GITHUB_REPOSITORY" '
-              .state == "open" and
-              .head.repo.full_name == $repository and
-              .head.ref == $branch and
-              .head.sha == $commit
-            ' "$RUNNER_TEMP/source-pr.json" > /dev/null
+          source_event="$(jq -er .event "$RUNNER_TEMP/source-run.json")"
+          if [ "$source_event" = "pull_request" ]; then
+            gh api \
+              "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
+              > "$RUNNER_TEMP/source-pr.json"
+            jq -e \
+              --arg branch "$SOURCE_BRANCH" \
+              --arg commit "$SOURCE_COMMIT" \
+              --arg repository "$GITHUB_REPOSITORY" '
+                .state == "open" and
+                .head.repo.full_name == $repository and
+                .head.ref == $branch and
+                .head.sha == $commit
+              ' "$RUNNER_TEMP/source-pr.json" > /dev/null
+            build_commit="$(
+              jq -er .merge_commit_sha "$RUNNER_TEMP/source-pr.json"
+            )"
+          else
+            build_commit="$SOURCE_COMMIT"
+          fi
+          [[ "$build_commit" =~ ^[0-9a-f]{40}$ ]]
+          printf '%s\n' "$source_event" > "$RUNNER_TEMP/source-event"
+          printf '%s\n' "$build_commit" > "$RUNNER_TEMP/build-commit"
 
       - name: Download the exact CI artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -135,12 +170,15 @@ jobs:
             > "$RUNNER_TEMP/expected-worker-dist.sha256"
           sha256sum --check "$RUNNER_TEMP/expected-worker-dist.sha256"
           sha256sum --check worker-dist.sha256
+          source_event="$(< "$RUNNER_TEMP/source-event")"
+          build_commit="$(< "$RUNNER_TEMP/build-commit")"
           jq -e \
             --arg artifact_sha256 "$ARTIFACT_SHA256" \
             --arg branch "$SOURCE_BRANCH" \
             --arg commit "$SOURCE_COMMIT" \
-            --arg run_id "$SOURCE_RUN_ID" '
-              .event_name == "pull_request" and
+            --arg run_id "$SOURCE_RUN_ID" \
+            --arg source_event "$source_event" '
+              .event_name == $source_event and
               .artifact_sha256 == $artifact_sha256 and
               .source_branch == $branch and
               .source_commit == $commit and
@@ -148,9 +186,6 @@ jobs:
               (.required_secrets | sort) ==
                 (["SEGMENT_FORMS_WRITE_KEY", "TURNSTILE_SECRET_KEY"] | sort)
             ' worker-manifest.json > /dev/null
-          build_commit="$(
-            jq -er .merge_commit_sha "$RUNNER_TEMP/source-pr.json"
-          )"
           [[ "$build_commit" =~ ^[0-9a-f]{40}$ ]]
           jq -e \
             --arg build_commit "$build_commit" '
@@ -330,30 +365,33 @@ jobs:
         run: |
           set -euo pipefail
           cd candidate
-          build_commit="$(
-            jq -er .merge_commit_sha "$RUNNER_TEMP/source-pr.json"
-          )"
+          source_event="$(< "$RUNNER_TEMP/source-event")"
+          build_commit="$(< "$RUNNER_TEMP/build-commit")"
           [[ "$build_commit" =~ ^[0-9a-f]{40}$ ]]
 
-          # Close the time-of-check gap before the privileged upload. A push to
-          # the PR after the first check must invalidate this dispatch.
+          # Close the time-of-check gap before the privileged upload. A changed
+          # PR head or a main artifact from any other commit must fail here.
           gh api \
             "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID" \
             > "$RUNNER_TEMP/source-run-before-upload.json"
+          live_main_commit=""
+          if [ "$source_event" = "push" ]; then
+            live_main_commit="$(
+              gh api \
+                "repos/$GITHUB_REPOSITORY/git/ref/heads/main" \
+                --jq .object.sha
+            )"
+          fi
           jq -e \
             --arg branch "$SOURCE_BRANCH" \
             --arg commit "$SOURCE_COMMIT" \
+            --arg live_main_commit "$live_main_commit" \
             --arg path ".github/workflows/deploy.yml" \
+            --arg pr "$PR_NUMBER" \
             --arg repository "$GITHUB_REPOSITORY" \
-            --argjson pr "$PR_NUMBER" '
-              .conclusion == "success" and
-              .event == "pull_request" and
-              .path == $path and
-              .head_repository.full_name == $repository and
-              .head_branch == $branch and
-              .head_sha == $commit and
-              any(.pull_requests[]?; .number == $pr)
-            ' "$RUNNER_TEMP/source-run-before-upload.json" > /dev/null
+            --arg trusted_commit "$GITHUB_SHA" \
+            "$SOURCE_RUN_PREDICATE" \
+            "$RUNNER_TEMP/source-run-before-upload.json" > /dev/null
           source_workflow_blob="$(
             gh api \
               "repos/$GITHUB_REPOSITORY/contents/.github/workflows/deploy.yml?ref=$build_commit" \
@@ -381,20 +419,32 @@ jobs:
           artifact_sha256="$(jq -r .artifact_sha256 worker-manifest.json)"
           version_message="source_commit=$SOURCE_COMMIT source_branch=$SOURCE_BRANCH source_run_id=$SOURCE_RUN_ID artifact_sha256=$artifact_sha256"
 
-          gh api \
-            "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
-            > "$RUNNER_TEMP/source-pr-before-upload.json"
-          jq -e \
-            --arg branch "$SOURCE_BRANCH" \
-            --arg build_commit "$build_commit" \
-            --arg commit "$SOURCE_COMMIT" \
-            --arg repository "$GITHUB_REPOSITORY" '
-              .state == "open" and
-              .head.repo.full_name == $repository and
-              .head.ref == $branch and
-              .head.sha == $commit and
-              .merge_commit_sha == $build_commit
-            ' "$RUNNER_TEMP/source-pr-before-upload.json" > /dev/null
+          if [ "$source_event" = "pull_request" ]; then
+            gh api \
+              "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
+              > "$RUNNER_TEMP/source-pr-before-upload.json"
+            jq -e \
+              --arg branch "$SOURCE_BRANCH" \
+              --arg build_commit "$build_commit" \
+              --arg commit "$SOURCE_COMMIT" \
+              --arg repository "$GITHUB_REPOSITORY" '
+                .state == "open" and
+                .head.repo.full_name == $repository and
+                .head.ref == $branch and
+                .head.sha == $commit and
+                .merge_commit_sha == $build_commit
+              ' "$RUNNER_TEMP/source-pr-before-upload.json" > /dev/null
+          fi
+
+          if [ "$source_event" = "push" ]; then
+            live_main_commit="$(
+              gh api \
+                "repos/$GITHUB_REPOSITORY/git/ref/heads/main" \
+                --jq .object.sha
+            )"
+            [[ "$live_main_commit" == "$SOURCE_COMMIT" ]]
+            [[ "$live_main_commit" == "$GITHUB_SHA" ]]
+          fi
 
           wrangler versions upload \
             --config upload-wrangler.json \
@@ -481,6 +531,8 @@ jobs:
             ${{ runner.temp }}/deployments-after-upload.json
             ${{ runner.temp }}/worker-subdomain.json
             ${{ runner.temp }}/worker-subdomain-after-upload.json
+            ${{ runner.temp }}/source-event
+            ${{ runner.temp }}/build-commit
             ${{ runner.temp }}/source-run.json
             ${{ runner.temp }}/source-pr.json
             ${{ runner.temp }}/source-run-before-upload.json
@@ -498,12 +550,16 @@ jobs:
           SOURCE_RUN_ID: ${{ inputs.source_run_id }}
           VERSION_ID: ${{ steps.upload.outputs.version_id }}
         run: |
+          source_event="$(< "$RUNNER_TEMP/source-event")"
+          build_commit="$(< "$RUNNER_TEMP/build-commit")"
           {
             echo "## Inactive preview Worker version"
             echo
             printf -- "- Worker: \`%s\`\n" "$WORKER_NAME"
             printf -- "- Version: \`%s\`\n" "$VERSION_ID"
+            printf -- "- Source event: \`%s\`\n" "$source_event"
             printf -- "- Source commit: \`%s\`\n" "$SOURCE_COMMIT"
+            printf -- "- Build commit: \`%s\`\n" "$build_commit"
             printf -- "- Source branch: \`%s\`\n" "$SOURCE_BRANCH"
             printf -- "- CI run: \`%s\`\n" "$SOURCE_RUN_ID"
             printf -- "- Artifact SHA-256: \`%s\`\n" "$ARTIFACT_SHA256"

--- a/docs/worker-preview-control-plane.md
+++ b/docs/worker-preview-control-plane.md
@@ -49,29 +49,38 @@ mutation and requires its own approval.
 
 After the upload and activation workflows exist on `main`:
 
-1. Reconcile the Astro 5 migration PR with current `main`.
-2. Keep both the trusted manual
+1. Choose one eligible source:
+   - an open same-repository pull request at its exact current head; or
+   - the successful `push` CI run for the exact current `main` commit.
+2. For a pull request, reconcile the Astro 5 migration PR with current `main`.
+3. Keep both the trusted manual
    `.github/workflows/upload-worker-preview.yml` and the reviewed producer
    snapshot `.github/trusted/worker-artifact-workflow.yml` during conflict
    resolution. The snapshot must remain byte-identical to
    `.github/workflows/deploy.yml`.
    Do not restore the feature branch's older automatic `workflow_run`
    uploader.
-3. Run the complete PR CI workflow.
-4. Download its `worker-dist` artifact.
-5. Record:
-   - pull request number;
+4. Run the complete CI workflow for the chosen source.
+5. Download its `worker-dist` artifact.
+6. Record:
+   - pull request number for a pull-request artifact, or leave it empty for an
+     exact current-`main` artifact;
    - source run ID;
    - source branch;
    - source commit;
-   - tested merge commit from the artifact manifest and current pull request;
+   - tested merge commit from the artifact manifest and current pull request,
+     or the exact current `main` commit for a `main` artifact;
    - `worker-dist.tar.gz` SHA-256 from both the checksum file and an
      independent computation;
    - manifest source branch, commit, run ID, and required binding names.
-6. Confirm the PR head, CI run, checksum, and manifest all agree. The current
-   pull request `merge_commit_sha` must still equal the manifest
-   `build_commit`. Any later merge to `main` recomputes that test merge and
-   invalidates the artifact, so rerun CI and record the new values.
+7. Confirm the source state, CI run, checksum, and manifest all agree:
+   - For a pull request, its current `merge_commit_sha` must equal the manifest
+     `build_commit`. A later merge to `main` recomputes that test merge and
+     invalidates the artifact.
+   - For `main`, the source branch must be exactly `main`, and the source commit,
+     manifest build commit, and trusted uploader dispatch commit must all be
+     identical to the live `main` tip. A later `main` commit invalidates the
+     earlier artifact.
 
 Any earlier artifact becomes historical evidence only. Do not upload it.
 
@@ -79,8 +88,10 @@ Any earlier artifact becomes historical evidence only. Do not upload it.
 
 Pause and capture a timestamped read-only snapshot:
 
-1. The candidate PR head and successful CI run still match the recorded
-   identifiers.
+1. The chosen source and successful CI run still match the recorded
+   identifiers. For a pull request, recheck its open head and tested merge
+   commit. For `main`, recheck that the artifact commit is still the exact
+   trusted uploader dispatch commit and live `main` tip.
 2. The preview Worker exists.
 3. Its `workers.dev` endpoint and version preview URLs are disabled.
 4. It has no custom domain and no Worker route.
@@ -99,18 +110,21 @@ action.
 Open **Actions → Upload Exact Preview Worker Version → Run workflow** and
 select `main`.
 
-Enter the six recorded values:
+Enter the recorded values:
 
-- PR number;
+- PR number for a pull-request artifact, or leave it empty for an exact
+  current-`main` artifact;
 - source run ID;
 - source branch;
 - source commit;
 - artifact SHA-256;
 - explicit self-review confirmation.
 
-The workflow re-reads the run and pull request from GitHub, downloads only that
-run's artifact, verifies that its tested merge commit used the immutable
-reviewed artifact workflow,
+The workflow re-reads the run and, when applicable, the pull request from
+GitHub. It downloads only that run's artifact and verifies that its tested
+build commit used the immutable reviewed artifact workflow. A `main` artifact
+is accepted only when its branch and commit exactly match the trusted uploader
+dispatch commit and the live `main` tip. It then
 checks its checksum and manifest, rejects unsafe archive or Wrangler
 configuration, confirms the preview Worker is private and route-less, and
 uploads one inactive version with the two non-production form secrets.

--- a/docs/worker-release-runbook.md
+++ b/docs/worker-release-runbook.md
@@ -12,8 +12,9 @@ U3 has four separate actions:
 1. `Website CI and Worker Artifact` builds once without credentials, validates
    that output, and publishes the exact archive plus checksum and provenance.
 2. `Upload Exact Preview Worker Version` is manually dispatched from `main`
-   after explicit review. It consumes one successful same-repository PR
-   artifact and uploads an inactive, unreachable version to
+   after explicit review. It consumes either one successful same-repository PR
+   artifact or the successful `push` artifact for the exact current `main`
+   commit, then uploads an inactive, unreachable version to
    `zenml-io-v2-worker-preview`.
 3. `Upload Worker Production Candidate` is manually dispatched from `main` with
    an exact successful CI run, branch, and commit. It uploads an inactive
@@ -107,11 +108,18 @@ checkpoint, where the plan expects the supported Astro preview path.
 
 Before dispatching `Upload Exact Preview Worker Version`, compare and enter:
 
-- source PR number;
-- exact source branch and current PR-head commit;
+- source PR number for an open same-repository PR artifact, or leave it empty
+  only for an exact current-`main` push artifact;
+- exact source branch and commit;
 - successful source CI run ID;
 - artifact SHA-256 from that exact run;
 - explicit self-review confirmation.
+
+For a PR artifact, the workflow requires the PR to remain open at the recorded
+head and tested merge commit. For a `main` artifact, the source branch must be
+exactly `main`, and the source commit, manifest build commit, trusted uploader
+dispatch commit, and live `main` tip must all remain identical. A later merge
+to `main` invalidates the earlier artifact.
 
 After it succeeds, record:
 

--- a/tests/config/deploymentWorkflows.test.ts
+++ b/tests/config/deploymentWorkflows.test.ts
@@ -266,7 +266,7 @@ describe("credential-free Worker artifact workflow", () => {
 });
 
 describe("trusted Worker preview uploader", () => {
-  it("requires an explicit trusted-main dispatch for an exact PR artifact", () => {
+  it("requires an explicit trusted-main dispatch for an exact eligible artifact", () => {
     expect(previewWorkflow).toContain("workflow_dispatch:");
     expect(previewWorkflow).not.toContain("workflow_run:");
     expect(previewWorkflow).not.toContain("pull_request:");
@@ -280,6 +280,7 @@ describe("trusted Worker preview uploader", () => {
     expect(previewWorkflow).toContain("inputs.self_reviewed");
     expect(previewWorkflow).toContain("actions/download-artifact@");
     expect(previewWorkflow).toContain(".head.sha == $commit");
+    expect(previewWorkflow).toContain("$commit == $trusted_commit");
     expect(previewWorkflow).toContain("cancel-in-progress: false");
   });
 

--- a/tests/config/workerPreviewControlPlane.test.ts
+++ b/tests/config/workerPreviewControlPlane.test.ts
@@ -49,6 +49,7 @@ interface ManualPreviewWorkflow {
     group: string;
   };
   env: {
+    SOURCE_RUN_PREDICATE: string;
     WORKER_NAME: string;
   };
   jobs: Record<
@@ -320,6 +321,10 @@ describe("preview Worker upload workflow", () => {
       required: true,
       type: "boolean",
     });
+    expect(uploadWorkflow.on.workflow_dispatch.inputs.pr_number).toMatchObject({
+      required: false,
+      type: "string",
+    });
     expect(uploadWorkflow.permissions).toEqual({});
     expect(uploadJob.if).toBe("github.ref == 'refs/heads/main'");
     expect(uploadJob.environment).toBe("worker-preview");
@@ -335,11 +340,15 @@ describe("preview Worker upload workflow", () => {
     });
   });
 
-  it("validates the exact same-repository PR run and current head", () => {
+  it("validates an exact same-repository PR or current-main run", () => {
     const validationStep = uploadStep("Validate dispatch identifiers");
-    const sourceStep = uploadStep("Verify the exact source run and PR head");
+    const sourceStep = uploadStep(
+      "Verify the exact source run and source state",
+    );
 
-    expect(validationStep.run).toContain('[[ "$PR_NUMBER" =~ ^[0-9]+$ ]]');
+    expect(validationStep.run).toContain(
+      '[[ -z "$PR_NUMBER" || "$PR_NUMBER" =~ ^[0-9]+$ ]]',
+    );
     expect(validationStep.run).toContain('[[ "$SOURCE_RUN_ID" =~ ^[0-9]+$ ]]');
     expect(validationStep.run).toContain(
       '[[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]',
@@ -353,12 +362,28 @@ describe("preview Worker upload workflow", () => {
     expect(sourceStep.run).toContain(
       "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID",
     );
+    expect(sourceStep.run).toContain('"$SOURCE_RUN_PREDICATE"');
     expect(sourceStep.run).toContain(
       '--arg path ".github/workflows/deploy.yml"',
     );
-    expect(sourceStep.run).toContain(".path == $path");
-    expect(sourceStep.run).toContain(
+    expect(uploadWorkflow.env.SOURCE_RUN_PREDICATE).toContain(".path == $path");
+    expect(uploadWorkflow.env.SOURCE_RUN_PREDICATE).toContain(
       ".head_repository.full_name == $repository",
+    );
+    expect(uploadWorkflow.env.SOURCE_RUN_PREDICATE).toContain(
+      '$branch == "main"',
+    );
+    expect(uploadWorkflow.env.SOURCE_RUN_PREDICATE).toContain(
+      "$commit == $trusted_commit",
+    );
+    expect(uploadWorkflow.env.SOURCE_RUN_PREDICATE).toContain(
+      "$commit == $live_main_commit",
+    );
+    expect(uploadWorkflow.env.SOURCE_RUN_PREDICATE).toContain(
+      '.event == "push"',
+    );
+    expect(uploadWorkflow.env.SOURCE_RUN_PREDICATE).toContain(
+      '.event == "pull_request"',
     );
     expect(sourceStep.run).toContain(
       "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER",
@@ -423,7 +448,11 @@ describe("preview Worker upload workflow", () => {
     expect(provenanceStep.run).toContain(".source_commit == $commit");
     expect(provenanceStep.run).toContain(".run_id == $run_id");
     expect(provenanceStep.run).toContain(
-      'jq -er .merge_commit_sha "$RUNNER_TEMP/source-pr.json"',
+      'source_event="$(< "$RUNNER_TEMP/source-event")"',
+    );
+    expect(provenanceStep.run).toContain(".event_name == $source_event");
+    expect(provenanceStep.run).toContain(
+      'build_commit="$(< "$RUNNER_TEMP/build-commit")"',
     );
     expect(provenanceStep.run).toContain(".build_commit == $build_commit");
     expectReviewedArtifactWorkflowGuard(provenanceStep.run);
@@ -484,7 +513,7 @@ describe("preview Worker upload workflow", () => {
       ".merge_commit_sha == $build_commit",
     );
     expect(uploadVersionStep.run).toContain(
-      'jq -er .merge_commit_sha "$RUNNER_TEMP/source-pr.json"',
+      'build_commit="$(< "$RUNNER_TEMP/build-commit")"',
     );
     expect(uploadVersionStep.run).not.toContain(
       'jq -er .merge_commit_sha "$RUNNER_TEMP/source-pr-before-upload.json"',
@@ -498,10 +527,16 @@ describe("preview Worker upload workflow", () => {
       uploadVersionStep.run?.indexOf(
         "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER",
       ) ?? -1;
+    const liveMainRecheckIndex =
+      uploadVersionStep.run?.lastIndexOf(
+        "repos/$GITHUB_REPOSITORY/git/ref/heads/main",
+      ) ?? -1;
     const uploadIndex =
       uploadVersionStep.run?.indexOf("wrangler versions upload") ?? -1;
     expect(trustedWorkflowIndex).toBeGreaterThan(-1);
     expect(prHeadRecheckIndex).toBeGreaterThan(trustedWorkflowIndex);
+    expect(liveMainRecheckIndex).toBeGreaterThan(prHeadRecheckIndex);
+    expect(uploadIndex).toBeGreaterThan(liveMainRecheckIndex);
     expect(uploadIndex).toBeGreaterThan(prHeadRecheckIndex);
     expect(uploadVersionStep.run).toContain("--secrets-file");
     expect(uploadVersionStep.run).not.toContain("--preview-alias");
@@ -538,6 +573,145 @@ describe("preview Worker upload workflow", () => {
     });
     expect(String(preserveStep.with?.path)).toContain(
       "candidate/upload-result.json",
+    );
+  });
+
+  it("accepts only exact open-PR or current-main source runs", () => {
+    const sourceStep = uploadStep(
+      "Verify the exact source run and source state",
+    );
+    const uploadVersionStep = uploadStep("Upload one inactive preview version");
+    const program = uploadWorkflow.env.SOURCE_RUN_PREDICATE;
+    expect(sourceStep.run).toContain('"$SOURCE_RUN_PREDICATE"');
+    expect(uploadVersionStep.run).toContain('"$SOURCE_RUN_PREDICATE"');
+    const repository = "zenml-io/zenml-io-v2";
+    const prCommit = "a".repeat(40);
+    const mainCommit = "b".repeat(40);
+    const commonArgs = [
+      "--arg",
+      "path",
+      ".github/workflows/deploy.yml",
+      "--arg",
+      "repository",
+      repository,
+    ];
+    const sourceRunArgs = (
+      branch: string,
+      commit: string,
+      pr: string,
+      trustedCommit = mainCommit,
+      liveMainCommit = mainCommit,
+    ) => [
+      ...commonArgs,
+      "--arg",
+      "branch",
+      branch,
+      "--arg",
+      "commit",
+      commit,
+      "--arg",
+      "live_main_commit",
+      liveMainCommit,
+      "--arg",
+      "pr",
+      pr,
+      "--arg",
+      "trusted_commit",
+      trustedCommit,
+    ];
+    const pullRequestRun = {
+      conclusion: "success",
+      event: "pull_request",
+      head_branch: "feat/astro5-workers-runtime",
+      head_repository: { full_name: repository },
+      head_sha: prCommit,
+      path: ".github/workflows/deploy.yml",
+      pull_requests: [{ number: 171 }],
+    };
+    const pushRun = {
+      conclusion: "success",
+      event: "push",
+      head_branch: "main",
+      head_repository: { full_name: repository },
+      head_sha: mainCommit,
+      path: ".github/workflows/deploy.yml",
+      pull_requests: [],
+    };
+
+    expectJqResult(
+      program,
+      pullRequestRun,
+      true,
+      sourceRunArgs("feat/astro5-workers-runtime", prCommit, "171"),
+    );
+    expectJqResult(
+      program,
+      pushRun,
+      true,
+      sourceRunArgs("main", mainCommit, ""),
+    );
+    expectJqResult(
+      program,
+      { ...pushRun, head_branch: "feature" },
+      false,
+      sourceRunArgs("feature", mainCommit, ""),
+    );
+    expectJqResult(
+      program,
+      pushRun,
+      false,
+      sourceRunArgs("main", mainCommit, "", "c".repeat(40)),
+    );
+    expectJqResult(
+      program,
+      pushRun,
+      false,
+      sourceRunArgs("main", mainCommit, "", mainCommit, "c".repeat(40)),
+    );
+    expectJqResult(
+      program,
+      { ...pushRun, conclusion: "failure" },
+      false,
+      sourceRunArgs("main", mainCommit, ""),
+    );
+    expectJqResult(
+      program,
+      { ...pullRequestRun, conclusion: "cancelled" },
+      false,
+      sourceRunArgs("feat/astro5-workers-runtime", prCommit, "171"),
+    );
+    expectJqResult(
+      program,
+      pullRequestRun,
+      false,
+      sourceRunArgs("feat/astro5-workers-runtime", prCommit, ""),
+    );
+    expectJqResult(
+      program,
+      pushRun,
+      false,
+      sourceRunArgs("main", mainCommit, "171"),
+    );
+    expectJqResult(
+      program,
+      { ...pullRequestRun, pull_requests: [{ number: 999 }] },
+      false,
+      sourceRunArgs("feat/astro5-workers-runtime", prCommit, "171"),
+    );
+    expectJqResult(
+      program,
+      { ...pushRun, path: ".github/workflows/other.yml" },
+      false,
+      sourceRunArgs("main", mainCommit, ""),
+    );
+    expectJqResult(
+      program,
+      {
+        ...pushRun,
+        head_repository: { full_name: "attacker/zenml-io-v2" },
+      },
+      false,
+      sourceRunArgs("main", mainCommit, ""),
     );
   });
 


### PR DESCRIPTION
## Summary

The isolated preview rehearsal can now use the exact successful artifact built
from the current `main` commit after a migration PR has merged. The existing
open-PR path remains available, and both paths still stop at an inactive,
private, route-less Worker version.

The new `main` path fails closed unless the run succeeded in this repository,
used the reviewed artifact workflow, came from branch `main`, and matches the
trusted dispatch commit plus the live `main` tip. If `main` advances while the
workflow waits, the upload is rejected.

## What changed

- Made the PR number optional only for exact current-`main` push artifacts.
- Preserved the existing open same-repository PR and tested-merge checks.
- Reused one source-authorization predicate at the initial and pre-upload
  checks, then rechecked the live `main` tip directly before Wrangler runs.
- Kept upload, activation, and route attachment as separate actions.
- Updated both Worker runbooks to document the two eligible source modes.
- Added executable rejection cases for failed or cancelled runs, stale `main`,
  cross-mode inputs, wrong workflow paths, and fork repositories.

## Reviewer focus

- Confirm that the `push` branch accepts only the exact live `main` commit.
- Confirm that the pull-request branch retains its open-head and merge-commit
  protections.
- Confirm that no activation, route, DNS, Pages, Access, custom-domain, or
  production-traffic authority was added.

## Validation

- `pnpm check`
- `pnpm check:tests`
- `pnpm check:surface`
- `pnpm check:alt`
- `pnpm lint`
- `pnpm test` (131 tests)
- `pnpm build`
- `pnpm smoke:dist`
- `pnpm check:worker` (18 runtime checks)
- `pnpm check:islands` (4 browser hydration checks)
- `actionlint .github/workflows/*.yml`
- `git diff --check`

The workflow was not dispatched, and no Cloudflare or production state changed.

## Post-Deploy Monitoring & Validation

No additional production monitoring is required because merging this PR does
not deploy or route a Worker. After merge, confirm the `main` Repo checks pass.
Before any later manual preview upload, record the exact `main` run, commit, and
artifact checksum; stop if the workflow rejects them or if `main` advances.
