### PR TITLE
Allow Worker preview PR comments

### DIFF
--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -67,8 +67,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-      issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Resolve one current eligible pull request
         id: source
@@ -755,8 +754,7 @@ jobs:
     environment: worker-pr-preview
     permissions:
       contents: read
-      issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Check whether this PR had a preview
         id: preview

--- a/tests/config/deploymentWorkflows.test.ts
+++ b/tests/config/deploymentWorkflows.test.ts
@@ -1627,13 +1627,11 @@ describe("automatic pull-request Worker previews", () => {
     expect(prPreviewWorkflowConfig.jobs.publish.permissions).toEqual({
       actions: "read",
       contents: "read",
-      issues: "write",
-      "pull-requests": "read",
+      "pull-requests": "write",
     });
     expect(prPreviewWorkflowConfig.jobs.retire.permissions).toEqual({
       contents: "read",
-      issues: "write",
-      "pull-requests": "read",
+      "pull-requests": "write",
     });
     expect(prPreviewWorkflowConfig.jobs.publish.if).toContain(
       "github.ref == 'refs/heads/main'",


### PR DESCRIPTION
## Summary

Allow the trusted PR-preview jobs to create and update their sticky comments on pull requests.

The first reviewed bootstrap reached the retirement-marker step but GitHub rejected the comment with `403 Resource not accessible by integration`. These jobs only comment on pull requests, so this change replaces unused `issues: write` access and `pull-requests: read` with the narrower effective permission, `pull-requests: write`.

The workflow contract tests now require the same least-privilege permission shape for both the publish and retirement jobs.

## What reviewers should focus on

- Confirm both the publish and retirement jobs receive PR-comment write access.
- Confirm `issues: write` is removed rather than retained as an additional permission.
- Confirm the test protects the updated permission contract.
- Confirm no Cloudflare permission, upload behavior, or production topology changes.

## Validation

- `pnpm exec vitest run tests/config/deploymentWorkflows.test.ts` — 60 passed.
- `pnpm test` — 176 passed.
- `pnpm check:tests`
- `pnpm lint`
- `actionlint .github/workflows/publish-pr-preview.yml`
- Parsed the workflow with the repository's `yaml` package and Ruby YAML parser.
- `git diff --check`

After this PR is merged, the current successful pilot artifact from CI run `30474589052` can be dispatched again without rebuilding it.
