### PR TITLE
Authorize Astro 7 Worker preview artifacts

### DIFF
--- a/.github/trusted/worker-artifact-workflow.yml
+++ b/.github/trusted/worker-artifact-workflow.yml
@@ -91,16 +91,31 @@ jobs:
           SOURCE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
+          astro_major="$(
+            node -p 'require("./node_modules/astro/package.json").version.split(".")[0]'
+          )"
+          case "$astro_major" in
+            6|7)
+              artifact_contract="astro-cloudflare-v${astro_major}"
+              ;;
+            *)
+              echo "Unsupported Astro major for Worker artifact: $astro_major" >&2
+              exit 1
+              ;;
+          esac
           jq -e '
             (keys | sort) == ["auxiliaryWorkers", "configPath", "prerenderWorkerConfigPath"] and
             .configPath == "../../dist/server/wrangler.json" and
             .auxiliaryWorkers == []
           ' .wrangler/deploy/config.json > /dev/null
-          jq -e '
+          jq -e --arg artifact_contract "$artifact_contract" '
             .name == "zenml-io-v2-worker" and
             .main == "entry.mjs" and
             .compatibility_date == "2026-02-10" and
-            .compatibility_flags == ["nodejs_compat"] and
+            ((($artifact_contract == "astro-cloudflare-v6") and
+              (.compatibility_flags == ["nodejs_compat"])) or
+             (($artifact_contract == "astro-cloudflare-v7") and
+              (.compatibility_flags == ["nodejs_compat", "disable_nodejs_process_v2"]))) and
             .workers_dev == false and
             .preview_urls == false and
             .no_bundle == true and
@@ -141,18 +156,6 @@ jobs:
           deploy_config_sha256="$(
             sha256sum .wrangler/deploy/config.json | cut -d ' ' -f 1
           )"
-          astro_major="$(
-            node -p 'require("./node_modules/astro/package.json").version.split(".")[0]'
-          )"
-          case "$astro_major" in
-            6|7)
-              artifact_contract="astro-cloudflare-v${astro_major}"
-              ;;
-            *)
-              echo "Unsupported Astro major for Worker artifact: $astro_major" >&2
-              exit 1
-              ;;
-          esac
           jq -n \
             --arg artifact_sha256 "$(cut -d ' ' -f 1 worker-dist.sha256)" \
             --arg artifact_contract "$artifact_contract" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,16 +91,31 @@ jobs:
           SOURCE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
+          astro_major="$(
+            node -p 'require("./node_modules/astro/package.json").version.split(".")[0]'
+          )"
+          case "$astro_major" in
+            6|7)
+              artifact_contract="astro-cloudflare-v${astro_major}"
+              ;;
+            *)
+              echo "Unsupported Astro major for Worker artifact: $astro_major" >&2
+              exit 1
+              ;;
+          esac
           jq -e '
             (keys | sort) == ["auxiliaryWorkers", "configPath", "prerenderWorkerConfigPath"] and
             .configPath == "../../dist/server/wrangler.json" and
             .auxiliaryWorkers == []
           ' .wrangler/deploy/config.json > /dev/null
-          jq -e '
+          jq -e --arg artifact_contract "$artifact_contract" '
             .name == "zenml-io-v2-worker" and
             .main == "entry.mjs" and
             .compatibility_date == "2026-02-10" and
-            .compatibility_flags == ["nodejs_compat"] and
+            ((($artifact_contract == "astro-cloudflare-v6") and
+              (.compatibility_flags == ["nodejs_compat"])) or
+             (($artifact_contract == "astro-cloudflare-v7") and
+              (.compatibility_flags == ["nodejs_compat", "disable_nodejs_process_v2"]))) and
             .workers_dev == false and
             .preview_urls == false and
             .no_bundle == true and
@@ -141,18 +156,6 @@ jobs:
           deploy_config_sha256="$(
             sha256sum .wrangler/deploy/config.json | cut -d ' ' -f 1
           )"
-          astro_major="$(
-            node -p 'require("./node_modules/astro/package.json").version.split(".")[0]'
-          )"
-          case "$astro_major" in
-            6|7)
-              artifact_contract="astro-cloudflare-v${astro_major}"
-              ;;
-            *)
-              echo "Unsupported Astro major for Worker artifact: $astro_major" >&2
-              exit 1
-              ;;
-          esac
           jq -n \
             --arg artifact_sha256 "$(cut -d ' ' -f 1 worker-dist.sha256)" \
             --arg artifact_contract "$artifact_contract" \

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -236,11 +236,15 @@ jobs:
           test "$(
             sha256sum .wrangler/deploy/config.json | cut -d ' ' -f 1
           )" = "$(jq -r .deploy_config_sha256 worker-manifest.json)"
-          jq -e '
+          artifact_contract="$(jq -r .artifact_contract worker-manifest.json)"
+          jq -e --arg artifact_contract "$artifact_contract" '
             .name == "zenml-io-v2-worker" and
             .main == "entry.mjs" and
             .compatibility_date == "2026-02-10" and
-            .compatibility_flags == ["nodejs_compat"] and
+            ((($artifact_contract == "astro-cloudflare-v6") and
+              (.compatibility_flags == ["nodejs_compat"])) or
+             (($artifact_contract == "astro-cloudflare-v7") and
+              (.compatibility_flags == ["nodejs_compat", "disable_nodejs_process_v2"]))) and
             .rules == [{"type":"ESModule","globs":["**/*.js","**/*.mjs"]}] and
             .workers_dev == false and
             .preview_urls == false and

--- a/tests/config/deploymentWorkflows.test.ts
+++ b/tests/config/deploymentWorkflows.test.ts
@@ -1418,6 +1418,21 @@ describe("automatic post-cutover production release", () => {
     expect(deployWorkflow).not.toContain(
       '--arg artifact_contract "astro-cloudflare-v6"',
     );
+    for (const workflow of [deployWorkflow, prPreviewWorkflow]) {
+      expect(workflow).toContain(
+        '($artifact_contract == "astro-cloudflare-v6") and',
+      );
+      expect(workflow).toContain(
+        '($artifact_contract == "astro-cloudflare-v7") and',
+      );
+      expect(workflow).toContain('.compatibility_flags == ["nodejs_compat"]');
+      expect(workflow).toContain(
+        '.compatibility_flags == ["nodejs_compat", "disable_nodejs_process_v2"]',
+      );
+    }
+    expect(prPreviewWorkflow).toContain(
+      'artifact_contract="$(jq -r .artifact_contract worker-manifest.json)"',
+    );
 
     for (const workflow of [
       previewWorkflow,

--- a/tests/config/workerPreviewControlPlane.test.ts
+++ b/tests/config/workerPreviewControlPlane.test.ts
@@ -405,7 +405,7 @@ describe("preview Worker upload workflow", () => {
       )
       .digest("hex");
 
-    expect(gitBlobSha).toBe("6ef20a3ab00c99aba12c3437a5abfb07f9e4ee44");
+    expect(gitBlobSha).toBe("713fbaf5160a1a3b710ccb89b2a4a3837cad9a21");
     expect(trustedArtifactWorkflowText).toBe(artifactWorkflowText);
     expect(trustedArtifactWorkflowText).toContain(
       "name: Website CI and Worker Artifact",


### PR DESCRIPTION
## Summary

Allow the trusted PR-preview pipeline to publish Astro 7 artifacts without weakening the existing Astro 6 contract. The current trust root rejects PR #204 before upload because its reviewed producer requires Astro 7's additional compatibility flag while `main` still pins the Astro 6-only rule.

## What changed

- Bind each supported artifact contract to one exact compatibility-flag list: Astro 6 requires `nodejs_compat`, while Astro 7 requires `nodejs_compat` plus `disable_nodejs_process_v2`.
- Keep the active producer byte-identical to its trusted copy so provenance checks continue to reject branch-defined build rules.
- Make the trusted per-PR publisher verify the same contract-to-flags pairing before it uses Cloudflare credentials.
- Add contract assertions and refresh the pinned trusted-workflow blob hash.

## Review focus

- Confirm that the transition accepts exactly the two intended contract/flag pairs and rejects crossed or arbitrary combinations.
- Confirm that `.github/workflows/deploy.yml` and `.github/trusted/worker-artifact-workflow.yml` remain byte-identical.
- Confirm that `production_release_eligible` remains `false`, so merging this prerequisite cannot activate a new production Worker version.

## Validation

- `actionlint`
- `pnpm check:tests` under Node 22.22.3
- `pnpm lint` under Node 22.22.3
- `pnpm test` under Node 22.22.3: 185 tests passed
- Focused workflow tests: 85 tests passed
- `git diff --check`

This trust-root PR is not expected to publish its own Worker preview. After it is merged, PR #204 can be updated from `main`; its next successful CI run should then publish and comment the isolated Astro 7 preview URL.
