### PR TITLE
Preflight automatic Worker promotion

### DIFF
--- a/.github/workflows/release-worker.yml
+++ b/.github/workflows/release-worker.yml
@@ -674,6 +674,58 @@ jobs:
             return 1
           }
 
+          deployment_state() {
+            local output_file="$1"
+            local max_attempts="${2:-3}"
+            local observed_state
+            for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+              if timeout 60s wrangler deployments list \
+                --name "$worker_name" \
+                --json > "$output_file" &&
+                observed_state="$(
+                  jq -r \
+                    --arg previous "$PREVIOUS_VERSION_ID" \
+                    --arg candidate "$CANDIDATE_VERSION_ID" '
+                    max_by(.created_on).versions as $versions |
+                    if
+                      ($versions | length) == 1 and
+                      $versions[0].version_id == $previous and
+                      $versions[0].percentage == 100
+                    then "previous"
+                    elif
+                      ($versions | length) == 1 and
+                      $versions[0].version_id == $candidate and
+                      $versions[0].percentage == 100
+                    then "candidate"
+                    elif
+                      ($versions | length) == 2 and
+                      ([
+                        $versions[] |
+                        select(
+                          .version_id == $previous and .percentage == 100
+                        )
+                      ] | length) == 1 and
+                      ([
+                        $versions[] |
+                        select(
+                          .version_id == $candidate and .percentage == 0
+                        )
+                      ] | length) == 1
+                    then "preflight"
+                    else "unknown"
+                    end
+                  ' "$output_file"
+                )"; then
+                printf '%s\n' "$observed_state"
+                return 0
+              fi
+              if [ "$attempt" -lt "$max_attempts" ]; then
+                sleep $((attempt * 2))
+              fi
+            done
+            return 1
+          }
+
           verify_deployment() {
             local expected_version="$1"
             local output_file="$2"
@@ -698,6 +750,64 @@ jobs:
             return 1
           }
 
+          verify_preflight_deployment() {
+            local output_file="$1"
+            local current_state=""
+            for attempt in 1 2 3; do
+              if current_state="$(deployment_state "$output_file" 1)" &&
+                [ "$current_state" = "preflight" ]; then
+                return 0
+              fi
+              if [ "$attempt" -lt 3 ]; then
+                sleep $((attempt * 2))
+              fi
+            done
+            echo "The zero-traffic candidate deployment did not converge." >&2
+            return 1
+          }
+
+          expect_status() {
+            local expected="$1"
+            local url="$2"
+            local label="$3"
+            local version_override="${4:-}"
+            local actual
+            local request_url
+            local -a curl_args
+            for attempt in 1 2 3; do
+              request_url="$url"
+              curl_args=(
+                --connect-timeout 10
+                --max-time 15
+                --silent
+                --show-error
+                --output "$RUNNER_TEMP/smoke-${label}.body"
+                --write-out "%{http_code}"
+              )
+              if [ -n "$version_override" ]; then
+                curl_args+=(
+                  --header
+                  "Cloudflare-Workers-Version-Overrides: $worker_name=\"$version_override\""
+                )
+                if [[ "$request_url" == *"?"* ]]; then
+                  request_url="${request_url}&__worker_smoke=${GITHUB_RUN_ID}-${attempt}"
+                else
+                  request_url="${request_url}?__worker_smoke=${GITHUB_RUN_ID}-${attempt}"
+                fi
+              fi
+              actual="$(curl "${curl_args[@]}" "$request_url")" || actual="000"
+              if [ "$actual" = "$expected" ]; then
+                return 0
+              fi
+              if [ "$attempt" -lt 3 ]; then
+                sleep 2
+              fi
+            done
+            printf '%s expected HTTP %s, received %s after 3 attempts.\n' \
+              "$url" "$expected" "$actual" >&2
+            return 1
+          }
+
           rollback_previous_version() {
             local original_status=$?
             trap - ERR
@@ -707,20 +817,22 @@ jobs:
               rollback_deploy_status=1
               rollback_verify_status=1
               for attempt in 1 2 3; do
-                if ! current_version="$(
-                  active_version \
+                if ! current_state="$(
+                  deployment_state \
                     "$RUNNER_TEMP/deployments-before-inline-rollback.json"
                 )"; then
-                  echo "Could not read the active production version from the Cloudflare control plane; inline rollback will not act." >&2
+                  echo "Could not read the production deployment from the Cloudflare control plane; inline rollback will not act." >&2
                   exit "$original_status"
                 fi
-                if [ "$current_version" = "$PREVIOUS_VERSION_ID" ]; then
+                if [ "$current_state" = "previous" ]; then
                   echo "Previous production version is already active." >&2
                   rollback_deploy_status=0
                   rollback_verify_status=0
                   break
                 fi
-                if [ "$current_version" != "$CANDIDATE_VERSION_ID" ]; then
+                if [ "$current_state" = "preflight" ]; then
+                  echo "Previous production version is serving 100 percent with the candidate held at 0 percent." >&2
+                elif [ "$current_state" != "candidate" ]; then
                   echo "An unknown production version is active; inline rollback will not replace it." >&2
                   exit "$original_status"
                 fi
@@ -730,18 +842,19 @@ jobs:
                     --name "$worker_name" \
                     --yes; then
                   rollback_deploy_status=0
-                  if ! current_version="$(
-                    active_version \
+                  if ! current_state="$(
+                    deployment_state \
                       "$RUNNER_TEMP/deployments-after-rollback.json"
                   )"; then
-                    echo "Could not read the active production version from the Cloudflare control plane after rollback; inline rollback will not retry." >&2
+                    echo "Could not read the production deployment from the Cloudflare control plane after rollback; inline rollback will not retry." >&2
                     exit "$original_status"
                   fi
-                  if [ "$current_version" = "$PREVIOUS_VERSION_ID" ]; then
+                  if [ "$current_state" = "previous" ]; then
                     rollback_verify_status=0
                     break
                   fi
-                  if [ "$current_version" != "$CANDIDATE_VERSION_ID" ]; then
+                  if [ "$current_state" != "candidate" ] &&
+                    [ "$current_state" != "preflight" ]; then
                     echo "An unknown production version is active; inline rollback will not replace it." >&2
                     exit "$original_status"
                   fi
@@ -796,6 +909,29 @@ jobs:
 
           activation_attempted=true
           timeout 90s \
+            wrangler versions deploy "$PREVIOUS_VERSION_ID@100%" "$CANDIDATE_VERSION_ID@0%" \
+              --name "$worker_name" \
+              --yes
+          verify_preflight_deployment \
+            "$RUNNER_TEMP/deployments-after-preflight.json"
+
+          expect_status 200 \
+            "https://www.zenml.io/" preflight-home "$CANDIDATE_VERSION_ID"
+          grep -Eo '/_astro/[^" ]+' "$RUNNER_TEMP/smoke-preflight-home.body" \
+            | sort -u \
+            | sed -n '1,6p' \
+            > "$RUNNER_TEMP/smoke-preflight-assets.txt"
+          test -s "$RUNNER_TEMP/smoke-preflight-assets.txt"
+          while read -r asset_path; do
+            expect_status 200 \
+              "https://www.zenml.io${asset_path}" \
+              preflight-asset \
+              "$CANDIDATE_VERSION_ID"
+          done < "$RUNNER_TEMP/smoke-preflight-assets.txt"
+          verify_preflight_deployment \
+            "$RUNNER_TEMP/deployments-immediately-before-promotion.json"
+
+          timeout 90s \
             wrangler versions deploy "$CANDIDATE_VERSION_ID@100%" \
               --name "$worker_name" \
               --yes
@@ -837,34 +973,6 @@ jobs:
             false
           fi
 
-          expect_status() {
-            local expected="$1"
-            local url="$2"
-            local label="$3"
-            local actual
-            for attempt in 1 2 3; do
-              actual="$(
-                curl \
-                  --connect-timeout 10 \
-                  --max-time 15 \
-                  --silent \
-                  --show-error \
-                  --output "$RUNNER_TEMP/smoke-${label}.body" \
-                  --write-out "%{http_code}" \
-                  "$url"
-              )" || actual="000"
-              if [ "$actual" = "$expected" ]; then
-                return 0
-              fi
-              if [ "$attempt" -lt 3 ]; then
-                sleep 2
-              fi
-            done
-            printf '%s expected HTTP %s, received %s after 3 attempts.\n' \
-              "$url" "$expected" "$actual" >&2
-            return 1
-          }
-
           expect_status 200 "https://www.zenml.io/" home
           expect_status 200 "https://www.zenml.io/blog" blog
           expect_status 200 "https://www.zenml.io/product/kitaru" kitaru
@@ -905,6 +1013,7 @@ jobs:
             printf -- "- Active version: \`%s\`\n" "$CANDIDATE_VERSION_ID"
             printf -- "- Artifact SHA-256: \`%s\`\n" "$ARTIFACT_SHA256"
             echo "- Production smoke: passed"
+            echo "- Zero-traffic exact-version preflight: passed"
             echo "- Worker routes and DNS: unchanged"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -918,6 +1027,8 @@ jobs:
             ${{ runner.temp }}/candidate-version.json
             ${{ runner.temp }}/deployments-before-activation.json
             ${{ runner.temp }}/deployments-immediately-before-activation.json
+            ${{ runner.temp }}/deployments-after-preflight.json
+            ${{ runner.temp }}/deployments-immediately-before-promotion.json
             ${{ runner.temp }}/deployments-before-inline-rollback.json
             ${{ runner.temp }}/deployments-after-activation.json
             ${{ runner.temp }}/deployments-after-smoke.json
@@ -928,6 +1039,7 @@ jobs:
             ${{ runner.temp }}/worker-domains-before-activation.json
             ${{ runner.temp }}/smoke-*.body
             ${{ runner.temp }}/smoke-assets.txt
+            ${{ runner.temp }}/smoke-preflight-assets.txt
           if-no-files-found: warn
           retention-days: 30
 
@@ -958,26 +1070,47 @@ jobs:
           [[ "$CANDIDATE_VERSION_ID" =~ ^[0-9a-f-]{36}$ ]]
           [[ "$PREVIOUS_VERSION_ID" =~ ^[0-9a-f-]{36}$ ]]
 
-          active_version() {
-            local observed_version
+          deployment_state() {
+            local observed_state
             for attempt in 1 2 3; do
               if timeout 60s wrangler deployments list \
                 --name "$WORKER_NAME" \
                 --json > "$RUNNER_TEMP/recovery-deployments.json" &&
-                observed_version="$(
-                  jq -r '
-                    max_by(.created_on) as $latest |
+                observed_state="$(
+                  jq -r \
+                    --arg previous "$PREVIOUS_VERSION_ID" \
+                    --arg candidate "$CANDIDATE_VERSION_ID" '
+                    max_by(.created_on).versions as $versions |
                     if
-                      ($latest.versions | type) == "array" and
-                      ($latest.versions | length) == 1 and
-                      $latest.versions[0].percentage == 100 and
-                      ($latest.versions[0].version_id | type) == "string"
-                    then $latest.versions[0].version_id
-                    else empty
+                      ($versions | length) == 1 and
+                      $versions[0].version_id == $previous and
+                      $versions[0].percentage == 100
+                    then "previous"
+                    elif
+                      ($versions | length) == 1 and
+                      $versions[0].version_id == $candidate and
+                      $versions[0].percentage == 100
+                    then "candidate"
+                    elif
+                      ($versions | length) == 2 and
+                      ([
+                        $versions[] |
+                        select(
+                          .version_id == $previous and .percentage == 100
+                        )
+                      ] | length) == 1 and
+                      ([
+                        $versions[] |
+                        select(
+                          .version_id == $candidate and .percentage == 0
+                        )
+                      ] | length) == 1
+                    then "preflight"
+                    else "unknown"
                     end
                   ' "$RUNNER_TEMP/recovery-deployments.json"
                 )"; then
-                printf '%s\n' "$observed_version"
+                printf '%s\n' "$observed_state"
                 return 0
               fi
               if [ "$attempt" -lt 3 ]; then
@@ -989,16 +1122,18 @@ jobs:
 
           recovered=false
           for attempt in 1 2 3; do
-            if ! current_version="$(active_version)"; then
-              echo "Could not read the active production version from the Cloudflare control plane; recovery will not act." >&2
+            if ! current_state="$(deployment_state)"; then
+              echo "Could not read the production deployment from the Cloudflare control plane; recovery will not act." >&2
               exit 1
             fi
-            if [ "$current_version" = "$PREVIOUS_VERSION_ID" ]; then
+            if [ "$current_state" = "previous" ]; then
               echo "Previous production version is already active."
               recovered=true
               break
             fi
-            if [ "$current_version" != "$CANDIDATE_VERSION_ID" ]; then
+            if [ "$current_state" = "preflight" ]; then
+              echo "Removing the zero-traffic candidate from the production deployment."
+            elif [ "$current_state" != "candidate" ]; then
               echo "An unknown production version is active; recovery will not replace it." >&2
               exit 1
             fi
@@ -1007,15 +1142,16 @@ jobs:
               wrangler versions deploy "$PREVIOUS_VERSION_ID@100%" \
                 --name "$WORKER_NAME" \
                 --yes; then
-              if ! current_version="$(active_version)"; then
-                echo "Could not read the active production version from the Cloudflare control plane after rollback; recovery will not retry." >&2
+              if ! current_state="$(deployment_state)"; then
+                echo "Could not read the production deployment from the Cloudflare control plane after rollback; recovery will not retry." >&2
                 exit 1
               fi
-              if [ "$current_version" = "$PREVIOUS_VERSION_ID" ]; then
+              if [ "$current_state" = "previous" ]; then
                 recovered=true
                 break
               fi
-              if [ "$current_version" != "$CANDIDATE_VERSION_ID" ]; then
+              if [ "$current_state" != "candidate" ] &&
+                [ "$current_state" != "preflight" ]; then
                 echo "An unknown production version is active; recovery will not replace it." >&2
                 exit 1
               fi
@@ -1054,11 +1190,11 @@ jobs:
             exit 1
           fi
 
-          if ! final_version="$(active_version)"; then
-            echo "Could not read the active production version after homepage verification; recovery did not complete." >&2
+          if ! final_state="$(deployment_state)"; then
+            echo "Could not read the production deployment after homepage verification; recovery did not complete." >&2
             exit 1
           fi
-          if [ "$final_version" != "$PREVIOUS_VERSION_ID" ]; then
+          if [ "$final_state" != "previous" ]; then
             echo "Active production version changed during recovery verification; recovery did not complete." >&2
             exit 1
           fi

--- a/docs/worker-release-runbook.md
+++ b/docs/worker-release-runbook.md
@@ -14,9 +14,12 @@ The release controls now have six paths:
 2. `Release Worker to Production` runs after a successful same-repository
    `push` to the current `main`. It downloads that exact artifact, uploads it
    inactive, verifies the accepted Worker topology and bindings, records the
-   previous version, activates the returned version at 100 percent, and runs
-   production smoke tests. A failed post-activation check restores and verifies
-   the previous version before leaving the workflow failed.
+   previous version, adds the candidate to the deployment at 0 percent, and
+   smoke-tests that exact version through Cloudflare's version-override header.
+   Only after that preflight passes does it activate the candidate at 100
+   percent and run public production smoke tests. A failed preflight or
+   post-activation check restores and verifies the previous version before
+   leaving the workflow failed.
 3. `Upload Exact Preview Worker Version` is manually dispatched from `main`
    after explicit review. It consumes either one successful same-repository PR
    artifact or the successful `push` artifact for the exact current `main`
@@ -89,21 +92,32 @@ activation it rechecks the candidate provenance, bindings, previous deployment,
 routes, endpoint privacy, and custom-domain state.
 
 Immediately before exact-version activation, the workflow rechecks that the
-source commit is still the live `main`. It then verifies the 100-percent
-deployment and unchanged routes, and checks representative pages, the newly
-merged Dagster article, API behavior, redirects, 404 behavior, and sampled
-production assets. The apex redirect is recorded separately because it is
-zone-level behavior, not behavior of the released Worker version.
+source commit is still the live `main`. It first creates a deployment with the
+accepted previous version at 100 percent and the exact candidate at 0 percent.
+Normal visitors therefore continue to receive the previous version. Requests
+carrying Cloudflare's exact-version override then verify the candidate homepage
+and a sample of its content-hashed assets. Retry requests use distinct query
+strings so a transient edge 404 cannot satisfy every retry from cache.
+
+After the zero-traffic preflight passes, the workflow rechecks that the accepted
+100/0 deployment is still present. It then promotes the candidate to 100
+percent, verifies the exact deployment and unchanged routes, and checks
+representative pages, the newly merged Dagster article, API behavior, redirects,
+404 behavior, and sampled production assets. The apex redirect is recorded
+separately because it is zone-level behavior, not behavior of the released
+Worker version.
 
 A failed post-activation check first inspects the live active version. Its
 inline rollback restores the previous version with bounded retries only when
-the exact candidate is still active. It accepts an already-restored previous
-version and refuses to replace any unknown version. A separate recovery job
-applies the same rule after a failed or timed-out activation job. The release
-stays failed for investigation. A manual cancellation of the whole workflow or
-loss of the GitHub runner can also cancel the recovery job, so an operator must
-verify the active version after either event. Workflow artifacts retain
-candidate, deployment, smoke, and recovery evidence for 30 days.
+the exact candidate is active or present at 0 percent beside the previous
+version at 100 percent. It accepts an already-restored previous version and
+refuses to replace any unknown version or percentage combination. A separate
+recovery job applies the same rule after a failed or timed-out activation job.
+The release stays failed for investigation. A manual cancellation of the whole
+workflow or loss of the GitHub runner can also cancel the recovery job, so an
+operator must verify the active version after either event. Workflow artifacts
+retain candidate, deployment, preflight, smoke, and recovery evidence for 30
+days.
 
 ## GitHub environments and secret names
 

--- a/tests/config/deploymentWorkflows.test.ts
+++ b/tests/config/deploymentWorkflows.test.ts
@@ -182,7 +182,12 @@ if [ "$1 $2" = "deployments list" ]; then
     exit 1
   fi
   version_id="$(cat "$ACTIVE_VERSION_FILE")"
-  printf '[{"created_on":"2026-07-29T00:00:00Z","versions":[{"version_id":"%s","percentage":100}]}]\\n' "$version_id"
+  if [ "$version_id" = "preflight" ]; then
+    printf '[{"created_on":"2026-07-29T00:00:00Z","versions":[{"version_id":"%s","percentage":100},{"version_id":"%s","percentage":0}]}]\\n' \
+      "$PREVIOUS_VERSION_ID" "$CANDIDATE_VERSION_ID"
+  else
+    printf '[{"created_on":"2026-07-29T00:00:00Z","versions":[{"version_id":"%s","percentage":100}]}]\\n' "$version_id"
+  fi
   exit 0
 fi
 if [ "$1 $2" = "versions deploy" ]; then
@@ -259,14 +264,18 @@ ${shouldFail ? "false" : ":"}
   );
 }
 
-function executeStatusRetry(): { curlCalls: number; error: unknown } {
+function executeStatusRetry(): {
+  curlArgs: string[];
+  curlCalls: number;
+  error: unknown;
+} {
   const releaseStep = workflowStep(
     releaseActivationSteps,
     "Activate, smoke-test, and roll back on failure",
   );
   const run = releaseStep.run ?? "";
   const functionStart = run.indexOf("expect_status() {");
-  const functionEnd = run.indexOf('expect_status 200 "https://www.zenml.io/"');
+  const functionEnd = run.indexOf("rollback_previous_version() {");
   expect(functionStart).toBeGreaterThan(-1);
   expect(functionEnd).toBeGreaterThan(functionStart);
   const expectStatusFunction = run.slice(functionStart, functionEnd);
@@ -275,7 +284,9 @@ function executeStatusRetry(): { curlCalls: number; error: unknown } {
     "worker-release-smoke-",
     (harnessDirectory, binDirectory) => {
       const callsFile = join(harnessDirectory, "curl-calls.txt");
+      const argsFile = join(harnessDirectory, "curl-args.txt");
       writeFileSync(callsFile, "0\n");
+      writeFileSync(argsFile, "");
       writeFileSync(
         join(binDirectory, "curl"),
         `#!/usr/bin/env bash
@@ -283,6 +294,7 @@ set -euo pipefail
 calls="$(cat "$CURL_CALLS_FILE")"
 calls=$((calls + 1))
 printf '%s\\n' "$calls" > "$CURL_CALLS_FILE"
+printf '%s\\n' "$*" >> "$CURL_ARGS_FILE"
 if [ "$calls" -eq 1 ]; then
   exit 7
 fi
@@ -299,13 +311,16 @@ printf '200\\n'
             "-c",
             `set -Eeuo pipefail
 ${expectStatusFunction}
-expect_status 200 "https://www.zenml.io/" retry-test
+worker_name="zenml-io-v2-worker"
+expect_status 200 "https://www.zenml.io/" retry-test "22222222-2222-2222-2222-222222222222"
 `,
           ],
           {
             env: {
               ...process.env,
+              CURL_ARGS_FILE: argsFile,
               CURL_CALLS_FILE: callsFile,
+              GITHUB_RUN_ID: "12345",
               PATH: `${binDirectory}:${process.env.PATH ?? ""}`,
               RUNNER_TEMP: harnessDirectory,
             },
@@ -316,7 +331,8 @@ expect_status 200 "https://www.zenml.io/" retry-test
         error = caught;
       }
       const curlCalls = Number.parseInt(readFileSync(callsFile, "utf8"), 10);
-      return { curlCalls, error };
+      const curlArgs = readFileSync(argsFile, "utf8").trim().split("\n");
+      return { curlArgs, curlCalls, error };
     },
   );
 }
@@ -373,7 +389,12 @@ if [ "$1 $2" = "deployments list" ]; then
     exit 1
   fi
   active_version="$(cat "$ACTIVE_VERSION_FILE")"
-  printf '[{"created_on":"2026-07-29T00:00:00Z","versions":[{"version_id":"%s","percentage":100}]}]\\n' "$active_version"
+  if [ "$active_version" = "preflight" ]; then
+    printf '[{"created_on":"2026-07-29T00:00:00Z","versions":[{"version_id":"%s","percentage":100},{"version_id":"%s","percentage":0}]}]\\n' \
+      "$PREVIOUS_VERSION_ID" "$CANDIDATE_VERSION_ID"
+  else
+    printf '[{"created_on":"2026-07-29T00:00:00Z","versions":[{"version_id":"%s","percentage":100}]}]\\n' "$active_version"
+  fi
   exit 0
 fi
 if [ "$1 $2" = "versions deploy" ]; then
@@ -1279,6 +1300,15 @@ describe("automatic post-cutover production release", () => {
     const activation = run.indexOf(
       'wrangler versions deploy "$CANDIDATE_VERSION_ID@100%"',
     );
+    const zeroTrafficPreflight = run.indexOf(
+      'wrangler versions deploy "$PREVIOUS_VERSION_ID@100%" "$CANDIDATE_VERSION_ID@0%"',
+    );
+    const candidateOverride = run.indexOf(
+      '"https://www.zenml.io/" preflight-home "$CANDIDATE_VERSION_ID"',
+    );
+    const finalPreflightCheck = run.indexOf(
+      '"$RUNNER_TEMP/deployments-immediately-before-promotion.json"',
+    );
     const liveBaselineCheck = run.indexOf(
       '"$RUNNER_TEMP/deployments-immediately-before-activation.json"',
     );
@@ -1287,6 +1317,10 @@ describe("automatic post-cutover production release", () => {
     expect(liveMainCheck).toBeGreaterThan(-1);
     expect(liveBaselineCheck).toBeGreaterThan(liveMainCheck);
     expect(activationAttempted).toBeGreaterThan(liveBaselineCheck);
+    expect(zeroTrafficPreflight).toBeGreaterThan(activationAttempted);
+    expect(candidateOverride).toBeGreaterThan(zeroTrafficPreflight);
+    expect(finalPreflightCheck).toBeGreaterThan(candidateOverride);
+    expect(activation).toBeGreaterThan(finalPreflightCheck);
     expect(activation).toBeGreaterThan(liveMainCheck);
     expect(activation).toBeGreaterThan(activationAttempted);
     expect(run).toMatch(
@@ -1340,6 +1374,9 @@ describe("automatic post-cutover production release", () => {
     expect(releaseWorkflow).toContain("Rollback verification failed");
     expect(releaseWorkflow).toContain("Automatic rollback completed");
     expect(releaseWorkflow).toContain(
+      "Previous production version is serving 100 percent with the candidate held at 0 percent.",
+    );
+    expect(releaseWorkflow).toContain(
       "Recover previous production version after failed activation",
     );
     expect(releaseWorkflow).toContain("needs.activate.result != 'success'");
@@ -1352,9 +1389,7 @@ describe("automatic post-cutover production release", () => {
     );
     expect(recoveryStep.run).toContain("for attempt in 1 2 3");
     expect(recoveryStep.run).toContain("timeout 90s");
-    expect(recoveryStep.run).toContain(
-      'current_version" != "$CANDIDATE_VERSION_ID',
-    );
+    expect(recoveryStep.run).toContain('[ "$current_state" != "candidate" ]');
     expect(recoveryStep.run).toContain(
       "An unknown production version is active; recovery will not replace it.",
     );
@@ -1363,11 +1398,11 @@ describe("automatic post-cutover production release", () => {
       'if [ "$home_status" != "200" ]',
     );
     const finalControlPlaneRead = recoveryRun.indexOf(
-      'final_version="$(active_version)"',
+      'final_state="$(deployment_state)"',
       homepageVerification,
     );
     const finalVersionComparison = recoveryRun.indexOf(
-      'if [ "$final_version" != "$PREVIOUS_VERSION_ID" ]',
+      'if [ "$final_state" != "previous" ]',
       finalControlPlaneRead,
     );
     const recoverySuccess = recoveryRun.indexOf(
@@ -1468,6 +1503,12 @@ describe("automatic post-cutover production release", () => {
       ),
     ).toBe(true);
 
+    const preflightRelease = executeReleaseTrap(true, "preflight");
+    expect(preflightRelease.error).toBeDefined();
+    expect(preflightRelease.wranglerCalls).toContain(
+      "versions deploy 11111111-1111-1111-1111-111111111111@100% --name zenml-io-v2-worker --yes",
+    );
+
     const exhaustedReadFailure = executeReleaseTrap(
       true,
       "22222222-2222-2222-2222-222222222222",
@@ -1481,7 +1522,7 @@ describe("automatic post-cutover production release", () => {
       ),
     ).toBe(false);
     expect(exhaustedReadFailure.stderr).toContain(
-      "Could not read the active production version from the Cloudflare control plane; inline rollback will not act.",
+      "Could not read the production deployment from the Cloudflare control plane; inline rollback will not act.",
     );
 
     const operatorVersion = "33333333-3333-3333-3333-333333333333";
@@ -1507,6 +1548,16 @@ describe("automatic post-cutover production release", () => {
     const result = executeStatusRetry();
     expect(result.error).toBeUndefined();
     expect(result.curlCalls).toBe(2);
+    expect(result.curlArgs).toEqual([
+      expect.stringContaining(
+        'Cloudflare-Workers-Version-Overrides: zenml-io-v2-worker="22222222-2222-2222-2222-222222222222"',
+      ),
+      expect.stringContaining(
+        'Cloudflare-Workers-Version-Overrides: zenml-io-v2-worker="22222222-2222-2222-2222-222222222222"',
+      ),
+    ]);
+    expect(result.curlArgs[0]).toContain("__worker_smoke=12345-1");
+    expect(result.curlArgs[1]).toContain("__worker_smoke=12345-2");
   });
 
   it("executes recovery reconciliation and fails closed when recovery cannot complete", () => {
@@ -1521,6 +1572,10 @@ describe("automatic post-cutover production release", () => {
     const transientFailure = executeRecovery(candidateVersion, 1, 200);
     expect(transientFailure.error).toBeUndefined();
     expect(transientFailure.deployCalls).toBe(2);
+
+    const preflightRecovery = executeRecovery("preflight", 0, 200);
+    expect(preflightRecovery.error).toBeUndefined();
+    expect(preflightRecovery.deployCalls).toBe(1);
 
     const exhaustedRecovery = executeRecovery(candidateVersion, 3, 200);
     expect(exhaustedRecovery.error).toBeDefined();
@@ -1547,7 +1602,7 @@ describe("automatic post-cutover production release", () => {
     expect(exhaustedReadFailure.deploymentReadCalls).toBe(3);
     expect(exhaustedReadFailure.deployCalls).toBe(0);
     expect(exhaustedReadFailure.stderr).toContain(
-      "Could not read the active production version from the Cloudflare control plane; recovery will not act.",
+      "Could not read the production deployment from the Cloudflare control plane; recovery will not act.",
     );
 
     const operatorReleaseDuringRetry = executeRecovery(
@@ -1584,7 +1639,7 @@ describe("automatic post-cutover production release", () => {
     expect(finalReadFailure.deployCalls).toBe(0);
     expect(finalReadFailure.deploymentReadCalls).toBe(4);
     expect(finalReadFailure.stderr).toContain(
-      "Could not read the active production version after homepage verification; recovery did not complete.",
+      "Could not read the production deployment after homepage verification; recovery did not complete.",
     );
   });
 });


### PR DESCRIPTION
## Summary

Add a zero-traffic preflight to the automatic Cloudflare Worker release so an exact candidate version and its content-hashed assets are checked before normal production traffic moves to it.

## Changes

- Deploy the accepted previous Worker version at 100% and the exact candidate at 0%.
- Send smoke requests to the candidate through Cloudflare's documented version-override header.
- Check the candidate homepage and six sampled hashed Astro assets with distinct cache-busting retry URLs.
- Recheck the exact 100/0 deployment immediately before promotion so an operator change is not overwritten.
- Promote the candidate to 100% only after the preflight passes.
- Extend inline rollback and the separate recovery job to clean up both candidate-only and previous-100/candidate-0 states while refusing unknown versions or percentage combinations.
- Record preflight control-plane and HTTP evidence in the retained workflow artifacts.
- Update the release runbook and workflow regression harnesses.

## What reviewers should focus on

- The deployment-state classifier must accept only the three known states: previous at 100%, candidate at 100%, or previous at 100% plus candidate at 0%.
- Every failure after the 0% candidate is added must leave normal traffic on the previous version or restore and verify it.
- The test harness now executes the exact-version header and confirms that retries use different `__worker_smoke` query values.
- The activation and recovery jobs intentionally keep separate copies of the state classifier because credentialed jobs should not execute a shared branch-controlled repository script.

## Production behavior

Merging this PR does not itself change DNS, Worker routes, Access, Pages, custom domains, or production traffic. After the resulting `main` CI artifact passes, the existing automatic release workflow will run. Normal visitors remain on the previous version during the new preflight. The candidate receives 100% only after its exact-version checks pass.

## Validation

- `pnpm check`
- `pnpm check:tests`
- `pnpm check:surface`
- `pnpm check:alt`
- `pnpm lint`
- `pnpm test` (178 tests)
- `pnpm build`
- `pnpm smoke:dist`
- `pnpm check:worker` (18 checks)
- `pnpm check:islands` (4 checks)
- `git diff --check`

The first full build attempt hit a transient external `fetch failed` error. A clean retry passed. After review-driven workflow and test changes, `pnpm check:tests`, `pnpm lint`, the full 178-test suite, and `git diff --check` passed again.

## Post-merge monitoring and validation

- Watch the source `main` CI run and its automatic `Release Worker to Production` run.
- Expect the release evidence to show previous 100% plus candidate 0%, exact candidate homepage and asset checks passing, candidate 100%, and the public production smoke passing.
- If preflight, promotion, or public smoke fails, confirm the workflow restores the accepted previous version and leaves the release failed for investigation.
- After the workflow passes, manually check the homepage, navigation, one blog page, one Kitaru page, and a hard refresh in a separate browser session.

<!-- compound-engineering:ce-work -->
