### PR TITLE
Prepare Astro 7 Worker artifact contracts

### DIFF
--- a/.github/trusted/worker-artifact-workflow.yml
+++ b/.github/trusted/worker-artifact-workflow.yml
@@ -141,15 +141,27 @@ jobs:
           deploy_config_sha256="$(
             sha256sum .wrangler/deploy/config.json | cut -d ' ' -f 1
           )"
+          astro_major="$(
+            node -p 'require("./node_modules/astro/package.json").version.split(".")[0]'
+          )"
+          case "$astro_major" in
+            6|7)
+              artifact_contract="astro-cloudflare-v${astro_major}"
+              ;;
+            *)
+              echo "Unsupported Astro major for Worker artifact: $astro_major" >&2
+              exit 1
+              ;;
+          esac
           jq -n \
             --arg artifact_sha256 "$(cut -d ' ' -f 1 worker-dist.sha256)" \
-            --arg artifact_contract "astro-cloudflare-v6" \
+            --arg artifact_contract "$artifact_contract" \
             --arg build_commit "$BUILD_COMMIT" \
             --arg deploy_config_sha256 "$deploy_config_sha256" \
             --arg event_name "$EVENT_NAME" \
             --arg generated_config_sha256 "$generated_config_sha256" \
             --arg lockfile_sha256 "$(sha256sum pnpm-lock.yaml | cut -d ' ' -f 1)" \
-            --argjson production_release_eligible true \
+            --argjson production_release_eligible false \
             --arg run_attempt "$RUN_ATTEMPT" \
             --arg run_id "$RUN_ID" \
             --arg source_branch "$SOURCE_BRANCH" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,15 +141,27 @@ jobs:
           deploy_config_sha256="$(
             sha256sum .wrangler/deploy/config.json | cut -d ' ' -f 1
           )"
+          astro_major="$(
+            node -p 'require("./node_modules/astro/package.json").version.split(".")[0]'
+          )"
+          case "$astro_major" in
+            6|7)
+              artifact_contract="astro-cloudflare-v${astro_major}"
+              ;;
+            *)
+              echo "Unsupported Astro major for Worker artifact: $astro_major" >&2
+              exit 1
+              ;;
+          esac
           jq -n \
             --arg artifact_sha256 "$(cut -d ' ' -f 1 worker-dist.sha256)" \
-            --arg artifact_contract "astro-cloudflare-v6" \
+            --arg artifact_contract "$artifact_contract" \
             --arg build_commit "$BUILD_COMMIT" \
             --arg deploy_config_sha256 "$deploy_config_sha256" \
             --arg event_name "$EVENT_NAME" \
             --arg generated_config_sha256 "$generated_config_sha256" \
             --arg lockfile_sha256 "$(sha256sum pnpm-lock.yaml | cut -d ' ' -f 1)" \
-            --argjson production_release_eligible true \
+            --argjson production_release_eligible false \
             --arg run_attempt "$RUN_ATTEMPT" \
             --arg run_id "$RUN_ID" \
             --arg source_branch "$SOURCE_BRANCH" \

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -173,7 +173,8 @@ jobs:
             --arg build_commit "$BUILD_COMMIT" \
             --arg commit "$SOURCE_COMMIT" \
             --arg run_id "$SOURCE_RUN_ID" '
-              .artifact_contract == "astro-cloudflare-v6" and
+              (.artifact_contract == "astro-cloudflare-v6" or
+               .artifact_contract == "astro-cloudflare-v7") and
               .artifact_sha256 == $artifact_sha256 and
               .build_commit == $build_commit and
               .event_name == "pull_request" and

--- a/.github/workflows/release-worker.yml
+++ b/.github/workflows/release-worker.yml
@@ -143,7 +143,8 @@ jobs:
             --arg commit "$SOURCE_COMMIT" \
             --arg run_id "$SOURCE_RUN_ID" \
             '.production_release_eligible == true and
-             .artifact_contract == "astro-cloudflare-v6" and
+             (.artifact_contract == "astro-cloudflare-v6" or
+              .artifact_contract == "astro-cloudflare-v7") and
              .artifact_sha256 == $artifact_sha256 and
              .build_commit == $commit and
              .event_name == "push" and

--- a/.github/workflows/upload-worker-candidate.yml
+++ b/.github/workflows/upload-worker-candidate.yml
@@ -114,7 +114,9 @@ jobs:
             --arg branch "$SOURCE_BRANCH" \
             --arg commit "$SOURCE_COMMIT" \
             --arg run_id "$SOURCE_RUN_ID" \
-            '.artifact_contract == "astro-cloudflare-v6" and
+            '(.artifact_contract == "astro-cloudflare-v6" or
+             .artifact_contract == "astro-cloudflare-v7") and
+             .production_release_eligible == true and
              .artifact_sha256 == $artifact_sha256 and
              .source_branch == $branch and
              .source_commit == $commit and

--- a/.github/workflows/upload-worker-preview.yml
+++ b/.github/workflows/upload-worker-preview.yml
@@ -178,7 +178,8 @@ jobs:
             --arg commit "$SOURCE_COMMIT" \
             --arg run_id "$SOURCE_RUN_ID" \
             --arg source_event "$source_event" '
-              .artifact_contract == "astro-cloudflare-v6" and
+              (.artifact_contract == "astro-cloudflare-v6" or
+               .artifact_contract == "astro-cloudflare-v7") and
               .event_name == $source_event and
               .artifact_sha256 == $artifact_sha256 and
               .source_branch == $branch and

--- a/docs/worker-release-runbook.md
+++ b/docs/worker-release-runbook.md
@@ -2,10 +2,11 @@
 
 ## Current boundary
 
-The accepted Astro 5 Worker serves `www.zenml.io/*`. Cloudflare Pages remains
-available beneath that route as the deeper fallback. No release workflow
-attaches or removes a route, changes a custom domain, edits DNS, changes Access,
-or removes Pages.
+The accepted Astro 6 Worker serves `www.zenml.io/*`. The accepted Astro 5
+Worker version remains the immediate version rollback, and Cloudflare Pages
+remains available beneath the Worker route as the deeper fallback. No release
+workflow attaches or removes a route, changes a custom domain, edits DNS,
+changes Access, or removes Pages.
 
 The release controls now have six paths:
 
@@ -46,11 +47,12 @@ review-only public versions on a dedicated Worker; they cannot promote a branch
 artifact to production. Explicitly approved branch-built production promotion
 remains a separate follow-up.
 
-The Astro 6 private-preview and protected-staging checkpoints were accepted on
-2026-07-29. The artifact manifest now sets `production_release_eligible` to
-`true`, so each exact successful current-`main` artifact may continue into the
-trusted automatic production release. Changing this gate again requires a
-separate reviewed PR.
+The Astro 6 production checkpoint was accepted on 2026-08-02. During the Astro
+7 checkpoint, the artifact manifest sets `production_release_eligible` to
+`false`. Successful `main` CI still builds and publishes the exact validated
+artifact, but the automatic release workflow stops before any credentialed
+Cloudflare upload or activation. Re-enabling production release requires a
+later, separately reviewed PR after preview and protected-staging acceptance.
 
 ## Automatic current-main release
 
@@ -199,30 +201,32 @@ Worker version directly.
 
 The `worker-dist` Actions artifact contains:
 
-- `worker-dist.tar.gz`, preserving Astro 6's repo-relative `dist/` tree and
-  `.wrangler/deploy/config.json`;
+- `worker-dist.tar.gz`, preserving the installed Astro version's repo-relative
+  `dist/` tree and `.wrangler/deploy/config.json`;
 - `worker-dist.sha256`;
 - `worker-manifest.json`, recording the source and build commits, branch, event,
   run ID and attempt, artifact digest, lockfile digest, the
-  `astro-cloudflare-v6` contract marker, and separate digests for the generated
-  and redirect Wrangler configurations.
+  `astro-cloudflare-v6` or `astro-cloudflare-v7` contract marker, and separate
+  digests for the generated and redirect Wrangler configurations. The
+  credential-free producer derives this marker from the installed Astro major
+  and fails closed for every other major.
 
-Credentialed workflows verify the checksum and provenance, reject absolute or
-parent-traversing archive paths, reject links and special files, verify both
-configuration digests, and accept only the reviewed generated Wrangler
-configuration shape. The generated config points to `dist/server/entry.mjs`
-and serves assets from `dist/client`. Before publishing the artifact, the
-credential-free CI job copies only the artifact tree to a clean directory and
-runs Wrangler's upload dry-run. This proves that later jobs can upload it
-without the repository, `node_modules`, a rebuild, or branch-controlled package
-scripts.
+Credentialed workflows accept exactly those two framework contract markers,
+verify the checksum and provenance, reject absolute or parent-traversing
+archive paths, reject links and special files, verify both configuration
+digests, and accept only the reviewed generated Wrangler configuration shape.
+The generated config points to `dist/server/entry.mjs` and serves assets from
+`dist/client`. Before publishing the artifact, the credential-free CI job
+copies only the artifact tree to a clean directory and runs Wrangler's upload
+dry-run. This proves that later jobs can upload it without the repository,
+`node_modules`, a rebuild, or branch-controlled package scripts.
 
 The production-candidate workflow also requires the source commit's CI workflow
 file to match the trusted `main` definition. Credentialed consumers install
 Wrangler 4.110.0 themselves, derive a minimal upload config beside the generated
 server entrypoint, and do not execute branch-controlled package scripts.
 
-Astro 6 local preview uses `astro preview`. The dedicated Worker runtime check
+Local preview uses `astro preview`. The dedicated Worker runtime check
 still starts the generated `dist/server/wrangler.json` directly because it must
 exercise bindings, APIs, redirects, headers, assets, and 404 behavior in the
 same Worker layout that release jobs upload.
@@ -230,9 +234,10 @@ same Worker layout that release jobs upload.
 ## Runtime toolchain
 
 Local development and CI use Node 22.23.1. The package engine allows Node
-22.12.0 or newer within Node 22, which is Astro 6's supported Node line, while
-`.nvmrc` and both artifact workflow definitions pin 22.23.1 for repeatability.
-Wrangler remains pinned to 4.110.0. The site declares only the four Worker
+22.12.0 or newer within Node 22, which supports both reviewed Astro 6 and Astro
+7 contracts, while `.nvmrc` and both artifact workflow definitions pin 22.23.1
+for repeatability. Wrangler remains pinned to 4.110.0, and the Cloudflare
+compatibility date remains `2026-02-10`. The site declares only the four Worker
 environment variables it reads in `src/cloudflare-workers.d.ts`. This avoids
 loading Worker DOM globals into browser-side source while keeping
 `cloudflare:workers` imports typed.

--- a/tests/config/deploymentWorkflows.test.ts
+++ b/tests/config/deploymentWorkflows.test.ts
@@ -63,12 +63,14 @@ const prPreviewWorkflow = readFileSync(
   "utf8",
 );
 const prPreviewWorkflowConfig = parse(prPreviewWorkflow) as ProductionWorkflow;
+const deployWorkflowConfig = parse(deployWorkflow) as ProductionWorkflow;
 const candidateWorkflowConfig = parse(candidateWorkflow) as ProductionWorkflow;
 const activationWorkflowConfig = parse(
   activationWorkflow,
 ) as ProductionWorkflow;
 const releaseWorkflowConfig = parse(releaseWorkflow) as ProductionWorkflow;
 const candidateSteps = candidateWorkflowConfig.jobs["upload-candidate"].steps;
+const deploySteps = deployWorkflowConfig.jobs["repo-check"].steps;
 const activationSteps = activationWorkflowConfig.jobs.activate.steps;
 const releaseUploadSteps = releaseWorkflowConfig.jobs.upload.steps;
 const releaseActivationSteps = releaseWorkflowConfig.jobs.activate.steps;
@@ -666,17 +668,20 @@ printf '%s\\n' "$RECOVERY_HOME_STATUS"
 }
 
 function jqProgramReadingFrom(run: string, source: string): string {
-  const destination = `' ${source} > /dev/null`;
-  const destinationIndex = run.indexOf(destination);
-  expect(destinationIndex, `missing jq source for ${source}`).toBeGreaterThan(
-    -1,
-  );
-  const commandPrefix = run.slice(0, destinationIndex);
+  const sourceIndex = run.indexOf(`${source} > /dev/null`);
+  expect(sourceIndex, `missing jq source for ${source}`).toBeGreaterThan(-1);
+  const commandPrefix = run.slice(0, sourceIndex);
   const commandIndex = commandPrefix.lastIndexOf("jq -e");
   expect(commandIndex, `missing jq command for ${source}`).toBeGreaterThan(-1);
-  const programStart = commandPrefix.indexOf("'", commandIndex);
-  expect(programStart, `missing jq program for ${source}`).toBeGreaterThan(-1);
-  return commandPrefix.slice(programStart + 1);
+  const programEnd = commandPrefix.lastIndexOf("'");
+  expect(programEnd, `missing jq program end for ${source}`).toBeGreaterThan(
+    commandIndex,
+  );
+  const programStart = commandPrefix.lastIndexOf("'", programEnd - 1);
+  expect(programStart, `missing jq program for ${source}`).toBeGreaterThan(
+    commandIndex,
+  );
+  return commandPrefix.slice(programStart + 1, programEnd);
 }
 
 function expectJqResult(
@@ -1026,6 +1031,59 @@ describe("trusted production candidate uploader", () => {
     expectNoRouteOrDnsMutation(candidateWorkflow);
   });
 
+  it("accepts only eligible Astro 6 or 7 artifacts with exact provenance", () => {
+    const provenanceStep = workflowStep(
+      candidateSteps,
+      "Verify artifact provenance and checksum",
+    );
+    const program = jqProgramReadingFrom(
+      provenanceStep.run ?? "",
+      "worker-manifest.json",
+    );
+    const args = [
+      "--arg",
+      "artifact_sha256",
+      "artifact-sha",
+      "--arg",
+      "branch",
+      "main",
+      "--arg",
+      "commit",
+      "source-commit",
+      "--arg",
+      "run_id",
+      "12345",
+    ];
+    const manifest = {
+      artifact_contract: "astro-cloudflare-v6",
+      artifact_sha256: "artifact-sha",
+      production_release_eligible: true,
+      run_id: "12345",
+      source_branch: "main",
+      source_commit: "source-commit",
+    };
+
+    expectJqResult(program, manifest, true, args);
+    expectJqResult(
+      program,
+      { ...manifest, artifact_contract: "astro-cloudflare-v7" },
+      true,
+      args,
+    );
+    expectJqResult(
+      program,
+      { ...manifest, production_release_eligible: false },
+      false,
+      args,
+    );
+    expectJqResult(
+      program,
+      { ...manifest, artifact_contract: "astro-cloudflare-v8" },
+      false,
+      args,
+    );
+  });
+
   it("rejects empty production secrets before creating or uploading a secrets file", () => {
     const guardStep = workflowStep(
       candidateSteps,
@@ -1313,6 +1371,67 @@ describe("trusted production activation workflow", () => {
 });
 
 describe("automatic post-cutover production release", () => {
+  it("labels only reviewed Astro 6 or 7 artifacts and pauses production release", () => {
+    const packageStep = workflowStep(
+      deploySteps,
+      "Package the validated Worker artifact",
+    );
+    const packageRun = packageStep.run ?? "";
+    const caseStart = packageRun.indexOf('case "$astro_major" in');
+    const caseEnd = packageRun.indexOf("esac", caseStart);
+
+    expect(caseStart).toBeGreaterThan(-1);
+    expect(caseEnd).toBeGreaterThan(caseStart);
+    const caseProgram = packageRun.slice(caseStart, caseEnd + "esac".length);
+    const artifactContractFor = (astroMajor: string): string =>
+      execFileSync(
+        "bash",
+        [
+          "-c",
+          `set -euo pipefail\n${caseProgram}\nprintf '%s' "$artifact_contract"`,
+        ],
+        {
+          encoding: "utf8",
+          env: { ...process.env, astro_major: astroMajor },
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+
+    expect(artifactContractFor("6")).toBe("astro-cloudflare-v6");
+    expect(artifactContractFor("7")).toBe("astro-cloudflare-v7");
+    expect(() => artifactContractFor("8")).toThrow();
+
+    expect(deployWorkflow).toContain('astro_major="$(');
+    expect(deployWorkflow).toContain("node -p");
+    expect(deployWorkflow).toContain("node_modules/astro/package.json");
+    expect(deployWorkflow).toContain("6|7)");
+    expect(deployWorkflow).toContain(
+      'artifact_contract="astro-cloudflare-v$' + '{astro_major}"',
+    );
+    expect(deployWorkflow).toContain("Unsupported Astro major");
+    expect(deployWorkflow).toContain(
+      '--arg artifact_contract "$artifact_contract"',
+    );
+    expect(deployWorkflow).toContain(
+      "--argjson production_release_eligible false",
+    );
+    expect(deployWorkflow).not.toContain(
+      '--arg artifact_contract "astro-cloudflare-v6"',
+    );
+
+    for (const workflow of [
+      previewWorkflow,
+      candidateWorkflow,
+      releaseWorkflow,
+      prPreviewWorkflow,
+    ]) {
+      expect(workflow).toMatch(
+        /\(\.artifact_contract == "astro-cloudflare-v6" or\s+\.artifact_contract == "astro-cloudflare-v7"\)/,
+      );
+      expect(workflow).not.toMatch(/astro-cloudflare-v(?:[0-5]|[89]|\d{2,})/);
+    }
+  });
+
   it("runs only after successful current-main artifact CI", () => {
     expect(releaseWorkflow).toContain("workflow_run:");
     expect(releaseWorkflow).toContain(
@@ -1336,7 +1455,7 @@ describe("automatic post-cutover production release", () => {
     expect(releaseWorkflow).toContain("eligible=false");
     expect(releaseWorkflow).toContain(".production_release_eligible == true");
     expect(deployWorkflow).toContain(
-      "--argjson production_release_eligible true",
+      "--argjson production_release_eligible false",
     );
   });
 

--- a/tests/config/workerPreviewControlPlane.test.ts
+++ b/tests/config/workerPreviewControlPlane.test.ts
@@ -405,7 +405,7 @@ describe("preview Worker upload workflow", () => {
       )
       .digest("hex");
 
-    expect(gitBlobSha).toBe("39d1e68210d303947f484abc436a25b4827d9990");
+    expect(gitBlobSha).toBe("6ef20a3ab00c99aba12c3437a5abfb07f9e4ee44");
     expect(trustedArtifactWorkflowText).toBe(artifactWorkflowText);
     expect(trustedArtifactWorkflowText).toContain(
       "name: Website CI and Worker Artifact",
@@ -465,8 +465,8 @@ describe("preview Worker upload workflow", () => {
     expect(safetyStep.run).toContain("dist/server/wrangler.json");
     expect(safetyStep.run).toContain("dist/server/entry.mjs");
     expect(safetyStep.run).toContain(".wrangler/deploy/config.json");
-    expect(provenanceStep.run).toContain(
-      '.artifact_contract == "astro-cloudflare-v6"',
+    expect(provenanceStep.run).toMatch(
+      /\(\.artifact_contract == "astro-cloudflare-v6" or\s+\.artifact_contract == "astro-cloudflare-v7"\)/,
     );
   });
 


### PR DESCRIPTION
## Summary

Prepare the trusted Worker pipeline to recognize either the accepted Astro 6 artifact contract or the future Astro 7 contract without allowing either framework change to reach production automatically.

The credential-free producer now derives the contract marker from the installed Astro major and fails closed for every value except 6 or 7. Trusted preview consumers accept exactly those two markers, while both automatic release and manual production-candidate upload remain blocked by `production_release_eligible: false`.

## What changed

- Preserve the byte-identical trusted producer mirror and all existing source-workflow, provenance, checksum, binding, topology, candidate-asset, activation, and rollback checks.
- Keep Node 22.23.1, Wrangler 4.110.0, and the `2026-02-10` Cloudflare compatibility date unchanged.
- Update the release runbook to record Astro 6 as the accepted production baseline, Astro 5 as the immediate version rollback, Pages as the deeper fallback, and the explicit Astro 7 production pause.
- Add behavioral tests that execute the producer's Astro-major decision and trusted consumer predicates, including unsupported-major and ineligible-artifact rejection.

## Reviewer focus

- Confirm that `production_release_eligible` remains false and both production paths require it to be true.
- Confirm that the producer rejects every Astro major except 6 and 7, and consumers accept no other contract marker.
- Confirm that the mirrored producer remains byte-identical and no route, DNS, Access, binding, dependency, runtime, or production-activation change is included.

## Validation

- `pnpm check`
- `pnpm check:tests`
- `pnpm check:surface`
- `pnpm check:alt`
- `pnpm lint`
- `pnpm test` (185 tests passed)
- `pnpm build`
- `pnpm smoke:dist`
- `pnpm check:worker` (16 runtime checks passed)
- `pnpm check:islands` (4 browser hydration checks passed)
- `cmp -s .github/workflows/deploy.yml .github/trusted/worker-artifact-workflow.yml`

## Explicitly out of scope

No Astro 7 dependency or application change, Worker upload, production activation, route or DNS change, Access change, Pages retirement, analytics change, or unrelated refactor is included.
