### PR TITLE
Guarantee GitHub stars timeout fallback

### DIFF
--- a/src/lib/githubStars.ts
+++ b/src/lib/githubStars.ts
@@ -131,9 +131,7 @@ export async function fetchGithubStarsFromGitHub({
   apiUrl?: string;
 } = {}): Promise<GithubStarsFetchResult> {
   const controller = new AbortController();
-  const timeoutId: ReturnType<typeof setTimeout> = setTimeout(() => {
-    controller.abort();
-  }, timeoutMs);
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
   try {
     const headers: Record<string, string> = {
@@ -145,10 +143,22 @@ export async function fetchGithubStarsFromGitHub({
       headers.Authorization = `Bearer ${token}`;
     }
 
-    const response = await fetchImpl(apiUrl, {
-      headers,
-      signal: controller.signal,
-    });
+    const response = await Promise.race([
+      fetchImpl(apiUrl, {
+        headers,
+        signal: controller.signal,
+      }),
+      new Promise<null>((resolveTimeout) => {
+        timeoutId = setTimeout(() => {
+          controller.abort();
+          resolveTimeout(null);
+        }, timeoutMs);
+      }),
+    ]);
+
+    if (response === null) {
+      return { ok: false };
+    }
 
     if (!response.ok) {
       return { ok: false, status: response.status };
@@ -164,6 +174,8 @@ export async function fetchGithubStarsFromGitHub({
   } catch {
     return { ok: false };
   } finally {
-    clearTimeout(timeoutId);
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
   }
 }

--- a/tests/lib/githubStars.test.ts
+++ b/tests/lib/githubStars.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchGithubStarsFromGitHub } from "../../src/lib/githubStars";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("fetchGithubStarsFromGitHub", () => {
+  it("returns the fallback result when fetch ignores the abort signal", async () => {
+    vi.useFakeTimers();
+    const requestSignals: AbortSignal[] = [];
+    const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
+      requestSignals.push(init?.signal as AbortSignal);
+      return await new Promise<Response>(() => {});
+    });
+
+    const resultPromise = fetchGithubStarsFromGitHub({
+      fetchImpl,
+      timeoutMs: 2_000,
+    });
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await expect(resultPromise).resolves.toEqual({ ok: false });
+    expect(requestSignals[0]?.aborted).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

The GitHub-stars endpoint now returns its existing safe fallback on schedule even when the Worker runtime’s outbound fetch does not settle after receiving an abort signal.

The previous timeout called `abort()` but then continued waiting for the fetch promise. Three consecutive CI runs for preview pilot B therefore stalled until the outer Worker-runtime check failed after ten seconds. The timeout now races the fetch directly, while still aborting the underlying request, and a regression test covers a fetch that ignores abort indefinitely.

## What reviewers should focus on

- A successful or failed GitHub response keeps the existing behavior.
- The explicit timeout returns `{ ok: false }`, which the API already converts into its safe cached fallback response.
- The outstanding request is still aborted, and the timer is cleared when either path settles first.

## Validation

- `pnpm exec vitest run tests/lib/githubStars.test.ts tests/api/github-stars.test.ts` (4 tests passed)
- `pnpm test` (178 tests passed)
- `pnpm check:tests`
- `pnpm lint`
- `pnpm build`
- `pnpm check:worker` (18 Worker runtime checks passed)
- `git diff --check`

## Acceptance context

This was found while running the do-not-merge multi-PR preview pilots #195 and #196. Pilot A published successfully, while pilot B failed the same `/api/github-stars` runtime probe on three independent CI attempts before any preview upload.

Related: #195

Related: #196
