### PR TITLE
Fix Worker preview baseline check

### DIFF
--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -348,7 +348,7 @@ jobs:
             --argjson allow_absent "$([ "$status" = "404" ] && echo true || echo false)" \
             --arg worker "$WORKER_NAME" '
               .success == true and
-              ([.result[] | select(.id == $worker)]) as $workers and
+              ([.result[] | select(.id == $worker)]) as $workers |
               (
                 ($allow_absent and ($workers | length) == 0) or
                 (


### PR DESCRIPTION
## Summary

Fix the trusted PR-preview baseline guard so jq binds the matching Worker list before evaluating the topology conditions.

The first pilot exposed this syntax error before any Worker upload. This one-line correction lets the reviewed manual bootstrap proceed while preserving every existing provenance, credential, and topology check.

## What reviewers should focus on

- Confirm the jq binding uses `|` after `as $workers`.
- Confirm no preview permission, mutation, or trust-boundary behavior changes.
- The separate pilot PR #191 remains open and must not be merged.

## Validation

- `actionlint .github/workflows/publish-pr-preview.yml`
- Parsed the workflow with the repository's `yaml` package and Ruby YAML parser.
- Evaluated the corrected jq expression against the absent-Worker bootstrap case.
- Searched trusted workflows for any other `as $variable and` occurrence; none remain.
- `git diff --check`

After this PR is merged, the existing successful pilot artifact from CI run `30473076741` can be dispatched again without rebuilding it.
