### PR TITLE
Enable Astro 6 production releases

### DIFF
--- a/.github/trusted/worker-artifact-workflow.yml
+++ b/.github/trusted/worker-artifact-workflow.yml
@@ -135,7 +135,7 @@ jobs:
             --arg event_name "$EVENT_NAME" \
             --arg generated_config_sha256 "$generated_config_sha256" \
             --arg lockfile_sha256 "$(sha256sum pnpm-lock.yaml | cut -d ' ' -f 1)" \
-            --argjson production_release_eligible false \
+            --argjson production_release_eligible true \
             --arg run_attempt "$RUN_ATTEMPT" \
             --arg run_id "$RUN_ID" \
             --arg source_branch "$SOURCE_BRANCH" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -135,7 +135,7 @@ jobs:
             --arg event_name "$EVENT_NAME" \
             --arg generated_config_sha256 "$generated_config_sha256" \
             --arg lockfile_sha256 "$(sha256sum pnpm-lock.yaml | cut -d ' ' -f 1)" \
-            --argjson production_release_eligible false \
+            --argjson production_release_eligible true \
             --arg run_attempt "$RUN_ATTEMPT" \
             --arg run_id "$RUN_ID" \
             --arg source_branch "$SOURCE_BRANCH" \

--- a/docs/worker-release-runbook.md
+++ b/docs/worker-release-runbook.md
@@ -43,11 +43,11 @@ review-only public versions on a dedicated Worker; they cannot promote a branch
 artifact to production. Explicitly approved branch-built production promotion
 remains a separate follow-up.
 
-During the Astro 6 implementation and staging checkpoint, the artifact manifest
-sets `production_release_eligible` to `false`. The automatic release eligibility
-job reads that flag without entering a credentialed GitHub environment and
-stops successfully before upload. Change the flag only in a separate reviewed
-PR after the Astro 6 preview and staging evidence has been accepted.
+The Astro 6 private-preview and protected-staging checkpoints were accepted on
+2026-07-29. The artifact manifest now sets `production_release_eligible` to
+`true`, so each exact successful current-`main` artifact may continue into the
+trusted automatic production release. Changing this gate again requires a
+separate reviewed PR.
 
 ## Automatic current-main release
 

--- a/tests/config/deploymentWorkflows.test.ts
+++ b/tests/config/deploymentWorkflows.test.ts
@@ -1133,7 +1133,7 @@ describe("automatic post-cutover production release", () => {
     expect(releaseWorkflow).toContain("eligible=false");
     expect(releaseWorkflow).toContain(".production_release_eligible == true");
     expect(deployWorkflow).toContain(
-      "--argjson production_release_eligible false",
+      "--argjson production_release_eligible true",
     );
   });
 

--- a/tests/config/workerPreviewControlPlane.test.ts
+++ b/tests/config/workerPreviewControlPlane.test.ts
@@ -405,7 +405,7 @@ describe("preview Worker upload workflow", () => {
       )
       .digest("hex");
 
-    expect(gitBlobSha).toBe("88361354fdff64b8a1174b80ce112a462cd22378");
+    expect(gitBlobSha).toBe("c6ab87cc03335b38d2d35c75efce878e4cea4f13");
     expect(trustedArtifactWorkflowText).toBe(artifactWorkflowText);
     expect(trustedArtifactWorkflowText).toContain(
       "name: Website CI and Worker Artifact",


### PR DESCRIPTION
## Summary

Allow the accepted Astro 6 build to enter the existing automatic production release after a successful `main` CI run.

The private Worker upload, exact-version activation, protected staging route, and manual staging review all passed. Merging this PR will not switch traffic immediately: the resulting `main` artifact must pass CI, then the trusted release workflow uploads it inactive, rechecks provenance and topology, activates it, smoke-tests production, and restores the current Astro 5 version if activation or verification fails.

## Changes

- Mark exact validated artifacts as eligible for automatic production release in both the branch-controlled producer and its trusted mirror.
- Preserve the mirror-integrity assertion by pinning the reviewed workflow's new Git blob SHA.
- Update the release contract test and runbook to reflect the accepted Astro 6 staging checkpoint.

## Reviewer focus

- Confirm that the two workflow definitions remain byte-for-byte identical and that the only runtime policy change is `production_release_eligible: true`.
- Confirm that the existing release workflow still owns inactive upload, topology and binding checks, exact-version activation, production smoke tests, and automatic restoration of the previous version.
- Treat merging as approval for the first automatic Astro 6 production release after green `main` CI.

## Validation

- `pnpm check`
- `pnpm check:tests`
- `pnpm check:surface`
- `pnpm check:alt`
- `pnpm lint`
- `pnpm test` (178 tests)
- `pnpm build`
- `pnpm smoke:dist`
- `pnpm check:worker` (18 runtime checks)
- `pnpm check:islands` (4 browser hydration checks)
- Workflow mirror comparison, Git blob pin verification, Prettier, and `git diff --check`
- Astro 6 private upload run `30489982813`, private activation run `30490308245`, protected staging verification, and manual staging review all passed

Related: #128
