### PR TITLE
Verify exact Worker candidate assets

### DIFF
--- a/.github/trusted/worker-artifact-workflow.yml
+++ b/.github/trusted/worker-artifact-workflow.yml
@@ -52,6 +52,18 @@ jobs:
       - name: Build site
         run: pnpm build
 
+      - name: Stamp exact release marker
+        shell: bash
+        env:
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_ID: ${{ github.run_id }}
+          SOURCE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          release_marker="worker-release-marker:$SOURCE_COMMIT:$RUN_ID:$RUN_ATTEMPT"
+          printf '\n<!-- %s -->\n' "$release_marker" >> dist/client/index.html
+          grep -Fq -- "$release_marker" dist/client/index.html
+
       - name: Smoke test built site output
         run: pnpm smoke:dist
 
@@ -108,8 +120,7 @@ jobs:
           ' dist/server/wrangler.json > /dev/null
           test -f dist/server/entry.mjs
           test -f dist/client/index.html
-          release_marker="worker-release-marker:$SOURCE_COMMIT"
-          printf '\n<!-- %s -->\n' "$release_marker" >> dist/client/index.html
+          release_marker="worker-release-marker:$SOURCE_COMMIT:$RUN_ID:$RUN_ATTEMPT"
           grep -Fq -- "$release_marker" dist/client/index.html
 
           replay_dir="$(mktemp -d)"

--- a/.github/trusted/worker-artifact-workflow.yml
+++ b/.github/trusted/worker-artifact-workflow.yml
@@ -108,6 +108,9 @@ jobs:
           ' dist/server/wrangler.json > /dev/null
           test -f dist/server/entry.mjs
           test -f dist/client/index.html
+          release_marker="worker-release-marker:$SOURCE_COMMIT"
+          printf '\n<!-- %s -->\n' "$release_marker" >> dist/client/index.html
+          grep -Fq -- "$release_marker" dist/client/index.html
 
           replay_dir="$(mktemp -d)"
           trap 'rm -rf "$replay_dir"' EXIT

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,18 @@ jobs:
       - name: Build site
         run: pnpm build
 
+      - name: Stamp exact release marker
+        shell: bash
+        env:
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_ID: ${{ github.run_id }}
+          SOURCE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          release_marker="worker-release-marker:$SOURCE_COMMIT:$RUN_ID:$RUN_ATTEMPT"
+          printf '\n<!-- %s -->\n' "$release_marker" >> dist/client/index.html
+          grep -Fq -- "$release_marker" dist/client/index.html
+
       - name: Smoke test built site output
         run: pnpm smoke:dist
 
@@ -108,8 +120,7 @@ jobs:
           ' dist/server/wrangler.json > /dev/null
           test -f dist/server/entry.mjs
           test -f dist/client/index.html
-          release_marker="worker-release-marker:$SOURCE_COMMIT"
-          printf '\n<!-- %s -->\n' "$release_marker" >> dist/client/index.html
+          release_marker="worker-release-marker:$SOURCE_COMMIT:$RUN_ID:$RUN_ATTEMPT"
           grep -Fq -- "$release_marker" dist/client/index.html
 
           replay_dir="$(mktemp -d)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,6 +108,9 @@ jobs:
           ' dist/server/wrangler.json > /dev/null
           test -f dist/server/entry.mjs
           test -f dist/client/index.html
+          release_marker="worker-release-marker:$SOURCE_COMMIT"
+          printf '\n<!-- %s -->\n' "$release_marker" >> dist/client/index.html
+          grep -Fq -- "$release_marker" dist/client/index.html
 
           replay_dir="$(mktemp -d)"
           trap 'rm -rf "$replay_dir"' EXIT

--- a/.github/workflows/release-worker.yml
+++ b/.github/workflows/release-worker.yml
@@ -114,7 +114,9 @@ jobs:
     timeout-minutes: 15
     outputs:
       artifact_sha256: ${{ steps.upload.outputs.artifact_sha256 }}
+      candidate_asset_paths: ${{ steps.upload.outputs.candidate_asset_paths }}
       previous_version_id: ${{ steps.baseline.outputs.previous_version_id }}
+      source_run_attempt: ${{ steps.upload.outputs.source_run_attempt }}
       version_id: ${{ steps.upload.outputs.version_id }}
     env:
       SOURCE_BRANCH: main
@@ -352,9 +354,34 @@ jobs:
 
           export WRANGLER_OUTPUT_FILE_PATH="$output_file"
           artifact_sha256="$(jq -r .artifact_sha256 worker-manifest.json)"
-          release_marker="worker-release-marker:$SOURCE_COMMIT"
+          source_run_attempt="$(
+            jq -er '
+              .run_attempt |
+              select(type == "string" and test("^[1-9][0-9]*$"))
+            ' worker-manifest.json
+          )"
+          release_marker="worker-release-marker:$SOURCE_COMMIT:$SOURCE_RUN_ID:$source_run_attempt"
           grep -Fq -- "$release_marker" dist/client/index.html
-          version_message="source_commit=$SOURCE_COMMIT source_branch=$SOURCE_BRANCH source_run_id=$SOURCE_RUN_ID artifact_sha256=$artifact_sha256"
+          grep -Eo '/_astro/[A-Za-z0-9._-]+' dist/client/index.html \
+            | LC_ALL=C sort -u \
+            | sed -n '1,6p' \
+            > "$RUNNER_TEMP/candidate-asset-paths.txt"
+          test -s "$RUNNER_TEMP/candidate-asset-paths.txt"
+          while IFS= read -r asset_path; do
+            test -f "dist/client$asset_path"
+          done < "$RUNNER_TEMP/candidate-asset-paths.txt"
+          candidate_asset_paths="$(
+            jq -R -s -c \
+              'split("\n") | map(select(length > 0))' \
+              "$RUNNER_TEMP/candidate-asset-paths.txt"
+          )"
+          jq -e '
+            type == "array" and
+            length >= 1 and
+            length <= 6 and
+            all(.[]; test("^/_astro/[A-Za-z0-9._-]+$"))
+          ' <<< "$candidate_asset_paths" > /dev/null
+          version_message="source_commit=$SOURCE_COMMIT source_branch=$SOURCE_BRANCH source_run_id=$SOURCE_RUN_ID source_run_attempt=$source_run_attempt artifact_sha256=$artifact_sha256"
           wrangler versions upload \
             --config dist/server/upload-wrangler.json \
             --secrets-file "$secrets_file" \
@@ -382,15 +409,21 @@ jobs:
           version_id="$(jq -er .version_id upload-result.json)"
           {
             echo "artifact_sha256=$artifact_sha256"
+            echo "candidate_asset_paths=$candidate_asset_paths"
+            echo "source_run_attempt=$source_run_attempt"
             echo "version_id=$version_id"
           } >> "$GITHUB_OUTPUT"
           jq -n \
             --arg artifact_sha256 "$artifact_sha256" \
+            --argjson candidate_asset_paths "$candidate_asset_paths" \
             --arg previous_version_id "$PREVIOUS_VERSION_ID" \
+            --arg source_run_attempt "$source_run_attempt" \
             --arg version_id "$version_id" \
             '{
               artifact_sha256: $artifact_sha256,
+              candidate_asset_paths: $candidate_asset_paths,
               previous_version_id: $previous_version_id,
+              source_run_attempt: $source_run_attempt,
               version_id: $version_id
             }' > candidate-identity.json
 
@@ -408,6 +441,7 @@ jobs:
           grep -Fq -- " source_commit=$SOURCE_COMMIT " <<< " $message "
           grep -Fq -- " source_branch=$SOURCE_BRANCH " <<< " $message "
           grep -Fq -- " source_run_id=$SOURCE_RUN_ID " <<< " $message "
+          grep -Fq -- " source_run_attempt=$source_run_attempt " <<< " $message "
           grep -Fq -- " artifact_sha256=$artifact_sha256 " <<< " $message "
 
       - name: Verify inactive upload preserved production
@@ -512,11 +546,13 @@ jobs:
     timeout-minutes: 20
     env:
       ARTIFACT_SHA256: ${{ needs.upload.outputs.artifact_sha256 }}
+      CANDIDATE_ASSET_PATHS_JSON: ${{ needs.upload.outputs.candidate_asset_paths }}
       CANDIDATE_VERSION_ID: ${{ needs.upload.outputs.version_id }}
       PREVIOUS_VERSION_ID: ${{ needs.upload.outputs.previous_version_id }}
       SOURCE_BRANCH: main
       SOURCE_COMMIT: ${{ github.event.workflow_run.head_sha }}
       SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+      SOURCE_RUN_ATTEMPT: ${{ needs.upload.outputs.source_run_attempt }}
     steps:
       - name: Install pinned Wrangler
         run: npm install --global wrangler@4.110.0
@@ -552,6 +588,7 @@ jobs:
           grep -Fq -- " source_commit=$SOURCE_COMMIT " <<< " $message "
           grep -Fq -- " source_branch=$SOURCE_BRANCH " <<< " $message "
           grep -Fq -- " source_run_id=$SOURCE_RUN_ID " <<< " $message "
+          grep -Fq -- " source_run_attempt=$SOURCE_RUN_ATTEMPT " <<< " $message "
           grep -Fq -- " artifact_sha256=$ARTIFACT_SHA256 " <<< " $message "
 
           timeout 60s wrangler deployments list \
@@ -813,7 +850,7 @@ jobs:
           }
 
           expect_candidate_home() {
-            local expected_marker="worker-release-marker:$SOURCE_COMMIT"
+            local expected_marker="worker-release-marker:$SOURCE_COMMIT:$SOURCE_RUN_ID:$SOURCE_RUN_ATTEMPT"
             local attempt
             for attempt in $(seq 1 12); do
               if expect_status 200 \
@@ -828,6 +865,60 @@ jobs:
               fi
             done
             echo "The exact-version homepage did not converge to the candidate release marker." >&2
+            return 1
+          }
+
+          expect_candidate_assets() {
+            local attempt
+            local asset_index
+            local asset_path
+            local actual
+            local -a pids
+
+            jq -e '
+              type == "array" and
+              length >= 1 and
+              length <= 6 and
+              all(.[]; test("^/_astro/[A-Za-z0-9._-]+$"))
+            ' <<< "$CANDIDATE_ASSET_PATHS_JSON" > /dev/null
+            jq -er '.[]' <<< "$CANDIDATE_ASSET_PATHS_JSON" \
+              > "$RUNNER_TEMP/candidate-asset-paths.txt"
+
+            for attempt in $(seq 1 12); do
+              asset_index=0
+              pids=()
+              while IFS= read -r asset_path; do
+                (
+                  actual="$(
+                    curl \
+                      --connect-timeout 10 \
+                      --max-time 15 \
+                      --silent \
+                      --show-error \
+                      --header "Cloudflare-Workers-Version-Overrides: $worker_name=\"$CANDIDATE_VERSION_ID\"" \
+                      --output "$RUNNER_TEMP/preflight-candidate-asset-${attempt}-${asset_index}.body" \
+                      --write-out "%{http_code}" \
+                      "https://www.zenml.io${asset_path}?__worker_candidate_asset=${GITHUB_RUN_ID}-${attempt}-${asset_index}"
+                  )" || actual="000"
+                  printf '%s\t%s\n' "$asset_path" "$actual" \
+                    > "$RUNNER_TEMP/preflight-candidate-asset-${attempt}-${asset_index}.status"
+                ) &
+                pids+=("$!")
+                asset_index=$((asset_index + 1))
+              done < "$RUNNER_TEMP/candidate-asset-paths.txt"
+              test "$asset_index" -ge 1
+              for pid in "${pids[@]}"; do
+                wait "$pid"
+              done
+              if awk -F '\t' '$2 != "200" { failed = 1 } END { exit failed }' \
+                "$RUNNER_TEMP"/preflight-candidate-asset-"$attempt"-*.status; then
+                return 0
+              fi
+              if [ "$attempt" -lt 12 ]; then
+                sleep 5
+              fi
+            done
+            echo "The exact-version candidate assets did not converge." >&2
             return 1
           }
 
@@ -939,6 +1030,7 @@ jobs:
             "$RUNNER_TEMP/deployments-after-preflight.json"
 
           expect_candidate_home
+          expect_candidate_assets
           verify_preflight_deployment \
             "$RUNNER_TEMP/deployments-immediately-before-promotion.json"
 
@@ -1048,6 +1140,8 @@ jobs:
             ${{ runner.temp }}/workers-before-activation.json
             ${{ runner.temp }}/workers-after-activation.json
             ${{ runner.temp }}/worker-domains-before-activation.json
+            ${{ runner.temp }}/preflight-candidate-asset-*.body
+            ${{ runner.temp }}/preflight-candidate-asset-*.status
             ${{ runner.temp }}/smoke-*.body
             ${{ runner.temp }}/smoke-assets.txt
           if-no-files-found: warn

--- a/.github/workflows/release-worker.yml
+++ b/.github/workflows/release-worker.yml
@@ -114,7 +114,6 @@ jobs:
     timeout-minutes: 15
     outputs:
       artifact_sha256: ${{ steps.upload.outputs.artifact_sha256 }}
-      candidate_asset_paths: ${{ steps.upload.outputs.candidate_asset_paths }}
       previous_version_id: ${{ steps.baseline.outputs.previous_version_id }}
       version_id: ${{ steps.upload.outputs.version_id }}
     env:
@@ -353,38 +352,8 @@ jobs:
 
           export WRANGLER_OUTPUT_FILE_PATH="$output_file"
           artifact_sha256="$(jq -r .artifact_sha256 worker-manifest.json)"
-          curl \
-            --connect-timeout 10 \
-            --max-time 30 \
-            --fail-with-body \
-            --silent \
-            --show-error \
-            "https://www.zenml.io/?__worker_candidate_baseline=$GITHUB_RUN_ID" \
-            > "$RUNNER_TEMP/accepted-production-home.html"
-          grep -Eo '/_astro/[A-Za-z0-9._-]+' dist/client/index.html \
-            | LC_ALL=C sort -u \
-            > "$RUNNER_TEMP/candidate-home-asset-paths.txt"
-          grep -Eo '/_astro/[A-Za-z0-9._-]+' \
-            "$RUNNER_TEMP/accepted-production-home.html" \
-            | LC_ALL=C sort -u \
-            > "$RUNNER_TEMP/accepted-production-asset-paths.txt"
-          comm -23 \
-            "$RUNNER_TEMP/candidate-home-asset-paths.txt" \
-            "$RUNNER_TEMP/accepted-production-asset-paths.txt" \
-            | sed -n '1,6p' \
-            > "$RUNNER_TEMP/candidate-asset-paths.txt"
-          test -s "$RUNNER_TEMP/candidate-asset-paths.txt"
-          candidate_asset_paths="$(
-            jq -R -s -c \
-              'split("\n") | map(select(length > 0))' \
-              "$RUNNER_TEMP/candidate-asset-paths.txt"
-          )"
-          jq -e '
-            type == "array" and
-            length >= 1 and
-            length <= 6 and
-            all(.[]; test("^/_astro/[A-Za-z0-9._-]+$"))
-          ' <<< "$candidate_asset_paths" > /dev/null
+          release_marker="worker-release-marker:$SOURCE_COMMIT"
+          grep -Fq -- "$release_marker" dist/client/index.html
           version_message="source_commit=$SOURCE_COMMIT source_branch=$SOURCE_BRANCH source_run_id=$SOURCE_RUN_ID artifact_sha256=$artifact_sha256"
           wrangler versions upload \
             --config dist/server/upload-wrangler.json \
@@ -413,7 +382,6 @@ jobs:
           version_id="$(jq -er .version_id upload-result.json)"
           {
             echo "artifact_sha256=$artifact_sha256"
-            echo "candidate_asset_paths=$candidate_asset_paths"
             echo "version_id=$version_id"
           } >> "$GITHUB_OUTPUT"
           jq -n \
@@ -544,7 +512,6 @@ jobs:
     timeout-minutes: 20
     env:
       ARTIFACT_SHA256: ${{ needs.upload.outputs.artifact_sha256 }}
-      CANDIDATE_ASSET_PATHS_JSON: ${{ needs.upload.outputs.candidate_asset_paths }}
       CANDIDATE_VERSION_ID: ${{ needs.upload.outputs.version_id }}
       PREVIOUS_VERSION_ID: ${{ needs.upload.outputs.previous_version_id }}
       SOURCE_BRANCH: main
@@ -845,6 +812,25 @@ jobs:
             return 1
           }
 
+          expect_candidate_home() {
+            local expected_marker="worker-release-marker:$SOURCE_COMMIT"
+            local attempt
+            for attempt in $(seq 1 12); do
+              if expect_status 200 \
+                "https://www.zenml.io/?__worker_marker_attempt=$attempt" \
+                preflight-home "$CANDIDATE_VERSION_ID" 1 0 &&
+                grep -Fq -- "$expected_marker" \
+                  "$RUNNER_TEMP/smoke-preflight-home.body"; then
+                return 0
+              fi
+              if [ "$attempt" -lt 12 ]; then
+                sleep 5
+              fi
+            done
+            echo "The exact-version homepage did not converge to the candidate release marker." >&2
+            return 1
+          }
+
           rollback_previous_version() {
             local original_status=$?
             trap - ERR
@@ -952,25 +938,7 @@ jobs:
           verify_preflight_deployment \
             "$RUNNER_TEMP/deployments-after-preflight.json"
 
-          jq -e '
-            type == "array" and
-            length >= 1 and
-            length <= 6 and
-            all(.[]; test("^/_astro/[A-Za-z0-9._-]+$"))
-          ' <<< "$CANDIDATE_ASSET_PATHS_JSON" > /dev/null
-          jq -er '.[]' <<< "$CANDIDATE_ASSET_PATHS_JSON" \
-            > "$RUNNER_TEMP/candidate-asset-paths.txt"
-          while read -r asset_path; do
-            expect_status 200 \
-              "https://www.zenml.io${asset_path}" \
-              preflight-candidate-asset "$CANDIDATE_VERSION_ID" 12 5
-          done < "$RUNNER_TEMP/candidate-asset-paths.txt"
-
-          expect_status 200 \
-            "https://www.zenml.io/" preflight-home "$CANDIDATE_VERSION_ID"
-          while read -r asset_path; do
-            grep -Fq "$asset_path" "$RUNNER_TEMP/smoke-preflight-home.body"
-          done < "$RUNNER_TEMP/candidate-asset-paths.txt"
+          expect_candidate_home
           verify_preflight_deployment \
             "$RUNNER_TEMP/deployments-immediately-before-promotion.json"
 
@@ -1082,7 +1050,6 @@ jobs:
             ${{ runner.temp }}/worker-domains-before-activation.json
             ${{ runner.temp }}/smoke-*.body
             ${{ runner.temp }}/smoke-assets.txt
-            ${{ runner.temp }}/candidate-asset-paths.txt
           if-no-files-found: warn
           retention-days: 30
 

--- a/.github/workflows/release-worker.yml
+++ b/.github/workflows/release-worker.yml
@@ -114,6 +114,7 @@ jobs:
     timeout-minutes: 15
     outputs:
       artifact_sha256: ${{ steps.upload.outputs.artifact_sha256 }}
+      candidate_asset_paths: ${{ steps.upload.outputs.candidate_asset_paths }}
       previous_version_id: ${{ steps.baseline.outputs.previous_version_id }}
       version_id: ${{ steps.upload.outputs.version_id }}
     env:
@@ -352,6 +353,38 @@ jobs:
 
           export WRANGLER_OUTPUT_FILE_PATH="$output_file"
           artifact_sha256="$(jq -r .artifact_sha256 worker-manifest.json)"
+          curl \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            "https://www.zenml.io/?__worker_candidate_baseline=$GITHUB_RUN_ID" \
+            > "$RUNNER_TEMP/accepted-production-home.html"
+          grep -Eo '/_astro/[A-Za-z0-9._-]+' dist/client/index.html \
+            | LC_ALL=C sort -u \
+            > "$RUNNER_TEMP/candidate-home-asset-paths.txt"
+          grep -Eo '/_astro/[A-Za-z0-9._-]+' \
+            "$RUNNER_TEMP/accepted-production-home.html" \
+            | LC_ALL=C sort -u \
+            > "$RUNNER_TEMP/accepted-production-asset-paths.txt"
+          comm -23 \
+            "$RUNNER_TEMP/candidate-home-asset-paths.txt" \
+            "$RUNNER_TEMP/accepted-production-asset-paths.txt" \
+            | sed -n '1,6p' \
+            > "$RUNNER_TEMP/candidate-asset-paths.txt"
+          test -s "$RUNNER_TEMP/candidate-asset-paths.txt"
+          candidate_asset_paths="$(
+            jq -R -s -c \
+              'split("\n") | map(select(length > 0))' \
+              "$RUNNER_TEMP/candidate-asset-paths.txt"
+          )"
+          jq -e '
+            type == "array" and
+            length >= 1 and
+            length <= 6 and
+            all(.[]; test("^/_astro/[A-Za-z0-9._-]+$"))
+          ' <<< "$candidate_asset_paths" > /dev/null
           version_message="source_commit=$SOURCE_COMMIT source_branch=$SOURCE_BRANCH source_run_id=$SOURCE_RUN_ID artifact_sha256=$artifact_sha256"
           wrangler versions upload \
             --config dist/server/upload-wrangler.json \
@@ -380,6 +413,7 @@ jobs:
           version_id="$(jq -er .version_id upload-result.json)"
           {
             echo "artifact_sha256=$artifact_sha256"
+            echo "candidate_asset_paths=$candidate_asset_paths"
             echo "version_id=$version_id"
           } >> "$GITHUB_OUTPUT"
           jq -n \
@@ -510,6 +544,7 @@ jobs:
     timeout-minutes: 20
     env:
       ARTIFACT_SHA256: ${{ needs.upload.outputs.artifact_sha256 }}
+      CANDIDATE_ASSET_PATHS_JSON: ${{ needs.upload.outputs.candidate_asset_paths }}
       CANDIDATE_VERSION_ID: ${{ needs.upload.outputs.version_id }}
       PREVIOUS_VERSION_ID: ${{ needs.upload.outputs.previous_version_id }}
       SOURCE_BRANCH: main
@@ -771,10 +806,12 @@ jobs:
             local url="$2"
             local label="$3"
             local version_override="${4:-}"
+            local max_attempts="${5:-3}"
+            local retry_delay="${6:-2}"
             local actual
             local request_url
             local -a curl_args
-            for attempt in 1 2 3; do
+            for ((attempt=1; attempt<=max_attempts; attempt++)); do
               request_url="$url"
               curl_args=(
                 --connect-timeout 10
@@ -799,12 +836,12 @@ jobs:
               if [ "$actual" = "$expected" ]; then
                 return 0
               fi
-              if [ "$attempt" -lt 3 ]; then
-                sleep 2
+              if [ "$attempt" -lt "$max_attempts" ]; then
+                sleep "$retry_delay"
               fi
             done
-            printf '%s expected HTTP %s, received %s after 3 attempts.\n' \
-              "$url" "$expected" "$actual" >&2
+            printf '%s expected HTTP %s, received %s after %s attempts.\n' \
+              "$url" "$expected" "$actual" "$max_attempts" >&2
             return 1
           }
 
@@ -915,19 +952,25 @@ jobs:
           verify_preflight_deployment \
             "$RUNNER_TEMP/deployments-after-preflight.json"
 
-          expect_status 200 \
-            "https://www.zenml.io/" preflight-home "$CANDIDATE_VERSION_ID"
-          grep -Eo '/_astro/[^" ]+' "$RUNNER_TEMP/smoke-preflight-home.body" \
-            | sort -u \
-            | sed -n '1,6p' \
-            > "$RUNNER_TEMP/smoke-preflight-assets.txt"
-          test -s "$RUNNER_TEMP/smoke-preflight-assets.txt"
+          jq -e '
+            type == "array" and
+            length >= 1 and
+            length <= 6 and
+            all(.[]; test("^/_astro/[A-Za-z0-9._-]+$"))
+          ' <<< "$CANDIDATE_ASSET_PATHS_JSON" > /dev/null
+          jq -er '.[]' <<< "$CANDIDATE_ASSET_PATHS_JSON" \
+            > "$RUNNER_TEMP/candidate-asset-paths.txt"
           while read -r asset_path; do
             expect_status 200 \
               "https://www.zenml.io${asset_path}" \
-              preflight-asset \
-              "$CANDIDATE_VERSION_ID"
-          done < "$RUNNER_TEMP/smoke-preflight-assets.txt"
+              preflight-candidate-asset "$CANDIDATE_VERSION_ID" 12 5
+          done < "$RUNNER_TEMP/candidate-asset-paths.txt"
+
+          expect_status 200 \
+            "https://www.zenml.io/" preflight-home "$CANDIDATE_VERSION_ID"
+          while read -r asset_path; do
+            grep -Fq "$asset_path" "$RUNNER_TEMP/smoke-preflight-home.body"
+          done < "$RUNNER_TEMP/candidate-asset-paths.txt"
           verify_preflight_deployment \
             "$RUNNER_TEMP/deployments-immediately-before-promotion.json"
 
@@ -1039,7 +1082,7 @@ jobs:
             ${{ runner.temp }}/worker-domains-before-activation.json
             ${{ runner.temp }}/smoke-*.body
             ${{ runner.temp }}/smoke-assets.txt
-            ${{ runner.temp }}/smoke-preflight-assets.txt
+            ${{ runner.temp }}/candidate-asset-paths.txt
           if-no-files-found: warn
           retention-days: 30
 

--- a/docs/worker-release-runbook.md
+++ b/docs/worker-release-runbook.md
@@ -95,17 +95,15 @@ Immediately before exact-version activation, the workflow rechecks that the
 source commit is still the live `main`. It first creates a deployment with the
 accepted previous version at 100 percent and the exact candidate at 0 percent.
 Normal visitors therefore continue to receive the previous version. Requests
-carrying Cloudflare's exact-version override then verify content-hashed asset
-paths present in the exact validated candidate artifact but absent from the
-accepted production homepage. The workflow stops before upload if it cannot
-derive at least one candidate-only path. It allows a
-bounded convergence window because Cloudflare can briefly ignore a version
-override after a deployment changes. An ignored override reaches the accepted
-previous version, where the candidate-only hashes return 404, so it cannot
-produce a false pass. Once those assets are reachable, the workflow verifies
-that the overridden homepage references the same candidate hashes. Retry
-requests use distinct query strings so a transient edge 404 cannot satisfy
-every retry from cache.
+carrying Cloudflare's exact-version override then verify a source-commit marker
+embedded in the exact validated candidate homepage. The marker is part of the
+checksummed Worker artifact, so it changes for every source commit, including
+content-only releases. The workflow retries the overridden homepage and its
+marker together for a bounded convergence window because Cloudflare can briefly
+ignore a version override after a deployment changes. An ignored override
+returns the accepted previous homepage, which lacks the candidate marker, so it
+cannot produce a false pass. Retry requests use distinct query strings so a
+stale edge response cannot satisfy every retry from cache.
 
 After the zero-traffic preflight passes, the workflow rechecks that the accepted
 100/0 deployment is still present. It then promotes the candidate to 100

--- a/docs/worker-release-runbook.md
+++ b/docs/worker-release-runbook.md
@@ -95,15 +95,24 @@ Immediately before exact-version activation, the workflow rechecks that the
 source commit is still the live `main`. It first creates a deployment with the
 accepted previous version at 100 percent and the exact candidate at 0 percent.
 Normal visitors therefore continue to receive the previous version. Requests
-carrying Cloudflare's exact-version override then verify a source-commit marker
-embedded in the exact validated candidate homepage. The marker is part of the
-checksummed Worker artifact, so it changes for every source commit, including
-content-only releases. The workflow retries the overridden homepage and its
-marker together for a bounded convergence window because Cloudflare can briefly
-ignore a version override after a deployment changes. An ignored override
-returns the accepted previous homepage, which lacks the candidate marker, so it
-cannot produce a false pass. Retry requests use distinct query strings so a
-stale edge response cannot satisfy every retry from cache.
+carrying Cloudflare's exact-version override then verify a marker embedded in
+the exact validated candidate homepage. CI stamps the marker with the source
+commit, CI run ID, and run attempt before the static, Worker-runtime, and
+browser-hydration checks. The marker is therefore part of the checksummed
+Worker artifact and changes for every source commit and every rerun. The
+workflow retries the overridden homepage and its marker together for a bounded
+convergence window because Cloudflare can briefly ignore a version override
+after a deployment changes. An ignored override returns the accepted previous
+homepage, which lacks the candidate marker, so it cannot produce a false pass.
+Retry requests use distinct query strings so a stale edge response cannot
+satisfy every retry from cache.
+
+After the homepage marker succeeds, the workflow also requests up to six
+`/_astro` paths extracted from that exact candidate homepage. The asset requests
+run in parallel, use the same version override, and retry as one bounded set.
+This catches the case where the candidate HTML has propagated but one of its
+referenced assets has not. The zero-traffic preflight stops before promotion if
+either the homepage identity or the candidate asset set cannot converge.
 
 After the zero-traffic preflight passes, the workflow rechecks that the accepted
 100/0 deployment is still present. It then promotes the candidate to 100

--- a/docs/worker-release-runbook.md
+++ b/docs/worker-release-runbook.md
@@ -95,9 +95,17 @@ Immediately before exact-version activation, the workflow rechecks that the
 source commit is still the live `main`. It first creates a deployment with the
 accepted previous version at 100 percent and the exact candidate at 0 percent.
 Normal visitors therefore continue to receive the previous version. Requests
-carrying Cloudflare's exact-version override then verify the candidate homepage
-and a sample of its content-hashed assets. Retry requests use distinct query
-strings so a transient edge 404 cannot satisfy every retry from cache.
+carrying Cloudflare's exact-version override then verify content-hashed asset
+paths present in the exact validated candidate artifact but absent from the
+accepted production homepage. The workflow stops before upload if it cannot
+derive at least one candidate-only path. It allows a
+bounded convergence window because Cloudflare can briefly ignore a version
+override after a deployment changes. An ignored override reaches the accepted
+previous version, where the candidate-only hashes return 404, so it cannot
+produce a false pass. Once those assets are reachable, the workflow verifies
+that the overridden homepage references the same candidate hashes. Retry
+requests use distinct query strings so a transient edge 404 cannot satisfy
+every retry from cache.
 
 After the zero-traffic preflight passes, the workflow rechecks that the accepted
 100/0 deployment is still present. It then promotes the candidate to 100

--- a/src/lib/githubStars.ts
+++ b/src/lib/githubStars.ts
@@ -143,34 +143,32 @@ export async function fetchGithubStarsFromGitHub({
       headers.Authorization = `Bearer ${token}`;
     }
 
-    const response = await Promise.race([
-      fetchImpl(apiUrl, {
-        headers,
-        signal: controller.signal,
-      }),
-      new Promise<null>((resolveTimeout) => {
+    return await Promise.race([
+      (async (): Promise<GithubStarsFetchResult> => {
+        const response = await fetchImpl(apiUrl, {
+          headers,
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          return { ok: false, status: response.status };
+        }
+
+        const payload = await response.json();
+        const stars = readStargazersCount(payload);
+        if (stars === null) {
+          return { ok: false, status: response.status };
+        }
+
+        return { ok: true, stars };
+      })(),
+      new Promise<GithubStarsFetchResult>((resolveTimeout) => {
         timeoutId = setTimeout(() => {
           controller.abort();
-          resolveTimeout(null);
+          resolveTimeout({ ok: false });
         }, timeoutMs);
       }),
     ]);
-
-    if (response === null) {
-      return { ok: false };
-    }
-
-    if (!response.ok) {
-      return { ok: false, status: response.status };
-    }
-
-    const payload = await response.json();
-    const stars = readStargazersCount(payload);
-    if (stars === null) {
-      return { ok: false, status: response.status };
-    }
-
-    return { ok: true, stars };
   } catch {
     return { ok: false };
   } finally {

--- a/tests/config/deploymentWorkflows.test.ts
+++ b/tests/config/deploymentWorkflows.test.ts
@@ -30,8 +30,10 @@ interface ProductionWorkflow {
   jobs: Record<
     string,
     {
+      env?: Record<string, string>;
       environment?: string;
       if?: string;
+      outputs?: Record<string, string>;
       permissions?: Record<string, string>;
       steps: WorkflowStep[];
     }
@@ -1306,6 +1308,9 @@ describe("automatic post-cutover production release", () => {
     const candidateOverride = run.indexOf(
       '"https://www.zenml.io/" preflight-home "$CANDIDATE_VERSION_ID"',
     );
+    const candidateAssetOverride = run.indexOf(
+      '"https://www.zenml.io$' + '{asset_path}"',
+    );
     const finalPreflightCheck = run.indexOf(
       '"$RUNNER_TEMP/deployments-immediately-before-promotion.json"',
     );
@@ -1318,7 +1323,9 @@ describe("automatic post-cutover production release", () => {
     expect(liveBaselineCheck).toBeGreaterThan(liveMainCheck);
     expect(activationAttempted).toBeGreaterThan(liveBaselineCheck);
     expect(zeroTrafficPreflight).toBeGreaterThan(activationAttempted);
+    expect(candidateAssetOverride).toBeGreaterThan(zeroTrafficPreflight);
     expect(candidateOverride).toBeGreaterThan(zeroTrafficPreflight);
+    expect(candidateOverride).toBeGreaterThan(candidateAssetOverride);
     expect(finalPreflightCheck).toBeGreaterThan(candidateOverride);
     expect(activation).toBeGreaterThan(finalPreflightCheck);
     expect(activation).toBeGreaterThan(liveMainCheck);
@@ -1328,6 +1335,49 @@ describe("automatic post-cutover production release", () => {
     );
     expect(run).toContain(
       "Production baseline changed before activation; refusing to overwrite it.",
+    );
+  });
+
+  it("proves the version override reached the exact candidate artifact before promotion", () => {
+    const uploadStep = workflowStep(
+      releaseUploadSteps,
+      "Upload inactive production version",
+    );
+    const releaseStep = workflowStep(
+      releaseActivationSteps,
+      "Activate, smoke-test, and roll back on failure",
+    );
+    const uploadProgram = uploadStep.run ?? "";
+    const releaseProgram = releaseStep.run ?? "";
+
+    expect(releaseWorkflowConfig.jobs.upload.outputs).toMatchObject({
+      candidate_asset_paths:
+        "$" + "{{ steps.upload.outputs.candidate_asset_paths }}",
+    });
+    expect(uploadProgram).toContain("dist/client/index.html");
+    expect(uploadProgram).toContain(
+      '"https://www.zenml.io/?__worker_candidate_baseline=$GITHUB_RUN_ID"',
+    );
+    expect(uploadProgram).toContain("comm -23");
+    expect(uploadProgram).toContain(
+      'echo "candidate_asset_paths=$candidate_asset_paths"',
+    );
+    expect(releaseWorkflowConfig.jobs.activate.env).toMatchObject({
+      CANDIDATE_ASSET_PATHS_JSON:
+        "$" + "{{ needs.upload.outputs.candidate_asset_paths }}",
+    });
+    expect(releaseProgram).toContain(
+      "jq -er '.[]' <<< \"$CANDIDATE_ASSET_PATHS_JSON\"",
+    );
+    expect(releaseProgram).toContain(
+      '"https://www.zenml.io$' + '{asset_path}"',
+    );
+    expect(releaseProgram).toContain('grep -Fq "$asset_path"');
+    expect(releaseProgram).toContain(
+      "for ((attempt=1; attempt<=max_attempts; attempt++))",
+    );
+    expect(releaseProgram).toContain(
+      'preflight-candidate-asset "$CANDIDATE_VERSION_ID" 12 5',
     );
   });
 

--- a/tests/config/deploymentWorkflows.test.ts
+++ b/tests/config/deploymentWorkflows.test.ts
@@ -379,7 +379,8 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 if [ "$calls" -ge "$CURL_MARKER_AFTER_CALL" ]; then
-  printf '<!-- worker-release-marker:%s -->\\n' "$SOURCE_COMMIT" > "$output_file"
+  printf '<!-- worker-release-marker:%s:%s:%s -->\\n' \
+    "$SOURCE_COMMIT" "$SOURCE_RUN_ID" "$SOURCE_RUN_ATTEMPT" > "$output_file"
 else
   printf '<html>old release</html>\\n' > "$output_file"
 fi
@@ -415,6 +416,84 @@ expect_candidate_home
               PATH: `${binDirectory}:${process.env.PATH ?? ""}`,
               RUNNER_TEMP: harnessDirectory,
               SOURCE_COMMIT: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              SOURCE_RUN_ATTEMPT: "1",
+              SOURCE_RUN_ID: "12345",
+            },
+            stdio: ["ignore", "pipe", "pipe"],
+          },
+        );
+      } catch (caught) {
+        error = caught;
+      }
+      const curlCalls = Number.parseInt(readFileSync(callsFile, "utf8"), 10);
+      return { curlCalls, error };
+    },
+  );
+}
+
+function executeCandidateAssetCheck(statusAfterCall: number): {
+  curlCalls: number;
+  error: unknown;
+} {
+  const releaseStep = workflowStep(
+    releaseActivationSteps,
+    "Activate, smoke-test, and roll back on failure",
+  );
+  const run = releaseStep.run ?? "";
+  const functionStart = run.indexOf("expect_status() {");
+  const functionEnd = run.indexOf("rollback_previous_version() {");
+  expect(functionStart).toBeGreaterThan(-1);
+  expect(functionEnd).toBeGreaterThan(functionStart);
+  const verificationFunctions = run.slice(functionStart, functionEnd);
+
+  return withTemporaryHarness(
+    "worker-release-candidate-asset-",
+    (harnessDirectory, binDirectory) => {
+      const callsFile = join(harnessDirectory, "curl-calls.txt");
+      writeFileSync(callsFile, "0\n");
+      writeFileSync(
+        join(binDirectory, "curl"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+calls="$(cat "$CURL_CALLS_FILE")"
+calls=$((calls + 1))
+printf '%s\\n' "$calls" > "$CURL_CALLS_FILE"
+if [ "$calls" -ge "$CURL_ASSET_STATUS_AFTER_CALL" ]; then
+  printf '200\\n'
+else
+  printf '404\\n'
+fi
+`,
+      );
+      writeFileSync(
+        join(binDirectory, "sleep"),
+        "#!/usr/bin/env bash\nexit 0\n",
+      );
+      chmodSync(join(binDirectory, "curl"), 0o755);
+      chmodSync(join(binDirectory, "sleep"), 0o755);
+
+      let error: unknown;
+      try {
+        execFileSync(
+          "bash",
+          [
+            "-c",
+            `set -Eeuo pipefail
+${verificationFunctions}
+worker_name="zenml-io-v2-worker"
+expect_candidate_assets
+`,
+          ],
+          {
+            env: {
+              ...process.env,
+              CANDIDATE_ASSET_PATHS_JSON: '["/_astro/candidate.js"]',
+              CANDIDATE_VERSION_ID: "22222222-2222-2222-2222-222222222222",
+              CURL_ASSET_STATUS_AFTER_CALL: String(statusAfterCall),
+              CURL_CALLS_FILE: callsFile,
+              GITHUB_RUN_ID: "12345",
+              PATH: `${binDirectory}:${process.env.PATH ?? ""}`,
+              RUNNER_TEMP: harnessDirectory,
             },
             stdio: ["ignore", "pipe", "pipe"],
           },
@@ -1432,8 +1511,9 @@ describe("automatic post-cutover production release", () => {
     const uploadProgram = uploadStep.run ?? "";
     const releaseProgram = releaseStep.run ?? "";
 
+    expect(deployWorkflow).toContain("- name: Stamp exact release marker");
     expect(deployWorkflow).toContain(
-      'release_marker="worker-release-marker:$SOURCE_COMMIT"',
+      'release_marker="worker-release-marker:$SOURCE_COMMIT:$RUN_ID:$RUN_ATTEMPT"',
     );
     expect(deployWorkflow).toContain(
       "printf '\\n<!-- %s -->\\n' \"$release_marker\" >> dist/client/index.html",
@@ -1441,21 +1521,28 @@ describe("automatic post-cutover production release", () => {
     expect(deployWorkflow).toContain(
       'grep -Fq -- "$release_marker" dist/client/index.html',
     );
-    expect(releaseWorkflowConfig.jobs.upload.outputs).not.toHaveProperty(
+    expect(deployWorkflow.indexOf("Stamp exact release marker")).toBeLessThan(
+      deployWorkflow.indexOf("Smoke test built site output"),
+    );
+    expect(releaseWorkflowConfig.jobs.upload.outputs).toHaveProperty(
       "candidate_asset_paths",
     );
     expect(uploadProgram).toContain(
-      'release_marker="worker-release-marker:$SOURCE_COMMIT"',
+      'release_marker="worker-release-marker:$SOURCE_COMMIT:$SOURCE_RUN_ID:$source_run_attempt"',
     );
     expect(uploadProgram).toContain(
       'grep -Fq -- "$release_marker" dist/client/index.html',
     );
-    expect(releaseWorkflowConfig.jobs.activate.env).not.toHaveProperty(
+    expect(uploadProgram).toContain("source_run_attempt");
+    expect(releaseWorkflowConfig.jobs.activate.env).toHaveProperty(
       "CANDIDATE_ASSET_PATHS_JSON",
+    );
+    expect(releaseWorkflowConfig.jobs.activate.env).toHaveProperty(
+      "SOURCE_RUN_ATTEMPT",
     );
     expect(releaseProgram).toContain("expect_candidate_home() {");
     expect(releaseProgram).toContain(
-      'local expected_marker="worker-release-marker:$SOURCE_COMMIT"',
+      'local expected_marker="worker-release-marker:$SOURCE_COMMIT:$SOURCE_RUN_ID:$SOURCE_RUN_ATTEMPT"',
     );
     expect(releaseProgram).toContain("for attempt in $(seq 1 12); do");
     expect(releaseProgram).toContain(
@@ -1468,7 +1555,19 @@ describe("automatic post-cutover production release", () => {
     expect(releaseProgram).toContain(
       "The exact-version homepage did not converge to the candidate release marker.",
     );
-    expect(releaseProgram).not.toContain("preflight-candidate-asset");
+    expect(releaseProgram).toContain("expect_candidate_assets() {");
+    expect(releaseProgram).toContain(
+      `"https://www.zenml.io\${asset_path}?__worker_candidate_asset=\${GITHUB_RUN_ID}-\${attempt}-\${asset_index}"`,
+    );
+    expect(releaseProgram).toContain(
+      'Cloudflare-Workers-Version-Overrides: $worker_name=\\"$CANDIDATE_VERSION_ID\\"',
+    );
+    expect(releaseProgram).toContain(
+      "The exact-version candidate assets did not converge.",
+    );
+    expect(
+      releaseProgram.lastIndexOf("expect_candidate_assets"),
+    ).toBeGreaterThan(releaseProgram.lastIndexOf("expect_candidate_home"));
   });
 
   it("bounds activation deployment reads and retries post-activation verification", () => {
@@ -1706,6 +1805,16 @@ describe("automatic post-cutover production release", () => {
     expect(converged.curlCalls).toBe(2);
 
     const exhausted = executeCandidateHomeCheck(13);
+    expect(exhausted.error).toBeDefined();
+    expect(exhausted.curlCalls).toBe(12);
+  });
+
+  it("retries candidate assets before promotion and fails closed when they stay unavailable", () => {
+    const converged = executeCandidateAssetCheck(2);
+    expect(converged.error).toBeUndefined();
+    expect(converged.curlCalls).toBe(2);
+
+    const exhausted = executeCandidateAssetCheck(13);
     expect(exhausted.error).toBeDefined();
     expect(exhausted.curlCalls).toBe(12);
   });

--- a/tests/config/deploymentWorkflows.test.ts
+++ b/tests/config/deploymentWorkflows.test.ts
@@ -339,6 +339,95 @@ expect_status 200 "https://www.zenml.io/" retry-test "22222222-2222-2222-2222-22
   );
 }
 
+function executeCandidateHomeCheck(markerAfterCall: number): {
+  curlCalls: number;
+  error: unknown;
+} {
+  const releaseStep = workflowStep(
+    releaseActivationSteps,
+    "Activate, smoke-test, and roll back on failure",
+  );
+  const run = releaseStep.run ?? "";
+  const functionStart = run.indexOf("expect_status() {");
+  const functionEnd = run.indexOf("rollback_previous_version() {");
+  expect(functionStart).toBeGreaterThan(-1);
+  expect(functionEnd).toBeGreaterThan(functionStart);
+  const verificationFunctions = run.slice(functionStart, functionEnd);
+
+  return withTemporaryHarness(
+    "worker-release-candidate-home-",
+    (harnessDirectory, binDirectory) => {
+      const callsFile = join(harnessDirectory, "curl-calls.txt");
+      writeFileSync(callsFile, "0\n");
+      writeFileSync(
+        join(binDirectory, "curl"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+calls="$(cat "$CURL_CALLS_FILE")"
+calls=$((calls + 1))
+printf '%s\\n' "$calls" > "$CURL_CALLS_FILE"
+output_file=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output)
+      output_file="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+if [ "$calls" -ge "$CURL_MARKER_AFTER_CALL" ]; then
+  printf '<!-- worker-release-marker:%s -->\\n' "$SOURCE_COMMIT" > "$output_file"
+else
+  printf '<html>old release</html>\\n' > "$output_file"
+fi
+printf '200\\n'
+`,
+      );
+      writeFileSync(
+        join(binDirectory, "sleep"),
+        "#!/usr/bin/env bash\nexit 0\n",
+      );
+      chmodSync(join(binDirectory, "curl"), 0o755);
+      chmodSync(join(binDirectory, "sleep"), 0o755);
+
+      let error: unknown;
+      try {
+        execFileSync(
+          "bash",
+          [
+            "-c",
+            `set -Eeuo pipefail
+${verificationFunctions}
+worker_name="zenml-io-v2-worker"
+expect_candidate_home
+`,
+          ],
+          {
+            env: {
+              ...process.env,
+              CANDIDATE_VERSION_ID: "22222222-2222-2222-2222-222222222222",
+              CURL_CALLS_FILE: callsFile,
+              CURL_MARKER_AFTER_CALL: String(markerAfterCall),
+              GITHUB_RUN_ID: "12345",
+              PATH: `${binDirectory}:${process.env.PATH ?? ""}`,
+              RUNNER_TEMP: harnessDirectory,
+              SOURCE_COMMIT: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            },
+            stdio: ["ignore", "pipe", "pipe"],
+          },
+        );
+      } catch (caught) {
+        error = caught;
+      }
+      const curlCalls = Number.parseInt(readFileSync(callsFile, "utf8"), 10);
+      return { curlCalls, error };
+    },
+  );
+}
+
 function executeRecovery(
   initialVersion: string,
   deployFailures: number,
@@ -1305,12 +1394,7 @@ describe("automatic post-cutover production release", () => {
     const zeroTrafficPreflight = run.indexOf(
       'wrangler versions deploy "$PREVIOUS_VERSION_ID@100%" "$CANDIDATE_VERSION_ID@0%"',
     );
-    const candidateOverride = run.indexOf(
-      '"https://www.zenml.io/" preflight-home "$CANDIDATE_VERSION_ID"',
-    );
-    const candidateAssetOverride = run.indexOf(
-      '"https://www.zenml.io$' + '{asset_path}"',
-    );
+    const candidateHome = run.lastIndexOf("expect_candidate_home");
     const finalPreflightCheck = run.indexOf(
       '"$RUNNER_TEMP/deployments-immediately-before-promotion.json"',
     );
@@ -1323,10 +1407,8 @@ describe("automatic post-cutover production release", () => {
     expect(liveBaselineCheck).toBeGreaterThan(liveMainCheck);
     expect(activationAttempted).toBeGreaterThan(liveBaselineCheck);
     expect(zeroTrafficPreflight).toBeGreaterThan(activationAttempted);
-    expect(candidateAssetOverride).toBeGreaterThan(zeroTrafficPreflight);
-    expect(candidateOverride).toBeGreaterThan(zeroTrafficPreflight);
-    expect(candidateOverride).toBeGreaterThan(candidateAssetOverride);
-    expect(finalPreflightCheck).toBeGreaterThan(candidateOverride);
+    expect(candidateHome).toBeGreaterThan(zeroTrafficPreflight);
+    expect(finalPreflightCheck).toBeGreaterThan(candidateHome);
     expect(activation).toBeGreaterThan(finalPreflightCheck);
     expect(activation).toBeGreaterThan(liveMainCheck);
     expect(activation).toBeGreaterThan(activationAttempted);
@@ -1338,7 +1420,7 @@ describe("automatic post-cutover production release", () => {
     );
   });
 
-  it("proves the version override reached the exact candidate artifact before promotion", () => {
+  it("proves the version override reached the exact checksummed candidate artifact before promotion", () => {
     const uploadStep = workflowStep(
       releaseUploadSteps,
       "Upload inactive production version",
@@ -1350,35 +1432,43 @@ describe("automatic post-cutover production release", () => {
     const uploadProgram = uploadStep.run ?? "";
     const releaseProgram = releaseStep.run ?? "";
 
-    expect(releaseWorkflowConfig.jobs.upload.outputs).toMatchObject({
-      candidate_asset_paths:
-        "$" + "{{ steps.upload.outputs.candidate_asset_paths }}",
-    });
-    expect(uploadProgram).toContain("dist/client/index.html");
+    expect(deployWorkflow).toContain(
+      'release_marker="worker-release-marker:$SOURCE_COMMIT"',
+    );
+    expect(deployWorkflow).toContain(
+      "printf '\\n<!-- %s -->\\n' \"$release_marker\" >> dist/client/index.html",
+    );
+    expect(deployWorkflow).toContain(
+      'grep -Fq -- "$release_marker" dist/client/index.html',
+    );
+    expect(releaseWorkflowConfig.jobs.upload.outputs).not.toHaveProperty(
+      "candidate_asset_paths",
+    );
     expect(uploadProgram).toContain(
-      '"https://www.zenml.io/?__worker_candidate_baseline=$GITHUB_RUN_ID"',
+      'release_marker="worker-release-marker:$SOURCE_COMMIT"',
     );
-    expect(uploadProgram).toContain("comm -23");
     expect(uploadProgram).toContain(
-      'echo "candidate_asset_paths=$candidate_asset_paths"',
+      'grep -Fq -- "$release_marker" dist/client/index.html',
     );
-    expect(releaseWorkflowConfig.jobs.activate.env).toMatchObject({
-      CANDIDATE_ASSET_PATHS_JSON:
-        "$" + "{{ needs.upload.outputs.candidate_asset_paths }}",
-    });
-    expect(releaseProgram).toContain(
-      "jq -er '.[]' <<< \"$CANDIDATE_ASSET_PATHS_JSON\"",
+    expect(releaseWorkflowConfig.jobs.activate.env).not.toHaveProperty(
+      "CANDIDATE_ASSET_PATHS_JSON",
     );
+    expect(releaseProgram).toContain("expect_candidate_home() {");
     expect(releaseProgram).toContain(
-      '"https://www.zenml.io$' + '{asset_path}"',
+      'local expected_marker="worker-release-marker:$SOURCE_COMMIT"',
     );
-    expect(releaseProgram).toContain('grep -Fq "$asset_path"');
+    expect(releaseProgram).toContain("for attempt in $(seq 1 12); do");
     expect(releaseProgram).toContain(
-      "for ((attempt=1; attempt<=max_attempts; attempt++))",
+      '"https://www.zenml.io/?__worker_marker_attempt=$attempt"',
     );
     expect(releaseProgram).toContain(
-      'preflight-candidate-asset "$CANDIDATE_VERSION_ID" 12 5',
+      'preflight-home "$CANDIDATE_VERSION_ID" 1 0',
     );
+    expect(releaseProgram).toContain('grep -Fq -- "$expected_marker"');
+    expect(releaseProgram).toContain(
+      "The exact-version homepage did not converge to the candidate release marker.",
+    );
+    expect(releaseProgram).not.toContain("preflight-candidate-asset");
   });
 
   it("bounds activation deployment reads and retries post-activation verification", () => {
@@ -1608,6 +1698,16 @@ describe("automatic post-cutover production release", () => {
     ]);
     expect(result.curlArgs[0]).toContain("__worker_smoke=12345-1");
     expect(result.curlArgs[1]).toContain("__worker_smoke=12345-2");
+  });
+
+  it("retries a stale 200 homepage only until it carries the candidate marker", () => {
+    const converged = executeCandidateHomeCheck(2);
+    expect(converged.error).toBeUndefined();
+    expect(converged.curlCalls).toBe(2);
+
+    const exhausted = executeCandidateHomeCheck(13);
+    expect(exhausted.error).toBeDefined();
+    expect(exhausted.curlCalls).toBe(12);
   });
 
   it("executes recovery reconciliation and fails closed when recovery cannot complete", () => {

--- a/tests/config/workerPreviewControlPlane.test.ts
+++ b/tests/config/workerPreviewControlPlane.test.ts
@@ -405,7 +405,7 @@ describe("preview Worker upload workflow", () => {
       )
       .digest("hex");
 
-    expect(gitBlobSha).toBe("f60e9bd4235c2395550a9d1e0b229c0c1dfeeade");
+    expect(gitBlobSha).toBe("39d1e68210d303947f484abc436a25b4827d9990");
     expect(trustedArtifactWorkflowText).toBe(artifactWorkflowText);
     expect(trustedArtifactWorkflowText).toContain(
       "name: Website CI and Worker Artifact",

--- a/tests/config/workerPreviewControlPlane.test.ts
+++ b/tests/config/workerPreviewControlPlane.test.ts
@@ -405,7 +405,7 @@ describe("preview Worker upload workflow", () => {
       )
       .digest("hex");
 
-    expect(gitBlobSha).toBe("c6ab87cc03335b38d2d35c75efce878e4cea4f13");
+    expect(gitBlobSha).toBe("f60e9bd4235c2395550a9d1e0b229c0c1dfeeade");
     expect(trustedArtifactWorkflowText).toBe(artifactWorkflowText);
     expect(trustedArtifactWorkflowText).toContain(
       "name: Website CI and Worker Artifact",

--- a/tests/lib/githubStars.test.ts
+++ b/tests/lib/githubStars.test.ts
@@ -23,4 +23,27 @@ describe("fetchGithubStarsFromGitHub", () => {
     await expect(resultPromise).resolves.toEqual({ ok: false });
     expect(requestSignals[0]?.aborted).toBe(true);
   });
+
+  it("returns the fallback result when a GitHub response body stalls", async () => {
+    vi.useFakeTimers();
+    const requestSignals: AbortSignal[] = [];
+    const response = {
+      ok: true,
+      status: 200,
+      json: async () => await new Promise<unknown>(() => {}),
+    } as Response;
+    const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
+      requestSignals.push(init?.signal as AbortSignal);
+      return response;
+    });
+
+    const resultPromise = fetchGithubStarsFromGitHub({
+      fetchImpl,
+      timeoutMs: 2_000,
+    });
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await expect(resultPromise).resolves.toEqual({ ok: false });
+    expect(requestSignals[0]?.aborted).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Prevent the automatic Worker release from mistaking the accepted Astro 5 site for the Astro 6 candidate while Cloudflare's exact-version override is still propagating.

Release run `30528635924` placed the candidate at 0 percent, but Cloudflare briefly ignored the override and returned Astro 5. Because the workflow derived its expected hashes from that response, the old homepage and old assets formed a false-positive preflight. Promotion then exposed Astro 6 HTML before its hashed asset was reachable, and the existing rollback restored Astro 5 correctly.

## Changes

- Derive homepage asset hashes from the exact validated candidate artifact before upload.
- Fetch the accepted production homepage and retain only hashes absent from that Astro 5 response, making the sample candidate-specific.
- Stop before upload if no candidate-only asset path can be established.
- After creating the 100/0 deployment, retry those candidate-only paths through the version override during a bounded propagation window.
- Verify the overridden homepage references the same candidate hashes before rechecking the 100/0 deployment and allowing promotion.
- Preserve the candidate path evidence and document the fail-closed behavior in the release runbook.
- Add workflow contract tests covering candidate identity, ordering, propagation retries, and handoff between the upload and activation jobs.

## Review focus

- Confirm an ignored version override cannot satisfy the candidate-only asset checks against Astro 5.
- Confirm normal visitors remain on the accepted Astro 5 version throughout the 100/0 preflight.
- Confirm the workflow still refuses unknown deployment states and retains the existing inline rollback and independent recovery behavior.

## Validation

- `pnpm check`
- `pnpm check:tests`
- `pnpm check:surface`
- `pnpm check:alt`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm smoke:dist`
- `pnpm check:worker`
- `pnpm check:islands`
- `git diff --check`

All passed locally with Node 22. The expected missing local form-secret warnings and two existing Astro diagnostic hints remain unchanged.

## Merge behavior

Merging this PR triggers a normal main CI run. If CI passes, the trusted automatic release may upload a new inactive Astro 6 candidate. Normal visitors remain on Astro 5 while the candidate-specific preflight runs. Only a successful candidate proof permits promotion; any failed post-promotion check retains the existing automatic rollback and recovery path.

This PR does not change DNS, Worker routes, Access, Pages fallback, dependencies, application code, or other `zenml.io` subdomains.
