### PR TITLE
Fix production Worker route baseline

### DIFF
--- a/.github/workflows/release-worker.yml
+++ b/.github/workflows/release-worker.yml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  ACCEPTED_WORKER_ROUTES_JSON: '["astro-workers-staging.zenml.io/*","www.zenml.io/*"]'
+  ACCEPTED_WORKER_ROUTES_JSON: '["www.zenml.io/*"]'
   WORKER_NAME: zenml-io-v2-worker
 
 jobs:

--- a/docs/worker-release-runbook.md
+++ b/docs/worker-release-runbook.md
@@ -75,8 +75,10 @@ credentials.
 Before upload, the workflow requires:
 
 - one active Worker version at 100 percent;
-- exactly the accepted `astro-workers-staging.zenml.io/*` and
-  `www.zenml.io/*` route patterns;
+- exactly the accepted `www.zenml.io/*` production route pattern;
+- no production ownership of the protected
+  `astro-workers-staging.zenml.io/*` route, which belongs to the preview
+  Worker;
 - disabled `workers.dev` and version preview endpoints;
 - no Worker custom domains; and
 - both required production form secrets.

--- a/tests/config/deploymentWorkflows.test.ts
+++ b/tests/config/deploymentWorkflows.test.ts
@@ -578,7 +578,7 @@ function expectPrivateWorkerPredicates(
 
 function expectAcceptedWorkerRoutePredicate(run: string, source: string): void {
   const program = jqProgramReadingFrom(run, source);
-  const acceptedRoutes = ["www.zenml.io/*", "astro-workers-staging.zenml.io/*"];
+  const acceptedRoutes = ["www.zenml.io/*"];
   const workerArgs = [
     "--arg",
     "worker",
@@ -642,7 +642,7 @@ function expectAcceptedWorkerRoutePredicate(run: string, source: string): void {
       result: [
         {
           id: "zenml-io-v2-worker",
-          routes: ["www.zenml.io/*"],
+          routes: ["www.zenml.io/*", "astro-workers-staging.zenml.io/*"],
         },
       ],
       success: true,
@@ -1176,8 +1176,8 @@ describe("automatic post-cutover production release", () => {
   });
 
   it("requires the accepted route topology and private Worker endpoints", () => {
-    expect(releaseWorkflow).toContain("astro-workers-staging.zenml.io/*");
     expect(releaseWorkflow).toContain("www.zenml.io/*");
+    expect(releaseWorkflow).not.toContain("astro-workers-staging.zenml.io/*");
     expect(releaseWorkflow).toContain(
       ".result.enabled == false and .result.previews_enabled == false",
     );


### PR DESCRIPTION
## Summary

Allow the accepted Astro 6 production release to pass its pre-upload safety check after the protected staging route intentionally moved to the preview Worker.

The first release attempt stopped before upload because the production baseline still expected both `www.zenml.io/*` and `astro-workers-staging.zenml.io/*`. Production now correctly owns only `www.zenml.io/*`; staging remains isolated on `zenml-io-v2-worker-preview`.

## Changes

- Narrow the production Worker route allowlist to `www.zenml.io/*`.
- Add a regression case that rejects the stale two-route production topology.
- Update the release runbook to record the current production and staging ownership.

## Reviewer focus

- Confirm this changes only the topology accepted by the release preflight and does not mutate Cloudflare routes, DNS, Workers, or traffic.
- Confirm every existing upload, provenance, binding, activation, smoke-test, and rollback guard remains intact.

## Validation

- `pnpm check`
- `pnpm check:tests`
- `pnpm check:surface`
- `pnpm check:alt`
- `pnpm lint`
- `pnpm test` (178 passed)
- `pnpm build`
- `pnpm smoke:dist`
- `pnpm check:worker` (18 passed)
- `pnpm check:islands` (4 passed)

The failed release run `30492627977` stopped at `Capture accepted production baseline` before uploading or activating any version, leaving production on Astro 5.

Related: #128
