### PR TITLE
Retry Worker preview retirement verification

### DIFF
--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -933,7 +933,31 @@ jobs:
               jq -er '.result.subdomain'
           )"
           preview_url="https://pr-$PR_NUMBER-$WORKER_NAME.$workers_subdomain.workers.dev"
-          test "$(curl --connect-timeout 10 --max-time 30 --silent --show-error --output /dev/null --write-out "%{http_code}" "$preview_url/")" = "410"
+          retired_status=""
+          for attempt in {1..10}; do
+            retired_status="$(
+              curl \
+                --connect-timeout 10 \
+                --max-time 30 \
+                --silent \
+                --show-error \
+                --output /dev/null \
+                --write-out "%{http_code}" \
+                "$preview_url/" ||
+                true
+            )"
+            if [ "$retired_status" = "410" ]; then
+              break
+            fi
+            if [ "$attempt" -lt 10 ]; then
+              echo "Retirement is still propagating (attempt $attempt/10, HTTP ${retired_status:-unavailable}); retrying in 3 seconds."
+              sleep 3
+            fi
+          done
+          if [ "$retired_status" != "410" ]; then
+            echo "PR preview alias did not retire after 10 attempts (last HTTP ${retired_status:-unavailable})." >&2
+            exit 1
+          fi
           echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
 
       - name: Mark sticky preview comment retired

--- a/tests/config/deploymentWorkflows.test.ts
+++ b/tests/config/deploymentWorkflows.test.ts
@@ -1742,6 +1742,26 @@ describe("automatic pull-request Worker previews", () => {
     expect(prPreviewWorkflow).toContain("status: 410");
   });
 
+  it("allows bounded propagation time before failing retirement verification", () => {
+    const verifyRetiredRun =
+      workflowStep(
+        prPreviewRetireSteps,
+        "Verify the alias is retired without deployment changes",
+      ).run ?? "";
+    expect(verifyRetiredRun).toContain("for attempt in {1..10}");
+    expect(verifyRetiredRun).toContain(
+      'if [ "$retired_status" = "410" ]; then',
+    );
+    expect(verifyRetiredRun).toContain('if [ "$attempt" -lt 10 ]; then');
+    expect(verifyRetiredRun).toContain("sleep 3");
+    expect(verifyRetiredRun).toContain(
+      "PR preview alias did not retire after 10 attempts",
+    );
+    expect(verifyRetiredRun).toContain(
+      'if [ "$retired_status" != "410" ]; then',
+    );
+  });
+
   it("cannot let an in-flight publish resurrect a closed PR alias", () => {
     const uploadIndex = prPreviewPublishSteps.findIndex(
       (step) => step.name === "Upload exact version with stable PR alias",


### PR DESCRIPTION
## Summary

Closing a PR no longer reports a false retirement failure when Cloudflare needs a few seconds to propagate the tombstone alias.

The retirement verifier now retries the public URL ten times with three-second pauses, records the latest HTTP result, and still fails closed unless it observes `410 Gone`. Deployment-preservation checks remain unchanged and run before the URL check.

## What reviewers should focus on

- The retry is bounded and accepts only `410`.
- Transient request failures are retried but cannot produce a successful workflow.
- This does not change uploads, aliases, credentials, routes, DNS, custom domains, or production releases.

## Validation

- `pnpm exec vitest run tests/config/deploymentWorkflows.test.ts` (61 tests passed)
- `pnpm test` (177 tests passed)
- `pnpm check:tests`
- `pnpm lint`
- `actionlint .github/workflows/publish-pr-preview.yml`
- Parsed the workflow with both the repository `yaml` package and Ruby YAML
- `pnpm exec prettier --check .github/workflows/publish-pr-preview.yml`
- `git diff --check`

After this reaches `main`, the follow-up acceptance test will run two simultaneous PR preview aliases, update only one, retire one, and verify that the other remains unchanged.
