### PR TITLE
Add isolated Worker previews for pull requests

### DIFF
--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -14,6 +14,10 @@ on:
         description: Open same-repository pull request number for that run
         required: true
         type: string
+      source_branch:
+        description: Exact source branch tested by that run
+        required: true
+        type: string
       allow_bootstrap:
         description: Allow this reviewed manual run to create the dedicated preview Worker
         required: true
@@ -33,7 +37,7 @@ concurrency:
     }}-${{
       github.event.pull_request.head.ref ||
       github.event.workflow_run.head_branch ||
-      format('pr-{0}', inputs.pr_number)
+      inputs.source_branch
     }}
   cancel-in-progress: false
 
@@ -72,6 +76,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          INPUT_SOURCE_BRANCH: ${{ inputs.source_branch }}
           SOURCE_RUN_ID: ${{ github.event.workflow_run.id || inputs.source_run_id }}
         run: |
           set -euo pipefail
@@ -95,6 +100,10 @@ jobs:
 
           source_branch="$(jq -er .head_branch "$RUNNER_TEMP/source-run.json")"
           source_commit="$(jq -er .head_sha "$RUNNER_TEMP/source-run.json")"
+          if [ -n "$INPUT_SOURCE_BRANCH" ] && [ "$INPUT_SOURCE_BRANCH" != "$source_branch" ]; then
+            echo "The supplied source branch does not own this exact CI run." >&2
+            exit 1
+          fi
           repo_owner="${GITHUB_REPOSITORY%%/*}"
           gh api \
             --method GET \
@@ -463,11 +472,18 @@ jobs:
             --strict \
             --dry-run \
             --outdir "$RUNNER_TEMP/pr-preview-upload-dry-run"
+          set +e
           wrangler versions upload \
             --config dist/server/upload-wrangler.json \
             --strict \
             --preview-alias "pr-$PR_NUMBER" \
             --message "$version_message"
+          upload_status=$?
+          set -e
+          echo "upload_attempted=true" >> "$GITHUB_OUTPUT"
+          if [ "$upload_status" -ne 0 ]; then
+            exit "$upload_status"
+          fi
           jq -s 'map(select(.type == "version-upload")) | last' \
             "$output_file" > upload-result.json
           version_id="$(jq -er .version_id upload-result.json)"
@@ -477,6 +493,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Retire alias if the PR closed during upload
+        if: always() && steps.upload.outputs.upload_attempted == 'true'
         shell: bash
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -524,6 +541,7 @@ jobs:
           exit 1
 
       - name: Verify isolated public preview
+        if: steps.upload.outcome == 'success'
         id: verify
         shell: bash
         env:

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -1,0 +1,915 @@
+name: Publish Worker PR Preview
+
+on:
+  workflow_run:
+    workflows: ["Website CI and Worker Artifact"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: Successful Website CI and Worker Artifact PR run ID
+        required: true
+        type: string
+      pr_number:
+        description: Open same-repository pull request number for that run
+        required: true
+        type: string
+      allow_bootstrap:
+        description: Allow this reviewed manual run to create the dedicated preview Worker
+        required: true
+        default: false
+        type: boolean
+      self_reviewed:
+        description: I reviewed the exact PR, CI run, and limited preview mutation
+        required: true
+        type: boolean
+  pull_request_target:
+    types: [closed]
+
+concurrency:
+  group: zenml-io-worker-pr-preview
+  cancel-in-progress: false
+
+permissions: {}
+
+env:
+  WORKER_NAME: zenml-io-v2-pr-preview
+
+jobs:
+  publish:
+    name: Publish exact PR artifact
+    if: >-
+      (
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      ) ||
+      (
+        github.event_name == 'workflow_dispatch' &&
+        github.ref == 'refs/heads/main' &&
+        inputs.self_reviewed == true
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: worker-pr-preview
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Resolve one current eligible pull request
+        id: source
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id || inputs.source_run_id }}
+        run: |
+          set -euo pipefail
+          [[ "$SOURCE_RUN_ID" =~ ^[0-9]+$ ]]
+          [[ -z "$INPUT_PR_NUMBER" || "$INPUT_PR_NUMBER" =~ ^[0-9]+$ ]]
+
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID" \
+            > "$RUNNER_TEMP/source-run.json"
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" '
+              .name == "Website CI and Worker Artifact" and
+              .path == ".github/workflows/deploy.yml" and
+              .status == "completed" and
+              .conclusion == "success" and
+              .event == "pull_request" and
+              .head_repository.full_name == $repository and
+              (.head_branch | type) == "string" and
+              (.head_branch | length) > 0 and
+              (.head_sha | test("^[0-9a-f]{40}$"))
+            ' "$RUNNER_TEMP/source-run.json" > /dev/null
+
+          source_branch="$(jq -er .head_branch "$RUNNER_TEMP/source-run.json")"
+          source_commit="$(jq -er .head_sha "$RUNNER_TEMP/source-run.json")"
+          repo_owner="${GITHUB_REPOSITORY%%/*}"
+          gh api \
+            --method GET \
+            "repos/$GITHUB_REPOSITORY/pulls" \
+            -f state=open \
+            -f head="$repo_owner:$source_branch" \
+            -f per_page=100 > "$RUNNER_TEMP/source-pr-candidates.json"
+          jq \
+            --arg branch "$source_branch" \
+            --arg commit "$source_commit" \
+            --arg repository "$GITHUB_REPOSITORY" '
+              [.[] |
+                select(
+                  .state == "open" and
+                  .draft == false and
+                  .head.repo.full_name == $repository and
+                  .user.login != "dependabot[bot]" and
+                  .head.ref == $branch and
+                  .head.sha == $commit
+                )
+              ]
+            ' "$RUNNER_TEMP/source-pr-candidates.json" \
+            > "$RUNNER_TEMP/eligible-prs.json"
+          test "$(jq 'length' "$RUNNER_TEMP/eligible-prs.json")" = "1"
+          jq '.[0]' "$RUNNER_TEMP/eligible-prs.json" \
+            > "$RUNNER_TEMP/source-pr.json"
+
+          pr_number="$(jq -er '.number | tostring' "$RUNNER_TEMP/source-pr.json")"
+          if [ -n "$INPUT_PR_NUMBER" ] && [ "$INPUT_PR_NUMBER" != "$pr_number" ]; then
+            echo "The supplied PR number does not own this exact CI run." >&2
+            exit 1
+          fi
+          build_commit="$(jq -er .merge_commit_sha "$RUNNER_TEMP/source-pr.json")"
+          [[ "$build_commit" =~ ^[0-9a-f]{40}$ ]]
+
+          {
+            echo "source_run_id=$SOURCE_RUN_ID"
+            echo "source_branch=$source_branch"
+            echo "source_commit=$source_commit"
+            echo "build_commit=$build_commit"
+            echo "pr_number=$pr_number"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download the exact validated Worker artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: worker-dist
+          path: candidate
+          run-id: ${{ steps.source.outputs.source_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify artifact provenance and checksum
+        shell: bash
+        env:
+          BUILD_COMMIT: ${{ steps.source.outputs.build_commit }}
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_BRANCH: ${{ steps.source.outputs.source_branch }}
+          SOURCE_COMMIT: ${{ steps.source.outputs.source_commit }}
+          SOURCE_RUN_ID: ${{ steps.source.outputs.source_run_id }}
+        run: |
+          set -euo pipefail
+          cd candidate
+          sha256sum --check worker-dist.sha256
+          artifact_sha256="$(cut -d ' ' -f 1 worker-dist.sha256)"
+          jq -e \
+            --arg artifact_sha256 "$artifact_sha256" \
+            --arg branch "$SOURCE_BRANCH" \
+            --arg build_commit "$BUILD_COMMIT" \
+            --arg commit "$SOURCE_COMMIT" \
+            --arg run_id "$SOURCE_RUN_ID" '
+              .artifact_contract == "astro-cloudflare-v6" and
+              .artifact_sha256 == $artifact_sha256 and
+              .build_commit == $build_commit and
+              .event_name == "pull_request" and
+              .source_branch == $branch and
+              .source_commit == $commit and
+              .run_id == $run_id and
+              (.required_secrets | sort) ==
+                (["SEGMENT_FORMS_WRITE_KEY", "TURNSTILE_SECRET_KEY"] | sort)
+            ' worker-manifest.json > /dev/null
+
+          source_workflow_blob="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/contents/.github/workflows/deploy.yml?ref=$BUILD_COMMIT" \
+              --jq .sha
+          )"
+          trusted_workflow_blob="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/contents/.github/trusted/worker-artifact-workflow.yml?ref=$GITHUB_SHA" \
+              --jq .sha
+          )"
+          if [ "$source_workflow_blob" != "$trusted_workflow_blob" ]; then
+            echo "The source run used an untrusted artifact workflow definition." >&2
+            exit 1
+          fi
+
+      - name: Reject unsafe Worker artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd candidate
+          tar -tzf worker-dist.tar.gz > "$RUNNER_TEMP/archive-paths.txt"
+          if grep -Eq '(^/|(^|/)\.\.(/|$))' "$RUNNER_TEMP/archive-paths.txt"; then
+            echo "Worker archive contains an unsafe path." >&2
+            exit 1
+          fi
+          tar -tvzf worker-dist.tar.gz > "$RUNNER_TEMP/archive-members.txt"
+          while read -r mode _; do
+            case "${mode:0:1}" in
+              -|d) ;;
+              *)
+                echo "Worker archive contains a link or special file." >&2
+                exit 1
+                ;;
+            esac
+          done < "$RUNNER_TEMP/archive-members.txt"
+          grep -Fx "dist/server/wrangler.json" "$RUNNER_TEMP/archive-paths.txt"
+          grep -Fx "dist/server/entry.mjs" "$RUNNER_TEMP/archive-paths.txt"
+          grep -Fx ".wrangler/deploy/config.json" "$RUNNER_TEMP/archive-paths.txt"
+
+      - name: Prepare trusted PR-preview configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd candidate
+          tar -xzf worker-dist.tar.gz
+          test "$(
+            sha256sum dist/server/wrangler.json | cut -d ' ' -f 1
+          )" = "$(jq -r .generated_config_sha256 worker-manifest.json)"
+          test "$(
+            sha256sum .wrangler/deploy/config.json | cut -d ' ' -f 1
+          )" = "$(jq -r .deploy_config_sha256 worker-manifest.json)"
+          jq -e '
+            .name == "zenml-io-v2-worker" and
+            .main == "entry.mjs" and
+            .compatibility_date == "2026-02-10" and
+            .compatibility_flags == ["nodejs_compat"] and
+            .rules == [{"type":"ESModule","globs":["**/*.js","**/*.mjs"]}] and
+            .workers_dev == false and
+            .preview_urls == false and
+            .no_bundle == true and
+            .assets.directory == "../client" and
+            .assets.binding == "ASSETS" and
+            .assets.html_handling == "drop-trailing-slash" and
+            .assets.not_found_handling == "404-page" and
+            .assets.run_worker_first == ["/api/*"] and
+            (.route == null) and
+            (.routes == null) and
+            (.build == null) and
+            (.durable_objects.bindings // [] | length) == 0 and
+            (.kv_namespaces // [] | length) == 0 and
+            (.d1_databases // [] | length) == 0 and
+            (.r2_buckets // [] | length) == 0 and
+            (.services // [] | length) == 0
+          ' dist/server/wrangler.json > /dev/null
+          jq '{
+            name: env.WORKER_NAME,
+            main,
+            compatibility_date,
+            compatibility_flags,
+            rules,
+            assets,
+            workers_dev: false,
+            preview_urls: true,
+            no_bundle
+          }' dist/server/wrangler.json > dist/server/upload-wrangler.json
+
+      - name: Install pinned Wrangler
+        run: npm install --global wrangler@4.110.0
+
+      - name: Verify dedicated Worker baseline
+        shell: bash
+        env:
+          ALLOW_BOOTSTRAP: ${{ github.event_name == 'workflow_dispatch' && inputs.allow_bootstrap || false }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_PR_PREVIEW_TOKEN }}
+        run: |
+          set -euo pipefail
+          api_base="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID"
+          auth_header="Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+          worker_url="$api_base/workers/scripts/$WORKER_NAME"
+          status="$(
+            curl \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --silent \
+              --show-error \
+              --output /dev/null \
+              --write-out "%{http_code}" \
+              --header "$auth_header" \
+              "$worker_url"
+          )"
+          if [ "$status" = "404" ]; then
+            if [ "$ALLOW_BOOTSTRAP" != "true" ]; then
+              echo "The dedicated PR-preview Worker is absent; bootstrap requires a reviewed manual run." >&2
+              exit 1
+            fi
+            printf '[]\n' > "$RUNNER_TEMP/deployments-before-upload.json"
+          elif [ "$status" = "200" ]; then
+            curl \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --fail-with-body \
+              --silent \
+              --show-error \
+              --header "$auth_header" \
+              "$worker_url/subdomain" > "$RUNNER_TEMP/worker-subdomain-before-upload.json"
+            jq -e '
+              .success == true and
+              .result.enabled == false and
+              .result.previews_enabled == true
+            ' "$RUNNER_TEMP/worker-subdomain-before-upload.json" > /dev/null
+            wrangler deployments list \
+              --name "$WORKER_NAME" \
+              --json > "$RUNNER_TEMP/deployments-before-upload.json"
+            wrangler versions list \
+              --name "$WORKER_NAME" \
+              --json > "$RUNNER_TEMP/versions-before-upload.json"
+            latest_version_id="$(
+              jq -er '.[0].id' "$RUNNER_TEMP/versions-before-upload.json"
+            )"
+            wrangler versions view "$latest_version_id" \
+              --name "$WORKER_NAME" \
+              --json > "$RUNNER_TEMP/latest-version-before-upload.json"
+            jq -e '
+              [.resources.bindings[]? | select(.type == "secret_text")] == []
+            ' "$RUNNER_TEMP/latest-version-before-upload.json" > /dev/null
+          else
+            echo "Could not inspect the dedicated PR-preview Worker (HTTP $status)." >&2
+            exit 1
+          fi
+
+          curl \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --header "$auth_header" \
+            "$api_base/workers/scripts" > "$RUNNER_TEMP/workers-before-upload.json"
+          jq -e \
+            --argjson allow_absent "$([ "$status" = "404" ] && echo true || echo false)" \
+            --arg worker "$WORKER_NAME" '
+              .success == true and
+              ([.result[] | select(.id == $worker)]) as $workers and
+              (
+                ($allow_absent and ($workers | length) == 0) or
+                (
+                  ($allow_absent | not) and
+                  ($workers | length) == 1 and
+                  (
+                    $workers[0].routes == null or
+                    (
+                      ($workers[0].routes | type) == "array" and
+                      ($workers[0].routes | length) == 0
+                    )
+                  )
+                )
+              )
+            ' "$RUNNER_TEMP/workers-before-upload.json" > /dev/null
+          curl \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --header "$auth_header" \
+            "$api_base/workers/domains?service=$WORKER_NAME&per_page=100" \
+            > "$RUNNER_TEMP/worker-domains-before-upload.json"
+          jq -e --arg worker "$WORKER_NAME" '
+            .success == true and
+            (.result | type) == "array" and
+            ([.result[] | select(.service == $worker)] | length == 0) and
+            .result_info.total_count == 0
+          ' "$RUNNER_TEMP/worker-domains-before-upload.json" > /dev/null
+
+      - name: Record preview retirement marker
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.source.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          marker="<!-- zenml-worker-pr-preview -->"
+          body="$marker
+          ## Cloudflare Worker PR preview
+
+          Publishing the validated preview. This marker ensures the alias is retired if a later step fails."
+          gh api \
+            --paginate \
+            --method GET \
+            "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+            -f per_page=100 \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("<!-- zenml-worker-pr-preview -->"))) | .id' \
+            > "$RUNNER_TEMP/pr-preview-comment-ids.txt"
+          mapfile -t comment_ids < "$RUNNER_TEMP/pr-preview-comment-ids.txt"
+          if [ "${#comment_ids[@]}" -gt 1 ]; then
+            echo "Multiple PR-preview marker comments exist; refusing to choose one." >&2
+            exit 1
+          elif [ "${#comment_ids[@]}" -eq 1 ]; then
+            gh api \
+              --method PATCH \
+              "repos/$GITHUB_REPOSITORY/issues/comments/${comment_ids[0]}" \
+              -f body="$body" > /dev/null
+          else
+            gh api \
+              --method POST \
+              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+              -f body="$body" > /dev/null
+          fi
+
+      - name: Upload exact version with stable PR alias
+        id: upload
+        shell: bash
+        env:
+          BUILD_COMMIT: ${{ steps.source.outputs.build_commit }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_PR_PREVIEW_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.source.outputs.pr_number }}
+          SOURCE_BRANCH: ${{ steps.source.outputs.source_branch }}
+          SOURCE_COMMIT: ${{ steps.source.outputs.source_commit }}
+          SOURCE_RUN_ID: ${{ steps.source.outputs.source_run_id }}
+        run: |
+          set -euo pipefail
+
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID" \
+            > "$RUNNER_TEMP/source-run-before-upload.json"
+          jq -e \
+            --arg branch "$SOURCE_BRANCH" \
+            --arg commit "$SOURCE_COMMIT" \
+            --arg repository "$GITHUB_REPOSITORY" '
+              .name == "Website CI and Worker Artifact" and
+              .path == ".github/workflows/deploy.yml" and
+              .status == "completed" and
+              .conclusion == "success" and
+              .event == "pull_request" and
+              .head_repository.full_name == $repository and
+              .head_branch == $branch and
+              .head_sha == $commit
+            ' "$RUNNER_TEMP/source-run-before-upload.json" > /dev/null
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
+            > "$RUNNER_TEMP/source-pr-before-upload.json"
+          jq -e \
+            --arg branch "$SOURCE_BRANCH" \
+            --arg build_commit "$BUILD_COMMIT" \
+            --arg commit "$SOURCE_COMMIT" \
+            --arg repository "$GITHUB_REPOSITORY" '
+              .state == "open" and
+              .draft == false and
+              .head.repo.full_name == $repository and
+              .user.login != "dependabot[bot]" and
+              .head.ref == $branch and
+              .head.sha == $commit and
+              .merge_commit_sha == $build_commit
+            ' "$RUNNER_TEMP/source-pr-before-upload.json" > /dev/null
+
+          cd candidate
+          output_file="$RUNNER_TEMP/wrangler-pr-preview-output.jsonl"
+          export WRANGLER_OUTPUT_FILE_PATH="$output_file"
+          artifact_sha256="$(jq -r .artifact_sha256 worker-manifest.json)"
+          version_message="pr_number=$PR_NUMBER source_commit=$SOURCE_COMMIT source_branch=$SOURCE_BRANCH source_run_id=$SOURCE_RUN_ID artifact_sha256=$artifact_sha256"
+
+          wrangler versions upload \
+            --config dist/server/upload-wrangler.json \
+            --strict \
+            --dry-run \
+            --outdir "$RUNNER_TEMP/pr-preview-upload-dry-run"
+          wrangler versions upload \
+            --config dist/server/upload-wrangler.json \
+            --strict \
+            --preview-alias "pr-$PR_NUMBER" \
+            --message "$version_message"
+          jq -s 'map(select(.type == "version-upload")) | last' \
+            "$output_file" > upload-result.json
+          version_id="$(jq -er .version_id upload-result.json)"
+          {
+            echo "version_id=$version_id"
+            echo "artifact_sha256=$artifact_sha256"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Verify isolated public preview
+        id: verify
+        shell: bash
+        env:
+          ARTIFACT_SHA256: ${{ steps.upload.outputs.artifact_sha256 }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_PR_PREVIEW_TOKEN }}
+          PR_NUMBER: ${{ steps.source.outputs.pr_number }}
+          SOURCE_BRANCH: ${{ steps.source.outputs.source_branch }}
+          SOURCE_COMMIT: ${{ steps.source.outputs.source_commit }}
+          SOURCE_RUN_ID: ${{ steps.source.outputs.source_run_id }}
+          VERSION_ID: ${{ steps.upload.outputs.version_id }}
+        run: |
+          set -euo pipefail
+          wrangler versions view "$VERSION_ID" \
+            --name "$WORKER_NAME" \
+            --json > "$RUNNER_TEMP/uploaded-version.json"
+          jq -e '
+            [.resources.bindings[]? | select(.type == "secret_text")] == []
+          ' "$RUNNER_TEMP/uploaded-version.json" > /dev/null
+          message="$(
+            jq -er '.annotations["workers/message"]' \
+              "$RUNNER_TEMP/uploaded-version.json"
+          )"
+          grep -Fq -- " pr_number=$PR_NUMBER " <<< " $message "
+          grep -Fq -- " source_commit=$SOURCE_COMMIT " <<< " $message "
+          grep -Fq -- " source_branch=$SOURCE_BRANCH " <<< " $message "
+          grep -Fq -- " source_run_id=$SOURCE_RUN_ID " <<< " $message "
+          grep -Fq -- " artifact_sha256=$ARTIFACT_SHA256 " <<< " $message "
+
+          api_base="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID"
+          auth_header="Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+          curl \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --header "$auth_header" \
+            "$api_base/workers/scripts/$WORKER_NAME/subdomain" \
+            > "$RUNNER_TEMP/worker-subdomain-after-upload.json"
+          jq -e '
+            .success == true and
+            .result.enabled == false and
+            .result.previews_enabled == true
+          ' "$RUNNER_TEMP/worker-subdomain-after-upload.json" > /dev/null
+          curl \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --header "$auth_header" \
+            "$api_base/workers/scripts" > "$RUNNER_TEMP/workers-after-upload.json"
+          jq -e --arg worker "$WORKER_NAME" '
+            .success == true and
+            ([.result[] | select(.id == $worker)]) as $workers |
+            ($workers | length) == 1 and
+            (
+              $workers[0].routes == null or
+              (
+                ($workers[0].routes | type) == "array" and
+                ($workers[0].routes | length) == 0
+              )
+            )
+          ' "$RUNNER_TEMP/workers-after-upload.json" > /dev/null
+          curl \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --header "$auth_header" \
+            "$api_base/workers/domains?service=$WORKER_NAME&per_page=100" \
+            > "$RUNNER_TEMP/worker-domains-after-upload.json"
+          jq -e --arg worker "$WORKER_NAME" '
+            .success == true and
+            (.result | type) == "array" and
+            ([.result[] | select(.service == $worker)] | length == 0) and
+            .result_info.total_count == 0
+          ' "$RUNNER_TEMP/worker-domains-after-upload.json" > /dev/null
+
+          wrangler deployments list \
+            --name "$WORKER_NAME" \
+            --json > "$RUNNER_TEMP/deployments-after-upload.json"
+          jq -S . "$RUNNER_TEMP/deployments-before-upload.json" \
+            > "$RUNNER_TEMP/deployments-before-upload.canonical.json"
+          jq -S . "$RUNNER_TEMP/deployments-after-upload.json" \
+            > "$RUNNER_TEMP/deployments-after-upload.canonical.json"
+          cmp \
+            "$RUNNER_TEMP/deployments-before-upload.canonical.json" \
+            "$RUNNER_TEMP/deployments-after-upload.canonical.json" ||
+            {
+              echo "The active PR-preview deployment changed during upload." >&2
+              exit 1
+            }
+
+          workers_subdomain="$(
+            curl \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --fail-with-body \
+              --silent \
+              --show-error \
+              --header "$auth_header" \
+              "$api_base/workers/subdomain" |
+              jq -er '.result.subdomain'
+          )"
+          preview_url="https://pr-$PR_NUMBER-$WORKER_NAME.$workers_subdomain.workers.dev"
+          test "$(curl --connect-timeout 10 --max-time 30 --silent --show-error --output /dev/null --write-out "%{http_code}" "$preview_url/")" = "200"
+          test "$(curl --connect-timeout 10 --max-time 30 --silent --show-error --output /dev/null --write-out "%{http_code}" "$preview_url/this-preview-path-does-not-exist")" = "404"
+          echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
+
+      - name: Post sticky preview URL
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREVIEW_URL: ${{ steps.verify.outputs.preview_url }}
+          PR_NUMBER: ${{ steps.source.outputs.pr_number }}
+          SOURCE_BRANCH: ${{ steps.source.outputs.source_branch }}
+          SOURCE_COMMIT: ${{ steps.source.outputs.source_commit }}
+          SOURCE_RUN_ID: ${{ steps.source.outputs.source_run_id }}
+        run: |
+          set -euo pipefail
+          marker="<!-- zenml-worker-pr-preview -->"
+          body="$(
+            jq -nr \
+              --arg marker "$marker" \
+              --arg preview_url "$PREVIEW_URL" \
+              --arg branch "$SOURCE_BRANCH" \
+              --arg commit "$SOURCE_COMMIT" \
+              --arg run_id "$SOURCE_RUN_ID" '
+                [$marker, "## Cloudflare Worker PR preview", "", "| | |", "|---|---|", "| **Preview URL** | " + $preview_url + " |", "| **Branch** | `" + $branch + "` |", "| **Commit** | `" + $commit + "` |", "| **CI run** | `" + $run_id + "` |", "", "This public preview is isolated from production and will be retired when the PR closes."] |
+                join("\n")
+              '
+          )"
+          gh api \
+            --paginate \
+            --method GET \
+            "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+            -f per_page=100 \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("<!-- zenml-worker-pr-preview -->"))) | .id' \
+            > "$RUNNER_TEMP/pr-preview-comment-ids.txt"
+          mapfile -t comment_ids < "$RUNNER_TEMP/pr-preview-comment-ids.txt"
+          if [ "${#comment_ids[@]}" -ne 1 ]; then
+            echo "Expected exactly one PR-preview marker comment." >&2
+            exit 1
+          else
+            gh api \
+              --method PATCH \
+              "repos/$GITHUB_REPOSITORY/issues/comments/${comment_ids[0]}" \
+              -f body="$body" > /dev/null
+          fi
+
+      - name: Preserve preview evidence
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: pr-preview-${{ steps.source.outputs.pr_number }}-${{ steps.source.outputs.source_run_id }}
+          path: |
+            candidate/upload-result.json
+            ${{ runner.temp }}/source-run.json
+            ${{ runner.temp }}/source-pr.json
+            ${{ runner.temp }}/source-run-before-upload.json
+            ${{ runner.temp }}/source-pr-before-upload.json
+            ${{ runner.temp }}/uploaded-version.json
+            ${{ runner.temp }}/versions-before-upload.json
+            ${{ runner.temp }}/latest-version-before-upload.json
+            ${{ runner.temp }}/worker-subdomain-before-upload.json
+            ${{ runner.temp }}/worker-subdomain-after-upload.json
+            ${{ runner.temp }}/workers-before-upload.json
+            ${{ runner.temp }}/workers-after-upload.json
+            ${{ runner.temp }}/worker-domains-before-upload.json
+            ${{ runner.temp }}/worker-domains-after-upload.json
+            ${{ runner.temp }}/deployments-before-upload.json
+            ${{ runner.temp }}/deployments-after-upload.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Record preview metadata
+        shell: bash
+        env:
+          ARTIFACT_SHA256: ${{ steps.upload.outputs.artifact_sha256 }}
+          PREVIEW_URL: ${{ steps.verify.outputs.preview_url }}
+          PR_NUMBER: ${{ steps.source.outputs.pr_number }}
+          SOURCE_COMMIT: ${{ steps.source.outputs.source_commit }}
+          SOURCE_RUN_ID: ${{ steps.source.outputs.source_run_id }}
+          VERSION_ID: ${{ steps.upload.outputs.version_id }}
+        run: |
+          {
+            echo "## Public Worker PR preview"
+            echo
+            printf -- "- PR: \`%s\`\n" "$PR_NUMBER"
+            printf -- "- Version: \`%s\`\n" "$VERSION_ID"
+            printf -- "- Source commit: \`%s\`\n" "$SOURCE_COMMIT"
+            printf -- "- CI run: \`%s\`\n" "$SOURCE_RUN_ID"
+            printf -- "- Artifact SHA-256: \`%s\`\n" "$ARTIFACT_SHA256"
+            printf -- "- Preview URL: %s\n" "$PREVIEW_URL"
+            echo
+            echo "No production deployment, route, custom domain, DNS record, or Pages project changed."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  retire:
+    name: Retire closed PR alias
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: worker-pr-preview
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Check whether this PR had a preview
+        id: preview
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]
+          gh api \
+            --paginate \
+            --method GET \
+            "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+            -f per_page=100 \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("<!-- zenml-worker-pr-preview -->"))) | .id' \
+            > "$RUNNER_TEMP/pr-preview-comment-ids.txt"
+          mapfile -t comment_ids < "$RUNNER_TEMP/pr-preview-comment-ids.txt"
+          if [ "${#comment_ids[@]}" -ge 1 ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## No PR preview to retire"
+              echo
+              echo "This pull request never received a Worker preview comment."
+              echo "No Cloudflare state was inspected or changed."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Install pinned Wrangler
+        if: steps.preview.outputs.exists == 'true'
+        run: npm install --global wrangler@4.110.0
+
+      - name: Verify the dedicated Worker remains isolated
+        if: steps.preview.outputs.exists == 'true'
+        shell: bash
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_PR_PREVIEW_TOKEN }}
+        run: |
+          set -euo pipefail
+          api_base="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID"
+          auth_header="Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+          worker_url="$api_base/workers/scripts/$WORKER_NAME"
+          curl \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --header "$auth_header" \
+            "$worker_url/subdomain" > "$RUNNER_TEMP/worker-subdomain-before-retire.json"
+          jq -e '
+            .success == true and
+            .result.enabled == false and
+            .result.previews_enabled == true
+          ' "$RUNNER_TEMP/worker-subdomain-before-retire.json" > /dev/null
+          curl \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --header "$auth_header" \
+            "$api_base/workers/scripts" > "$RUNNER_TEMP/workers-before-retire.json"
+          jq -e --arg worker "$WORKER_NAME" '
+            .success == true and
+            ([.result[] | select(.id == $worker)]) as $workers |
+            ($workers | length) == 1 and
+            (
+              $workers[0].routes == null or
+              (
+                ($workers[0].routes | type) == "array" and
+                ($workers[0].routes | length) == 0
+              )
+            )
+          ' "$RUNNER_TEMP/workers-before-retire.json" > /dev/null
+          curl \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --header "$auth_header" \
+            "$api_base/workers/domains?service=$WORKER_NAME&per_page=100" \
+            > "$RUNNER_TEMP/worker-domains-before-retire.json"
+          jq -e --arg worker "$WORKER_NAME" '
+            .success == true and
+            (.result | type) == "array" and
+            ([.result[] | select(.service == $worker)] | length == 0) and
+            .result_info.total_count == 0
+          ' "$RUNNER_TEMP/worker-domains-before-retire.json" > /dev/null
+          wrangler deployments list \
+            --name "$WORKER_NAME" \
+            --json > "$RUNNER_TEMP/deployments-before-retire.json"
+
+      - name: Replace the closed PR alias with a tombstone
+        if: steps.preview.outputs.exists == 'true'
+        shell: bash
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_PR_PREVIEW_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]
+          retire_dir="$RUNNER_TEMP/pr-preview-retired"
+          mkdir -p "$retire_dir"
+          printf '%s\n' \
+            'export default {' \
+            '  fetch() {' \
+            '    return new Response("PR preview retired", {' \
+            '      status: 410,' \
+            '      headers: { "content-type": "text/plain; charset=utf-8" },' \
+            '    });' \
+            '  },' \
+            '};' > "$retire_dir/retired.mjs"
+          jq -n \
+            --arg name "$WORKER_NAME" '
+              {
+                name: $name,
+                main: "retired.mjs",
+                compatibility_date: "2026-02-10",
+                compatibility_flags: ["nodejs_compat"],
+                workers_dev: false,
+                preview_urls: true,
+                no_bundle: true
+              }
+            ' > "$retire_dir/wrangler.json"
+          export WRANGLER_OUTPUT_FILE_PATH="$RUNNER_TEMP/wrangler-pr-retire-output.jsonl"
+          wrangler versions upload \
+            --config "$retire_dir/wrangler.json" \
+            --strict \
+            --preview-alias "pr-$PR_NUMBER" \
+            --message "PR preview retired pr_number=$PR_NUMBER"
+          jq -s 'map(select(.type == "version-upload")) | last' \
+            "$WRANGLER_OUTPUT_FILE_PATH" > "$RUNNER_TEMP/retire-result.json"
+          jq -er .version_id "$RUNNER_TEMP/retire-result.json" > /dev/null
+
+      - name: Verify the alias is retired without deployment changes
+        if: steps.preview.outputs.exists == 'true'
+        id: verify-retired
+        shell: bash
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_PR_PREVIEW_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          wrangler deployments list \
+            --name "$WORKER_NAME" \
+            --json > "$RUNNER_TEMP/deployments-after-retire.json"
+          jq -S . "$RUNNER_TEMP/deployments-before-retire.json" \
+            > "$RUNNER_TEMP/deployments-before-retire.canonical.json"
+          jq -S . "$RUNNER_TEMP/deployments-after-retire.json" \
+            > "$RUNNER_TEMP/deployments-after-retire.canonical.json"
+          cmp \
+            "$RUNNER_TEMP/deployments-before-retire.canonical.json" \
+            "$RUNNER_TEMP/deployments-after-retire.canonical.json" ||
+            {
+              echo "The active PR-preview deployment changed during retirement." >&2
+              exit 1
+            }
+          api_base="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID"
+          auth_header="Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+          workers_subdomain="$(
+            curl \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --fail-with-body \
+              --silent \
+              --show-error \
+              --header "$auth_header" \
+              "$api_base/workers/subdomain" |
+              jq -er '.result.subdomain'
+          )"
+          preview_url="https://pr-$PR_NUMBER-$WORKER_NAME.$workers_subdomain.workers.dev"
+          test "$(curl --connect-timeout 10 --max-time 30 --silent --show-error --output /dev/null --write-out "%{http_code}" "$preview_url/")" = "410"
+          echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
+
+      - name: Mark sticky preview comment retired
+        if: steps.preview.outputs.exists == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREVIEW_URL: ${{ steps.verify-retired.outputs.preview_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          marker="<!-- zenml-worker-pr-preview -->"
+          body="$(
+            jq -nr \
+              --arg marker "$marker" \
+              --arg preview_url "$PREVIEW_URL" '
+                [$marker, "## Cloudflare Worker PR preview", "", "This preview was retired when the pull request closed.", "", "- Former URL: " + $preview_url, "- Current response: `410 Gone`"] |
+                join("\n")
+              '
+          )"
+          gh api \
+            --paginate \
+            --method GET \
+            "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+            -f per_page=100 \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("<!-- zenml-worker-pr-preview -->"))) | .id' \
+            > "$RUNNER_TEMP/pr-preview-comment-ids.txt"
+          mapfile -t comment_ids < "$RUNNER_TEMP/pr-preview-comment-ids.txt"
+          for comment_id in "${comment_ids[@]}"; do
+            gh api \
+              --method PATCH \
+              "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" \
+              -f body="$body" > /dev/null
+          done
+
+      - name: Preserve retirement evidence
+        if: always() && steps.preview.outputs.exists == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: pr-preview-retired-${{ github.event.pull_request.number }}-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/retire-result.json
+            ${{ runner.temp }}/worker-subdomain-before-retire.json
+            ${{ runner.temp }}/workers-before-retire.json
+            ${{ runner.temp }}/worker-domains-before-retire.json
+            ${{ runner.temp }}/deployments-before-retire.json
+            ${{ runner.temp }}/deployments-after-retire.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -27,7 +27,14 @@ on:
     types: [closed]
 
 concurrency:
-  group: zenml-io-worker-pr-preview
+  group: >-
+    zenml-io-worker-pr-preview-${{
+      github.event_name == 'pull_request_target' && 'retire' || 'publish'
+    }}-${{
+      github.event.pull_request.head.ref ||
+      github.event.workflow_run.head_branch ||
+      format('pr-{0}', inputs.pr_number)
+    }}
   cancel-in-progress: false
 
 permissions: {}
@@ -468,6 +475,53 @@ jobs:
             echo "version_id=$version_id"
             echo "artifact_sha256=$artifact_sha256"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Retire alias if the PR closed during upload
+        shell: bash
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_PR_PREVIEW_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.source.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          pr_state="$(
+            gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .state
+          )"
+          if [ "$pr_state" = "open" ]; then
+            exit 0
+          fi
+
+          retire_dir="$RUNNER_TEMP/pr-preview-closed-during-upload"
+          mkdir -p "$retire_dir"
+          printf '%s\n' \
+            'export default {' \
+            '  fetch() {' \
+            '    return new Response("PR preview retired", {' \
+            '      status: 410,' \
+            '      headers: { "content-type": "text/plain; charset=utf-8" },' \
+            '    });' \
+            '  },' \
+            '};' > "$retire_dir/retired.mjs"
+          jq -n \
+            --arg name "$WORKER_NAME" '
+              {
+                name: $name,
+                main: "retired.mjs",
+                compatibility_date: "2026-02-10",
+                compatibility_flags: ["nodejs_compat"],
+                workers_dev: false,
+                preview_urls: true,
+                no_bundle: true
+              }
+            ' > "$retire_dir/wrangler.json"
+          wrangler versions upload \
+            --config "$retire_dir/wrangler.json" \
+            --strict \
+            --preview-alias "pr-$PR_NUMBER" \
+            --message "PR preview retired after close during upload pr_number=$PR_NUMBER"
+          echo "The PR closed during upload; its alias was retired instead of published." >&2
+          exit 1
 
       - name: Verify isolated public preview
         id: verify

--- a/docs/worker-pr-preview-runbook.md
+++ b/docs/worker-pr-preview-runbook.md
@@ -124,7 +124,7 @@ After merging the reviewed workflow:
    current `main`.
 3. Wait for its complete `Website CI and Worker Artifact` run to pass.
 4. Open **Actions → Publish Worker PR Preview → Run workflow** on `main`.
-5. Enter that open PR number and exact CI run ID.
+5. Enter that open PR number, exact source branch, and exact CI run ID.
 6. Check `allow_bootstrap` only after confirming
    `zenml-io-v2-pr-preview` does not already exist.
 7. Check `self_reviewed`.

--- a/docs/worker-pr-preview-runbook.md
+++ b/docs/worker-pr-preview-runbook.md
@@ -1,0 +1,193 @@
+# Cloudflare Worker PR previews
+## Purpose
+
+`Publish Worker PR Preview` gives each eligible pull request a stable public
+preview of its exact CI-validated Cloudflare Worker artifact. It is separate
+from:
+
+- the production Worker `zenml-io-v2-worker`;
+- the private migration Worker `zenml-io-v2-worker-preview`; and
+- the retained Cloudflare Pages project.
+
+The dedicated service is named `zenml-io-v2-pr-preview`. It has no route,
+custom domain, production secret, production-release token, DNS authority, or
+Pages authority. Only version preview URLs are public.
+
+## What runs
+
+The workflow has three entry points:
+
+1. A successful `Website CI and Worker Artifact` pull-request run starts an
+   automatic preview attempt.
+2. A reviewed manual dispatch can publish an exact successful PR run and is the
+   only path allowed to create the dedicated Worker on the first pilot.
+3. Closing a same-repository pull request replaces its alias with a small
+   `410 Gone` Worker version so the old site is no longer exposed.
+
+Draft pull requests, fork pull requests, failed CI runs, closed pull requests,
+stale heads, stale test merges, and artifacts built by an untrusted workflow
+definition fail closed before upload.
+
+GitHub's `workflow_run.pull_requests` list is not reliable enough to identify
+the source PR. The workflow instead reads the completed CI run, queries the
+open same-repository PR for that exact branch and head SHA, requires exactly
+one non-draft match, and then verifies its current test-merge commit against
+the artifact manifest.
+
+## Stable aliases and concurrent PRs
+
+Each open PR uses the immutable alias `pr-<number>`. Cloudflare maps that alias
+to a URL with this shape:
+
+```text
+https://pr-<number>-zenml-io-v2-pr-preview.<account-subdomain>.workers.dev
+```
+
+A new successful commit updates only that PR's alias. Other PR aliases still
+point to their own versions. The global GitHub concurrency lock serializes
+Cloudflare mutations, but it does not prevent several aliases from remaining
+available at the same time.
+
+The workflow creates the sticky PR marker before uploading, then records the
+URL, source branch, source commit, and CI run after verification. This means a
+later failure cannot hide an alias from the retirement job. When the PR closes,
+the same alias returns `410 Gone` and the comment is marked retired. Historical
+Worker versions remain Cloudflare account history; the retirement path prevents
+their PR aliases from continuing to serve the site.
+
+## Trust boundary
+
+The branch-controlled CI job never receives Cloudflare credentials. It builds,
+tests, and packages the artifact once.
+
+The credentialed workflow runs from the version committed to the default
+branch. Before upload it:
+
+- re-reads the successful CI run and exact open PR;
+- verifies same-repository ownership, non-draft state, branch, head SHA, and
+  current test-merge commit;
+- excludes Dependabot PRs from the credentialed preview path;
+- downloads rather than rebuilds the `worker-dist` artifact;
+- verifies both recorded checksums and manifest provenance;
+- compares the source build workflow blob with
+  `.github/trusted/worker-artifact-workflow.yml`;
+- rejects unsafe archive paths, links, and special files;
+- allowlists the generated Astro 6 Worker configuration;
+- rewrites only the fixed Worker name and explicit preview endpoint settings;
+- dry-runs the exact configuration before upload;
+- rechecks the CI run and PR immediately before the privileged upload; and
+- proves that the dedicated Worker has no route or custom domain and that its
+  latest version has no secret bindings and its active deployment did not
+  change.
+
+The upload uses `wrangler versions upload`, not `wrangler deploy`. Each preview
+is an inactive version addressed through its preview alias. The workflow does
+not bind any secret to PR-controlled code. Preview forms therefore validate in
+the browser and Worker, but they do not forward submissions to Segment or call
+Turnstile.
+
+## Required GitHub environment
+
+Create the `worker-pr-preview` environment only after the workflow PR has been
+reviewed.
+
+Configure:
+
+1. Deployment branches and tags: **Selected branches and tags**.
+2. The only branch rule: exactly `main`.
+3. No tag or pull-request deployment rule.
+4. Exactly these secret names:
+   - `CLOUDFLARE_ACCOUNT_ID`
+   - `CLOUDFLARE_WORKERS_PR_PREVIEW_TOKEN`
+
+The Cloudflare token needs account-scoped **Workers Scripts: Edit** for the
+ZenML account. Do not give this environment the Worker-routes token, production
+Worker token, DNS permissions, Pages permissions, or form secrets.
+
+Cloudflare does not offer per-Worker script-edit tokens. The trusted
+default-branch workflow, fixed Worker name, selected-`main` environment policy,
+and absence of route credentials are therefore enforcement controls.
+
+## First pilot and bootstrap
+
+GitHub only executes a new `workflow_run` or `workflow_dispatch` workflow after
+its definition exists on the default branch. The PR that introduces this
+workflow cannot publish its own preview through that workflow.
+
+After merging the reviewed workflow:
+
+1. Pause and confirm production, retained Pages, private migration Worker,
+   staging hostname, and platform-service hostnames match their recorded
+   baselines.
+2. Create or reuse one harmless same-repository, non-draft pilot PR based on
+   current `main`.
+3. Wait for its complete `Website CI and Worker Artifact` run to pass.
+4. Open **Actions → Publish Worker PR Preview → Run workflow** on `main`.
+5. Enter that open PR number and exact CI run ID.
+6. Check `allow_bootstrap` only after confirming
+   `zenml-io-v2-pr-preview` does not already exist.
+7. Check `self_reviewed`.
+
+That run uploads the exact pilot artifact and intentionally enables public
+version previews only for the new dedicated Worker. It must finish with:
+
+- `workers.dev` disabled;
+- version previews enabled;
+- no Worker route;
+- no custom domain;
+- no active-deployment change;
+- no secret bindings;
+- a working homepage;
+- a `404` response for an unknown path; and
+- one sticky preview comment on the pilot PR.
+
+Stop if the run reports that the Worker already exists with different endpoint
+settings or topology. Do not repair drift during the same run.
+
+## Manual acceptance
+
+For the pilot URL, check:
+
+- homepage, navigation, pricing, blog, Kitaru, and LLMOps pages;
+- representative assets and image optimization;
+- Pagefind search;
+- hydrated Preact islands;
+- `/api/github-stars`;
+- redirects, headers, and a real `404`;
+- desktop and narrow browser widths;
+- keyboard navigation and visible focus; and
+- browser console and network errors.
+
+Forms are deliberately non-operational in hosted PR previews. Client-side and
+Worker-side validation can be tested, but a successful response does not send
+data to Segment. Do not enter real user data or treat the preview as an
+end-to-end form test.
+
+## Prove multiple PR isolation
+
+After the first pilot is accepted:
+
+1. Create or reuse a second eligible same-repository PR.
+2. Let both PRs complete CI and publish previews.
+3. Confirm both `pr-<number>` URLs remain accessible and show their respective
+   commits.
+4. Push a harmless update to one PR.
+5. Confirm only its alias and sticky comment advance.
+6. Close the pilot PR and verify only its URL changes to `410 Gone`; the second
+   PR preview must remain available.
+
+Stop automatic use if aliases collide, another PR changes, a preview acquires a
+route or custom domain, production changes, or retirement affects another
+alias.
+
+## Failure and rollback
+
+- Before bootstrap, closing the implementation PR leaves Cloudflare unchanged.
+- A failed automatic upload leaves production unchanged. Inspect the evidence
+  artifact before retrying.
+- If bootstrap produces unexpected exposure or topology, disable preview URLs
+  only on `zenml-io-v2-pr-preview`, disable the automatic GitHub workflow, and
+  stop.
+- Never change `www.zenml.io/*`, `astro-workers-staging.zenml.io/*`, DNS,
+  retained Pages, the private migration Worker, or production deployment
+  percentages as part of PR-preview recovery.

--- a/docs/worker-pr-preview-runbook.md
+++ b/docs/worker-pr-preview-runbook.md
@@ -44,9 +44,10 @@ https://pr-<number>-zenml-io-v2-pr-preview.<account-subdomain>.workers.dev
 ```
 
 A new successful commit updates only that PR's alias. Other PR aliases still
-point to their own versions. The global GitHub concurrency lock serializes
-Cloudflare mutations, but it does not prevent several aliases from remaining
-available at the same time.
+point to their own versions. Per-PR publish and retirement queues prevent a new
+publish event from discarding a pending close event. A publish that was already
+running when the PR closed rechecks the PR after upload and replaces its own
+alias with a tombstone. Several aliases can remain available at the same time.
 
 The workflow creates the sticky PR marker before uploading, then records the
 URL, source branch, source commit, and CI run after verification. This means a

--- a/docs/worker-release-runbook.md
+++ b/docs/worker-release-runbook.md
@@ -7,7 +7,7 @@ available beneath that route as the deeper fallback. No release workflow
 attaches or removes a route, changes a custom domain, edits DNS, changes Access,
 or removes Pages.
 
-The release controls now have five paths:
+The release controls now have six paths:
 
 1. `Website CI and Worker Artifact` builds once without credentials, validates
    that output, and publishes the exact archive plus checksum and provenance.
@@ -30,12 +30,18 @@ The release controls now have five paths:
 5. `Activate Exact Worker Version` is manually dispatched from `main` with an
    exact version ID and matching provenance. It is also a retained pre-cutover
    control and intentionally refuses to activate a routed Worker.
+6. `Publish Worker PR Preview` consumes successful same-repository,
+   non-draft PR artifacts from trusted `main` and publishes stable public
+   aliases on the separate, route-less `zenml-io-v2-pr-preview` Worker. It
+   never rebuilds the artifact or receives production, route, DNS, or Pages
+   authority. See `docs/worker-pr-preview-runbook.md`.
 
 The automatic release is the normal post-cutover production path. The manual
 candidate and activation workflows are not post-cutover escape hatches until a
-separate reviewed change adapts their route predicates. Branch previews remain
-available; explicitly approved branch-built production promotion remains a
-separate follow-up.
+separate reviewed change adapts their route predicates. PR previews are
+review-only public versions on a dedicated Worker; they cannot promote a branch
+artifact to production. Explicitly approved branch-built production promotion
+remains a separate follow-up.
 
 During the Astro 6 implementation and staging checkpoint, the artifact manifest
 sets `production_release_eligible` to `false`. The automatic release eligibility

--- a/tests/config/deploymentWorkflows.test.ts
+++ b/tests/config/deploymentWorkflows.test.ts
@@ -17,6 +17,7 @@ import { REQUIRED_WORKER_SECRETS } from "../../scripts/check-worker-bindings";
 interface WorkflowStep {
   "continue-on-error"?: boolean;
   env?: Record<string, string>;
+  if?: string;
   name: string;
   run?: string;
 }
@@ -1615,7 +1616,7 @@ describe("automatic pull-request Worker previews", () => {
       "github.event.workflow_run.head_branch",
     );
     expect(prPreviewWorkflowConfig.concurrency?.group).toContain(
-      "format('pr-{0}', inputs.pr_number)",
+      "inputs.source_branch",
     );
     expect(prPreviewWorkflowConfig.jobs.publish.environment).toBe(
       "worker-pr-preview",
@@ -1725,7 +1726,7 @@ describe("automatic pull-request Worker previews", () => {
     expect(prPreviewWorkflow).toContain(
       "github.event_name == 'pull_request_target' && 'retire' || 'publish'",
     );
-    expect(prPreviewWorkflow).toContain("format('pr-{0}', inputs.pr_number)");
+    expect(prPreviewWorkflow).toContain("inputs.source_branch");
     expect(prPreviewWorkflow).toContain("cancel-in-progress: false");
     expect(prPreviewWorkflow).toContain(
       "The active PR-preview deployment changed",
@@ -1757,7 +1758,17 @@ describe("automatic pull-request Worker previews", () => {
     expect(closeCheckIndex).toBeGreaterThan(uploadIndex);
     expect(verifyIndex).toBeGreaterThan(closeCheckIndex);
 
+    const uploadRun = prPreviewPublishSteps[uploadIndex].run ?? "";
     const closeCheckRun = prPreviewPublishSteps[closeCheckIndex].run ?? "";
+    const closeCheck = prPreviewPublishSteps[closeCheckIndex];
+    const verify = prPreviewPublishSteps[verifyIndex];
+    expect(uploadRun).toMatch(
+      /set \+e\n\s*wrangler versions upload[\s\S]*?upload_status=\$\?\n\s*set -e\n\s*echo "upload_attempted=true" >> "\$GITHUB_OUTPUT"\n\s*if \[ "\$upload_status" -ne 0 \]; then\n\s*exit "\$upload_status"/,
+    );
+    expect(closeCheck.if).toBe(
+      "always() && steps.upload.outputs.upload_attempted == 'true'",
+    );
+    expect(verify.if).toBe("steps.upload.outcome == 'success'");
     expect(closeCheckRun).toContain(
       'gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .state',
     );
@@ -1765,6 +1776,19 @@ describe("automatic pull-request Worker previews", () => {
     expect(closeCheckRun).toContain("--strict");
     expect(closeCheckRun).toContain("status: 410");
     expect(closeCheckRun).toContain("exit 1");
+  });
+
+  it("keys manual and automatic publishes by the same verified source branch", () => {
+    expect(prPreviewWorkflow).toContain("source_branch:");
+    expect(prPreviewWorkflow).toContain(
+      "INPUT_SOURCE_BRANCH: $" + "{{ inputs.source_branch }}",
+    );
+    expect(prPreviewWorkflow).toContain(
+      '[ -n "$INPUT_SOURCE_BRANCH" ] && [ "$INPUT_SOURCE_BRANCH" != "$source_branch" ]',
+    );
+    expect(prPreviewWorkflow).toContain(
+      "The supplied source branch does not own this exact CI run.",
+    );
   });
 
   it("records retirement before upload and fails closed on comment lookup errors", () => {

--- a/tests/config/deploymentWorkflows.test.ts
+++ b/tests/config/deploymentWorkflows.test.ts
@@ -22,12 +22,20 @@ interface WorkflowStep {
 }
 
 interface ProductionWorkflow {
+  concurrency?: {
+    "cancel-in-progress": boolean;
+    group: string;
+  };
   jobs: Record<
     string,
     {
+      environment?: string;
+      if?: string;
+      permissions?: Record<string, string>;
       steps: WorkflowStep[];
     }
   >;
+  on?: Record<string, unknown>;
 }
 
 const deployWorkflow = readFileSync(".github/workflows/deploy.yml", "utf8");
@@ -47,6 +55,11 @@ const releaseWorkflow = readFileSync(
   ".github/workflows/release-worker.yml",
   "utf8",
 );
+const prPreviewWorkflow = readFileSync(
+  ".github/workflows/publish-pr-preview.yml",
+  "utf8",
+);
+const prPreviewWorkflowConfig = parse(prPreviewWorkflow) as ProductionWorkflow;
 const candidateWorkflowConfig = parse(candidateWorkflow) as ProductionWorkflow;
 const activationWorkflowConfig = parse(
   activationWorkflow,
@@ -57,6 +70,8 @@ const activationSteps = activationWorkflowConfig.jobs.activate.steps;
 const releaseUploadSteps = releaseWorkflowConfig.jobs.upload.steps;
 const releaseActivationSteps = releaseWorkflowConfig.jobs.activate.steps;
 const releaseRecoverySteps = releaseWorkflowConfig.jobs.recover.steps;
+const prPreviewPublishSteps = prPreviewWorkflowConfig.jobs.publish.steps;
+const prPreviewRetireSteps = prPreviewWorkflowConfig.jobs.retire.steps;
 const allWorkflows = readdirSync(".github/workflows")
   .filter((filename) => filename.endsWith(".yml"))
   .map(
@@ -1569,6 +1584,185 @@ describe("automatic post-cutover production release", () => {
     expect(finalReadFailure.deploymentReadCalls).toBe(4);
     expect(finalReadFailure.stderr).toContain(
       "Could not read the active production version after homepage verification; recovery did not complete.",
+    );
+  });
+});
+
+describe("automatic pull-request Worker previews", () => {
+  it("parses as one publish job and one guarded retirement job", () => {
+    expect(Object.keys(prPreviewWorkflowConfig.jobs).sort()).toEqual([
+      "publish",
+      "retire",
+    ]);
+    expect(Object.keys(prPreviewWorkflowConfig.on ?? {}).sort()).toEqual([
+      "pull_request_target",
+      "workflow_dispatch",
+      "workflow_run",
+    ]);
+    expect(prPreviewWorkflowConfig.concurrency).toEqual({
+      group: "zenml-io-worker-pr-preview",
+      "cancel-in-progress": false,
+    });
+    expect(prPreviewWorkflowConfig.jobs.publish.environment).toBe(
+      "worker-pr-preview",
+    );
+    expect(prPreviewWorkflowConfig.jobs.retire.environment).toBe(
+      "worker-pr-preview",
+    );
+    expect(prPreviewWorkflowConfig.jobs.publish.permissions).toEqual({
+      actions: "read",
+      contents: "read",
+      issues: "write",
+      "pull-requests": "read",
+    });
+    expect(prPreviewWorkflowConfig.jobs.retire.permissions).toEqual({
+      contents: "read",
+      issues: "write",
+      "pull-requests": "read",
+    });
+    expect(prPreviewWorkflowConfig.jobs.publish.if).toContain(
+      "github.ref == 'refs/heads/main'",
+    );
+    expect(prPreviewWorkflowConfig.jobs.retire.if).toContain(
+      "github.event.pull_request.head.repo.full_name == github.repository",
+    );
+  });
+
+  it("publishes only exact successful same-repository PR artifacts from trusted main", () => {
+    expect(prPreviewWorkflow).toContain("workflow_run:");
+    expect(prPreviewWorkflow).toContain(
+      'workflows: ["Website CI and Worker Artifact"]',
+    );
+    expect(prPreviewWorkflow).toContain("types: [completed]");
+    expect(prPreviewWorkflow).toContain("workflow_dispatch:");
+    expect(prPreviewWorkflow).toContain("pull_request_target:");
+    expect(prPreviewWorkflow).toContain("types: [closed]");
+    expect(prPreviewWorkflow).toContain(
+      ".head_repository.full_name == $repository",
+    );
+    expect(prPreviewWorkflow).toContain('.event == "pull_request"');
+    expect(prPreviewWorkflow).toContain('.conclusion == "success"');
+    expect(prPreviewWorkflow).toContain('.state == "open"');
+    expect(prPreviewWorkflow).toContain(".draft == false");
+    expect(prPreviewWorkflow).toContain('.user.login != "dependabot[bot]"');
+    expect(prPreviewWorkflow).toContain(".merge_commit_sha == $build_commit");
+    expect(prPreviewWorkflow).toContain(
+      ".github/trusted/worker-artifact-workflow.yml",
+    );
+  });
+
+  it("uploads the exact validated artifact to one route-less dedicated Worker with a stable per-PR alias", () => {
+    expect(prPreviewWorkflow).toContain("WORKER_NAME: zenml-io-v2-pr-preview");
+    expect(prPreviewWorkflow).toContain("actions/download-artifact@");
+    expect(prPreviewWorkflow).toContain("sha256sum --check");
+    expectArtifactGuards(prPreviewWorkflow);
+    expect(prPreviewWorkflow).toContain("preview_urls: true");
+    expect(prPreviewWorkflow).toContain("workers_dev: false");
+    expect(prPreviewWorkflow).toContain('--preview-alias "pr-$PR_NUMBER"');
+    expect(prPreviewWorkflow).toMatch(
+      /wrangler versions upload[\s\S]*?--config dist\/server\/upload-wrangler\.json[\s\S]*?--strict[\s\S]*?--preview-alias "pr-\$PR_NUMBER"/,
+    );
+    expect(prPreviewWorkflow).toContain(
+      'preview_url="https://pr-$PR_NUMBER-$WORKER_NAME.$workers_subdomain.workers.dev"',
+    );
+    expect(prPreviewWorkflow).not.toContain("pnpm build");
+    expect(prPreviewWorkflow).not.toContain("actions/checkout@");
+    expect(prPreviewWorkflow).not.toContain("wrangler deploy ");
+    expect(prPreviewWorkflow).not.toContain("wrangler pages deploy");
+    expectNoRouteOrDnsMutation(prPreviewWorkflow);
+  });
+
+  it("keeps credentials and secret bindings out of PR-controlled preview code", () => {
+    expect(prPreviewWorkflow).toContain("environment: worker-pr-preview");
+    expect(prPreviewWorkflow).toContain("CLOUDFLARE_WORKERS_PR_PREVIEW_TOKEN");
+    expect(prPreviewWorkflow).not.toContain(
+      "PR_PREVIEW_SEGMENT_FORMS_WRITE_KEY",
+    );
+    expect(prPreviewWorkflow).not.toContain("PR_PREVIEW_TURNSTILE_SECRET_KEY");
+    expect(prPreviewWorkflow).not.toContain("--secrets-file");
+    expect(prPreviewWorkflow).toContain(
+      '[.resources.bindings[]? | select(.type == "secret_text")] == []',
+    );
+    const baselineRun =
+      workflowStep(prPreviewPublishSteps, "Verify dedicated Worker baseline")
+        .run ?? "";
+    expect(baselineRun).toContain("wrangler versions list");
+    expect(baselineRun).toContain("wrangler versions view");
+    expect(baselineRun).toContain(
+      '[.resources.bindings[]? | select(.type == "secret_text")] == []',
+    );
+    expect(prPreviewWorkflow).not.toContain(
+      "CLOUDFLARE_WORKERS_PRODUCTION_TOKEN",
+    );
+    expect(prPreviewWorkflow).not.toContain("CLOUDFLARE_WORKERS_ROUTES_TOKEN");
+    expect(prPreviewWorkflow).not.toContain(
+      "SEGMENT_FORMS_WRITE_KEY: $" + "{{ secrets.SEGMENT_FORMS_WRITE_KEY }}",
+    );
+    expect(prPreviewWorkflow).not.toContain(
+      "TURNSTILE_SECRET_KEY: $" + "{{ secrets.TURNSTILE_SECRET_KEY }}",
+    );
+  });
+
+  it("serializes mutations, preserves deployments, posts a sticky URL, and retires closed PR aliases", () => {
+    expect(prPreviewWorkflow).toContain("group: zenml-io-worker-pr-preview");
+    expect(prPreviewWorkflow).toContain("cancel-in-progress: false");
+    expect(prPreviewWorkflow).toContain(
+      "The active PR-preview deployment changed",
+    );
+    expect(prPreviewWorkflow).toContain("<!-- zenml-worker-pr-preview -->");
+    expect(prPreviewWorkflow).toContain('.user.login == "github-actions[bot]"');
+    expect(prPreviewWorkflow).toContain("--paginate");
+    expect(prPreviewWorkflow).toContain("Record preview retirement marker");
+    expect(prPreviewWorkflow).toContain(
+      "Multiple PR-preview marker comments exist",
+    );
+    expect(prPreviewWorkflow).toContain("PR preview retired");
+    expect(prPreviewWorkflow).toContain('--preview-alias "pr-$PR_NUMBER"');
+    expect(prPreviewWorkflow).toContain("return new Response");
+    expect(prPreviewWorkflow).toContain("status: 410");
+  });
+
+  it("records retirement before upload and fails closed on comment lookup errors", () => {
+    const markerIndex = prPreviewPublishSteps.findIndex(
+      (step) => step.name === "Record preview retirement marker",
+    );
+    const uploadIndex = prPreviewPublishSteps.findIndex(
+      (step) => step.name === "Upload exact version with stable PR alias",
+    );
+    expect(markerIndex).toBeGreaterThan(-1);
+    expect(uploadIndex).toBeGreaterThan(markerIndex);
+
+    const markerRun = prPreviewPublishSteps[markerIndex].run ?? "";
+    const retirementCheckRun =
+      workflowStep(prPreviewRetireSteps, "Check whether this PR had a preview")
+        .run ?? "";
+    for (const run of [markerRun, retirementCheckRun]) {
+      expect(run).toContain("gh api");
+      expect(run).toContain("--paginate");
+      expect(run).toContain('> "$RUNNER_TEMP/pr-preview-comment-ids.txt"');
+      expect(run).toContain(
+        'mapfile -t comment_ids < "$RUNNER_TEMP/pr-preview-comment-ids.txt"',
+      );
+      expect(run).not.toContain("< <(");
+    }
+  });
+
+  it("uses strict mode on every state-changing preview-alias upload", () => {
+    const publishRun =
+      workflowStep(
+        prPreviewPublishSteps,
+        "Upload exact version with stable PR alias",
+      ).run ?? "";
+    const retireRun =
+      workflowStep(
+        prPreviewRetireSteps,
+        "Replace the closed PR alias with a tombstone",
+      ).run ?? "";
+    expect(publishRun).toMatch(
+      /wrangler versions upload \\\n\s+--config dist\/server\/upload-wrangler\.json \\\n\s+--strict \\\n\s+--preview-alias "pr-\$PR_NUMBER"/,
+    );
+    expect(retireRun).toMatch(
+      /wrangler versions upload \\\n\s+--config "\$retire_dir\/wrangler\.json" \\\n\s+--strict \\\n\s+--preview-alias "pr-\$PR_NUMBER"/,
     );
   });
 });

--- a/tests/config/deploymentWorkflows.test.ts
+++ b/tests/config/deploymentWorkflows.test.ts
@@ -1599,10 +1599,24 @@ describe("automatic pull-request Worker previews", () => {
       "workflow_dispatch",
       "workflow_run",
     ]);
-    expect(prPreviewWorkflowConfig.concurrency).toEqual({
-      group: "zenml-io-worker-pr-preview",
-      "cancel-in-progress": false,
-    });
+    expect(prPreviewWorkflowConfig.concurrency?.["cancel-in-progress"]).toBe(
+      false,
+    );
+    expect(prPreviewWorkflowConfig.concurrency?.group).toContain(
+      "zenml-io-worker-pr-preview-",
+    );
+    expect(prPreviewWorkflowConfig.concurrency?.group).toContain(
+      "github.event_name == 'pull_request_target' && 'retire' || 'publish'",
+    );
+    expect(prPreviewWorkflowConfig.concurrency?.group).toContain(
+      "github.event.pull_request.head.ref",
+    );
+    expect(prPreviewWorkflowConfig.concurrency?.group).toContain(
+      "github.event.workflow_run.head_branch",
+    );
+    expect(prPreviewWorkflowConfig.concurrency?.group).toContain(
+      "format('pr-{0}', inputs.pr_number)",
+    );
     expect(prPreviewWorkflowConfig.jobs.publish.environment).toBe(
       "worker-pr-preview",
     );
@@ -1704,7 +1718,14 @@ describe("automatic pull-request Worker previews", () => {
   });
 
   it("serializes mutations, preserves deployments, posts a sticky URL, and retires closed PR aliases", () => {
-    expect(prPreviewWorkflow).toContain("group: zenml-io-worker-pr-preview");
+    expect(prPreviewWorkflow).toContain("github.event.pull_request.head.ref");
+    expect(prPreviewWorkflow).toContain(
+      "github.event.workflow_run.head_branch",
+    );
+    expect(prPreviewWorkflow).toContain(
+      "github.event_name == 'pull_request_target' && 'retire' || 'publish'",
+    );
+    expect(prPreviewWorkflow).toContain("format('pr-{0}', inputs.pr_number)");
     expect(prPreviewWorkflow).toContain("cancel-in-progress: false");
     expect(prPreviewWorkflow).toContain(
       "The active PR-preview deployment changed",
@@ -1720,6 +1741,30 @@ describe("automatic pull-request Worker previews", () => {
     expect(prPreviewWorkflow).toContain('--preview-alias "pr-$PR_NUMBER"');
     expect(prPreviewWorkflow).toContain("return new Response");
     expect(prPreviewWorkflow).toContain("status: 410");
+  });
+
+  it("cannot let an in-flight publish resurrect a closed PR alias", () => {
+    const uploadIndex = prPreviewPublishSteps.findIndex(
+      (step) => step.name === "Upload exact version with stable PR alias",
+    );
+    const closeCheckIndex = prPreviewPublishSteps.findIndex(
+      (step) => step.name === "Retire alias if the PR closed during upload",
+    );
+    const verifyIndex = prPreviewPublishSteps.findIndex(
+      (step) => step.name === "Verify isolated public preview",
+    );
+    expect(uploadIndex).toBeGreaterThan(-1);
+    expect(closeCheckIndex).toBeGreaterThan(uploadIndex);
+    expect(verifyIndex).toBeGreaterThan(closeCheckIndex);
+
+    const closeCheckRun = prPreviewPublishSteps[closeCheckIndex].run ?? "";
+    expect(closeCheckRun).toContain(
+      'gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .state',
+    );
+    expect(closeCheckRun).toContain('--preview-alias "pr-$PR_NUMBER"');
+    expect(closeCheckRun).toContain("--strict");
+    expect(closeCheckRun).toContain("status: 410");
+    expect(closeCheckRun).toContain("exit 1");
   });
 
   it("records retirement before upload and fails closed on comment lookup errors", () => {


### PR DESCRIPTION
## Summary

Successful same-repository pull requests can now receive stable, isolated Cloudflare Worker preview URLs without rebuilding their validated CI artifact or changing production traffic.

Each PR uses its own `pr-<number>` alias on a dedicated route-less Worker, so several previews can remain available at once. Closing a PR replaces its alias with a `410 Gone` tombstone.

## Safety design

- The credentialed workflow runs only from `main`, rejects drafts, forks, Dependabot, stale heads, and ambiguous PR matches, and rechecks eligibility immediately before upload.
- PR-controlled Worker code receives no secrets. Preview forms validate but do not send data to Segment or call Turnstile.
- The workflow verifies artifact checksums and trusted build provenance, allowlists the generated Astro 6 Worker configuration, and uses strict inactive version uploads rather than `wrangler deploy`.
- A durable sticky marker is written before upload, so a later failure cannot leave an untracked alias. Comment lookup is paginated and fails closed.
- Publish and retirement use separate per-PR lifecycle queues, so newer publishes may supersede older publishes but can never discard a pending close event. An in-flight publish also tombstones itself if the PR closes during upload.
- Before and after each mutation, the workflow proves that the dedicated Worker has no routes, custom domains, secret bindings, or active-deployment changes.

## What reviewers should focus on

- The `workflow_run`, manual bootstrap, and `pull_request_target` trust boundaries.
- Secret inheritance prevention before and after upload.
- Alias retirement behavior when publishing or comment updates fail.
- The explicit separation from production Worker, routes, DNS, Pages, and release credentials.

## Validation

- `actionlint -shellcheck shellcheck .github/workflows/publish-pr-preview.yml`
- `pnpm exec prettier --check .github/workflows/publish-pr-preview.yml`
- `pnpm check`
- `pnpm check:tests`
- `pnpm check:surface`
- `pnpm check:alt`
- `pnpm lint`
- `pnpm test` (176 passed)
- `pnpm build`
- `pnpm smoke:dist`
- `pnpm check:worker` (18 passed)
- `pnpm check:islands` (4 passed)
- Three independent workflow reviews, followed by a final re-review with no remaining P1/P2 findings.

The local machine used Node 26 and emitted the repository's engine warning; CI will provide the authoritative Node 22.23.1 result.

## Merge and rollout behavior

Merging this PR does not change production traffic or create Cloudflare resources. The introducing PR cannot preview itself because GitHub only runs this trusted workflow after it exists on `main`.

After merge, we will pause before configuring the `worker-pr-preview` GitHub environment or creating the dedicated Cloudflare Worker. A separate reviewed bootstrap run will publish one harmless pilot PR, followed by manual testing and a two-PR alias-isolation check.

## Post-Deploy Monitoring & Validation

Before the later bootstrap, no additional runtime monitoring is required because this PR alone cannot reach Cloudflare. For the separately approved pilot, the operator will watch the `Publish Worker PR Preview` job and its evidence artifact, confirm the sticky URL returns `200` and an unknown path returns `404`, verify the dedicated Worker remains route-less with no custom domains, secrets, or active deployment, and manually close the pilot to confirm `410 Gone`.

Healthy signal: only `zenml-io-v2-pr-preview` receives an inactive aliased version and production remains unchanged. Stop and disable the preview workflow if topology, bindings, active deployment state, another PR alias, or any production hostname changes. The pilot validation window runs through upload, manual browser acceptance, PR close, and retirement verification; Alex and the migration agent are the owners.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
