### PR TITLE
Improve CSP report diagnostics

### DIFF
--- a/src/pages/api/csp-report.ts
+++ b/src/pages/api/csp-report.ts
@@ -10,6 +10,37 @@ import type { APIContext } from "astro";
 
 export const prerender = false;
 
+const SAFE_CSP_KEYWORDS = new Set([
+  "eval",
+  "inline",
+  "wasm-eval",
+  "trusted-types-policy",
+  "trusted-types-sink",
+  "self",
+]);
+
+function sanitizeCspResource(value: unknown): string {
+  if (typeof value !== "string" || value.length === 0) {
+    return "";
+  }
+
+  if (SAFE_CSP_KEYWORDS.has(value)) {
+    return value;
+  }
+
+  try {
+    const url = new URL(value);
+
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      return `${url.origin}${url.pathname}`;
+    }
+
+    return url.protocol;
+  } catch {
+    return "(unparseable)";
+  }
+}
+
 export async function POST(context: APIContext): Promise<Response> {
   try {
     const body = (await context.request.json()) as Record<string, unknown>;
@@ -17,14 +48,16 @@ export async function POST(context: APIContext): Promise<Response> {
       (body?.["csp-report"] as Record<string, unknown>) ?? body ?? {};
 
     // Log only non-PII fields for debugging
-    const documentUri = String(report["document-uri"] ?? "").split("?")[0];
+    const documentUri = sanitizeCspResource(report["document-uri"]);
     const violatedDirective = String(report["violated-directive"] ?? "");
     const effectiveDirective = String(report["effective-directive"] ?? "");
+    const blockedResource = sanitizeCspResource(report["blocked-uri"]);
 
     console.log("[csp-report]", {
       documentUri,
       violatedDirective,
       effectiveDirective,
+      blockedResource,
     });
   } catch {
     // Malformed payload — silently accept to avoid 4xx noise

--- a/src/pages/api/csp-report.ts
+++ b/src/pages/api/csp-report.ts
@@ -19,6 +19,8 @@ const SAFE_CSP_KEYWORDS = new Set([
   "self",
 ]);
 
+const SAFE_CSP_SCHEMES = new Set(["data:", "blob:"]);
+
 function sanitizeCspResource(value: unknown): string {
   if (typeof value !== "string" || value.length === 0) {
     return "";
@@ -28,6 +30,10 @@ function sanitizeCspResource(value: unknown): string {
     return value;
   }
 
+  if (value === "data" || value === "blob") {
+    return `${value}:`;
+  }
+
   try {
     const url = new URL(value);
 
@@ -35,7 +41,11 @@ function sanitizeCspResource(value: unknown): string {
       return `${url.origin}${url.pathname}`;
     }
 
-    return url.protocol;
+    if (SAFE_CSP_SCHEMES.has(url.protocol)) {
+      return url.protocol;
+    }
+
+    return "(other-scheme)";
   } catch {
     return "(unparseable)";
   }

--- a/tests/api/csp-report.test.ts
+++ b/tests/api/csp-report.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
 });
 
 describe("/api/csp-report", () => {
-  it("accepts a report and strips the document query from its log", async () => {
+  it("logs the blocked HTTP resource without its query or fragment", async () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
     const response = await POST(
       makeContext(
@@ -26,6 +26,8 @@ describe("/api/csp-report", () => {
             "document-uri": "https://www.zenml.io/product/kitaru?private=value",
             "violated-directive": "script-src",
             "effective-directive": "script-src-elem",
+            "blocked-uri":
+              "https://cdn.example.com/scripts/app.js?token=secret#fragment",
           },
         }),
       ),
@@ -36,7 +38,135 @@ describe("/api/csp-report", () => {
       documentUri: "https://www.zenml.io/product/kitaru",
       violatedDirective: "script-src",
       effectiveDirective: "script-src-elem",
+      blockedResource: "https://cdn.example.com/scripts/app.js",
     });
+    expect(JSON.stringify(log.mock.calls)).not.toContain("secret");
+  });
+
+  it.each([
+    ["data:text/javascript,alert('secret')", "data:"],
+    ["blob:https://www.zenml.io/private-identifier", "blob:"],
+  ])("logs only the scheme for %s resources", async (blockedUri, expected) => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await POST(
+      makeContext(
+        JSON.stringify({
+          "csp-report": {
+            "blocked-uri": blockedUri,
+          },
+        }),
+      ),
+    );
+
+    expect(log).toHaveBeenCalledWith(
+      "[csp-report]",
+      expect.objectContaining({ blockedResource: expected }),
+    );
+    expect(JSON.stringify(log.mock.calls)).not.toContain("private-identifier");
+    expect(JSON.stringify(log.mock.calls)).not.toContain("alert");
+  });
+
+  it.each([
+    "eval",
+    "inline",
+    "wasm-eval",
+    "trusted-types-policy",
+    "trusted-types-sink",
+    "self",
+  ])("preserves the safe CSP keyword %s", async (blockedUri) => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await POST(
+      makeContext(
+        JSON.stringify({
+          "csp-report": {
+            "blocked-uri": blockedUri,
+          },
+        }),
+      ),
+    );
+
+    expect(log).toHaveBeenCalledWith(
+      "[csp-report]",
+      expect.objectContaining({ blockedResource: blockedUri }),
+    );
+  });
+
+  it("logs an empty blocked resource when the field is missing", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await POST(makeContext(JSON.stringify({ "csp-report": {} })));
+
+    expect(log).toHaveBeenCalledWith(
+      "[csp-report]",
+      expect.objectContaining({ blockedResource: "" }),
+    );
+  });
+
+  it("logs a fixed marker for an unparseable blocked resource", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await POST(
+      makeContext(
+        JSON.stringify({
+          "csp-report": {
+            "blocked-uri": "not a valid URL?token=secret",
+          },
+        }),
+      ),
+    );
+
+    expect(log).toHaveBeenCalledWith(
+      "[csp-report]",
+      expect.objectContaining({ blockedResource: "(unparseable)" }),
+    );
+    expect(JSON.stringify(log.mock.calls)).not.toContain("secret");
+  });
+
+  it("does not string-coerce array values into logged paths", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await POST(
+      makeContext(
+        JSON.stringify({
+          "csp-report": {
+            "blocked-uri": ["https://cdn.example.com/", "private-secret-value"],
+          },
+        }),
+      ),
+    );
+
+    expect(log).toHaveBeenCalledWith(
+      "[csp-report]",
+      expect.objectContaining({ blockedResource: "" }),
+    );
+    expect(JSON.stringify(log.mock.calls)).not.toContain(
+      "private-secret-value",
+    );
+  });
+
+  it("removes fragments from the logged document URI", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await POST(
+      makeContext(
+        JSON.stringify({
+          "csp-report": {
+            "document-uri":
+              "https://www.zenml.io/product/kitaru#private-fragment",
+          },
+        }),
+      ),
+    );
+
+    expect(log).toHaveBeenCalledWith(
+      "[csp-report]",
+      expect.objectContaining({
+        documentUri: "https://www.zenml.io/product/kitaru",
+      }),
+    );
+    expect(JSON.stringify(log.mock.calls)).not.toContain("private-fragment");
   });
 
   it("accepts malformed reports without raising a Worker error", async () => {

--- a/tests/api/csp-report.test.ts
+++ b/tests/api/csp-report.test.ts
@@ -46,6 +46,8 @@ describe("/api/csp-report", () => {
   it.each([
     ["data:text/javascript,alert('secret')", "data:"],
     ["blob:https://www.zenml.io/private-identifier", "blob:"],
+    ["data", "data:"],
+    ["blob", "blob:"],
   ])("logs only the scheme for %s resources", async (blockedUri, expected) => {
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
 
@@ -65,6 +67,26 @@ describe("/api/csp-report", () => {
     );
     expect(JSON.stringify(log.mock.calls)).not.toContain("private-identifier");
     expect(JSON.stringify(log.mock.calls)).not.toContain("alert");
+  });
+
+  it("does not log an attacker-controlled custom URL scheme", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await POST(
+      makeContext(
+        JSON.stringify({
+          "csp-report": {
+            "blocked-uri": "private-sentinel-scheme:payload",
+          },
+        }),
+      ),
+    );
+
+    expect(log).toHaveBeenCalledWith(
+      "[csp-report]",
+      expect.objectContaining({ blockedResource: "(other-scheme)" }),
+    );
+    expect(JSON.stringify(log.mock.calls)).not.toContain("private-sentinel");
   });
 
   it.each([


### PR DESCRIPTION
## Summary

CSP reports now identify the blocked resource without retaining query strings, fragments, embedded non-HTTP payloads, or malformed attacker-controlled values. This gives the next Pages-to-Workers cutover enough detail to distinguish known Pages noise from a new Worker regression.

This PR changes diagnostic logging only. It does not alter CSP enforcement or production routing.

## Changes

- Preserve safe CSP tokens such as `eval`.
- Reduce HTTP(S) values to their origin and query-free, fragment-free path.
- Preserve only allowlisted `data:` and `blob:` schemes, including their bare report forms.
- Map every other parsed custom scheme to a fixed marker.
- Apply the same privacy boundary to document and blocked URIs.
- Reject non-string values and use a fixed marker for malformed strings.
- Add focused regression coverage for privacy and diagnostic edge cases.

## Reviewer focus

Please check the sanitizer's privacy boundary and whether the safe CSP keyword allowlist is appropriately narrow.

## Validation

- `pnpm test` (146 tests)
- `pnpm check`
- `pnpm check:tests`
- `pnpm lint`
- `pnpm build`
- `pnpm smoke:dist`
- `pnpm check:worker` (18/18 runtime checks)

The implementation also received correctness, security, testing, project-standards, and independent adversarial review. All actionable findings were applied.

## Post-Deploy Monitoring & Validation

- Watch Worker or Pages logs for `[csp-report]`.
- Healthy: `blockedResource` contains only a safe CSP token, an HTTP(S) origin plus query-free path, `data:`, `blob:`, an empty missing value, `(other-scheme)`, or `(unparseable)`.
- Failure: query strings, fragments, embedded payload contents, custom scheme names, or array/object values appear in logs; malformed reports cause non-204 responses.
- Observe during the next staging smoke and production cutover window.
- Owner: Alex and Codex during the supervised migration.
- Mitigation: revert this commit if sensitive values appear. This PR does not change CSP enforcement or production routing.

Related: #169
