### PR TITLE
Fix protected staging route guards

### DIFF
--- a/.github/workflows/activate-worker-preview.yml
+++ b/.github/workflows/activate-worker-preview.yml
@@ -36,6 +36,7 @@ permissions: {}
 
 env:
   WORKER_NAME: zenml-io-v2-worker-preview
+  STAGING_ROUTE: astro-workers-staging.zenml.io/*
 
 jobs:
   activate:
@@ -72,7 +73,7 @@ jobs:
       - name: Install pinned Wrangler
         run: npm install --global wrangler@4.110.0
 
-      - name: Verify the preview Worker is private and route-less
+      - name: Verify the preview Worker has only the protected staging route
         shell: bash
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -120,16 +121,21 @@ jobs:
             --show-error \
             --header "$auth_header" \
             "$api_base/workers/scripts" > "$RUNNER_TEMP/workers-before-activation.json"
-          jq -e --arg worker "$WORKER_NAME" '
+          jq -e --arg route "$STAGING_ROUTE" --arg worker "$WORKER_NAME" '
             .success == true and
             ([.result[] | select(.id == $worker)]) as $workers |
             ($workers | length) == 1 and
             ($workers[0] | has("routes")) and
+            ($workers[0].routes | type) == "array" and
+            ($workers[0].routes | length) == 1 and
             (
-              $workers[0].routes == null or
+              ($workers[0].routes[0] | type) == "string" and
+              $workers[0].routes[0] == $route
+              or
               (
-                ($workers[0].routes | type) == "array" and
-                ($workers[0].routes | length) == 0
+                ($workers[0].routes[0] | type) == "object" and
+                $workers[0].routes[0].pattern == $route and
+                $workers[0].routes[0].script == $worker
               )
             )
           ' "$RUNNER_TEMP/workers-before-activation.json" > /dev/null
@@ -272,16 +278,21 @@ jobs:
             --header "$auth_header" \
             "$api_base/workers/scripts" \
             > "$RUNNER_TEMP/workers-before-deploy.json"
-          jq -e --arg worker "$WORKER_NAME" '
+          jq -e --arg route "$STAGING_ROUTE" --arg worker "$WORKER_NAME" '
             .success == true and
             ([.result[] | select(.id == $worker)]) as $workers |
             ($workers | length) == 1 and
             ($workers[0] | has("routes")) and
+            ($workers[0].routes | type) == "array" and
+            ($workers[0].routes | length) == 1 and
             (
-              $workers[0].routes == null or
+              ($workers[0].routes[0] | type) == "string" and
+              $workers[0].routes[0] == $route
+              or
               (
-                ($workers[0].routes | type) == "array" and
-                ($workers[0].routes | length) == 0
+                ($workers[0].routes[0] | type) == "object" and
+                $workers[0].routes[0].pattern == $route and
+                $workers[0].routes[0].script == $worker
               )
             )
           ' "$RUNNER_TEMP/workers-before-deploy.json" > /dev/null
@@ -351,16 +362,21 @@ jobs:
             --show-error \
             --header "$auth_header" \
             "$api_base/workers/scripts" > "$RUNNER_TEMP/workers-after-activation.json"
-          jq -e --arg worker "$WORKER_NAME" '
+          jq -e --arg route "$STAGING_ROUTE" --arg worker "$WORKER_NAME" '
             .success == true and
             ([.result[] | select(.id == $worker)]) as $workers |
             ($workers | length) == 1 and
             ($workers[0] | has("routes")) and
+            ($workers[0].routes | type) == "array" and
+            ($workers[0].routes | length) == 1 and
             (
-              $workers[0].routes == null or
+              ($workers[0].routes[0] | type) == "string" and
+              $workers[0].routes[0] == $route
+              or
               (
-                ($workers[0].routes | type) == "array" and
-                ($workers[0].routes | length) == 0
+                ($workers[0].routes[0] | type) == "object" and
+                $workers[0].routes[0].pattern == $route and
+                $workers[0].routes[0].script == $worker
               )
             )
           ' "$RUNNER_TEMP/workers-after-activation.json" > /dev/null

--- a/.github/workflows/activate-worker-preview.yml
+++ b/.github/workflows/activate-worker-preview.yml
@@ -35,6 +35,8 @@ concurrency:
 permissions: {}
 
 env:
+  ACCESS_LOGIN_PREFIX: https://zenml.cloudflareaccess.com/cdn-cgi/access/login/astro-workers-staging.zenml.io
+  STAGING_URL: https://astro-workers-staging.zenml.io/
   WORKER_NAME: zenml-io-v2-worker-preview
   STAGING_ROUTE: astro-workers-staging.zenml.io/*
 
@@ -155,6 +157,23 @@ jobs:
             ([.result[] | select(.service == $worker)] | length == 0) and
             .result_info.total_count == 0
           ' "$RUNNER_TEMP/worker-domains.json" > /dev/null
+
+          access_status="$(
+            curl \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --silent \
+              --show-error \
+              --output /dev/null \
+              --dump-header "$RUNNER_TEMP/staging-access-before-activation.headers" \
+              --write-out "%{http_code}" \
+              "$STAGING_URL"
+          )"
+          test "$access_status" = "302"
+          tr -d '\r' < "$RUNNER_TEMP/staging-access-before-activation.headers" \
+            | grep -Fqi -- "location: $ACCESS_LOGIN_PREFIX"
+          tr -d '\r' < "$RUNNER_TEMP/staging-access-before-activation.headers" \
+            | grep -Fqi -- "www-authenticate: Cloudflare-Access"
 
       - name: Inspect the exact preview version
         shell: bash
@@ -313,6 +332,23 @@ jobs:
             .result_info.total_count == 0
           ' "$RUNNER_TEMP/worker-domains-before-deploy.json" > /dev/null
 
+          access_status="$(
+            curl \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --silent \
+              --show-error \
+              --output /dev/null \
+              --dump-header "$RUNNER_TEMP/staging-access-before-deploy.headers" \
+              --write-out "%{http_code}" \
+              "$STAGING_URL"
+          )"
+          test "$access_status" = "302"
+          tr -d '\r' < "$RUNNER_TEMP/staging-access-before-deploy.headers" \
+            | grep -Fqi -- "location: $ACCESS_LOGIN_PREFIX"
+          tr -d '\r' < "$RUNNER_TEMP/staging-access-before-deploy.headers" \
+            | grep -Fqi -- "www-authenticate: Cloudflare-Access"
+
           wrangler versions deploy "$VERSION_ID@100%" \
             --name "$WORKER_NAME" \
             --yes
@@ -396,3 +432,20 @@ jobs:
             ([.result[] | select(.service == $worker)] | length == 0) and
             .result_info.total_count == 0
           ' "$RUNNER_TEMP/worker-domains-after-activation.json" > /dev/null
+
+          access_status="$(
+            curl \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --silent \
+              --show-error \
+              --output /dev/null \
+              --dump-header "$RUNNER_TEMP/staging-access-after-activation.headers" \
+              --write-out "%{http_code}" \
+              "$STAGING_URL"
+          )"
+          test "$access_status" = "302"
+          tr -d '\r' < "$RUNNER_TEMP/staging-access-after-activation.headers" \
+            | grep -Fqi -- "location: $ACCESS_LOGIN_PREFIX"
+          tr -d '\r' < "$RUNNER_TEMP/staging-access-after-activation.headers" \
+            | grep -Fqi -- "www-authenticate: Cloudflare-Access"

--- a/.github/workflows/upload-worker-preview.yml
+++ b/.github/workflows/upload-worker-preview.yml
@@ -35,6 +35,8 @@ concurrency:
 permissions: {}
 
 env:
+  ACCESS_LOGIN_PREFIX: https://zenml.cloudflareaccess.com/cdn-cgi/access/login/astro-workers-staging.zenml.io
+  STAGING_URL: https://astro-workers-staging.zenml.io/
   WORKER_NAME: zenml-io-v2-worker-preview
   STAGING_ROUTE: astro-workers-staging.zenml.io/*
   SOURCE_RUN_PREDICATE: |
@@ -315,6 +317,23 @@ jobs:
             ([.result[] | select(.service == $worker)] | length == 0) and
             .result_info.total_count == 0
           ' "$RUNNER_TEMP/worker-domains.json" > /dev/null
+
+          access_status="$(
+            curl \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --silent \
+              --show-error \
+              --output /dev/null \
+              --dump-header "$RUNNER_TEMP/staging-access-before-upload.headers" \
+              --write-out "%{http_code}" \
+              "$STAGING_URL"
+          )"
+          test "$access_status" = "302"
+          tr -d '\r' < "$RUNNER_TEMP/staging-access-before-upload.headers" \
+            | grep -Fqi -- "location: $ACCESS_LOGIN_PREFIX"
+          tr -d '\r' < "$RUNNER_TEMP/staging-access-before-upload.headers" \
+            | grep -Fqi -- "www-authenticate: Cloudflare-Access"
 
       - name: Prepare trusted preview configuration
         shell: bash

--- a/.github/workflows/upload-worker-preview.yml
+++ b/.github/workflows/upload-worker-preview.yml
@@ -36,6 +36,7 @@ permissions: {}
 
 env:
   WORKER_NAME: zenml-io-v2-worker-preview
+  STAGING_ROUTE: astro-workers-staging.zenml.io/*
   SOURCE_RUN_PREDICATE: |
     .conclusion == "success" and
     .path == $path and
@@ -232,7 +233,7 @@ jobs:
           grep -Fx "dist/server/entry.mjs" "$RUNNER_TEMP/archive-paths.txt"
           grep -Fx ".wrangler/deploy/config.json" "$RUNNER_TEMP/archive-paths.txt"
 
-      - name: Verify the preview Worker is private and route-less
+      - name: Verify the preview Worker has only the protected staging route
         shell: bash
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -280,16 +281,21 @@ jobs:
             --show-error \
             --header "$auth_header" \
             "$api_base/workers/scripts" > "$RUNNER_TEMP/workers-before-upload.json"
-          jq -e --arg worker "$WORKER_NAME" '
+          jq -e --arg route "$STAGING_ROUTE" --arg worker "$WORKER_NAME" '
             .success == true and
             ([.result[] | select(.id == $worker)]) as $workers |
             ($workers | length) == 1 and
             ($workers[0] | has("routes")) and
+            ($workers[0].routes | type) == "array" and
+            ($workers[0].routes | length) == 1 and
             (
-              $workers[0].routes == null or
+              ($workers[0].routes[0] | type) == "string" and
+              $workers[0].routes[0] == $route
+              or
               (
-                ($workers[0].routes | type) == "array" and
-                ($workers[0].routes | length) == 0
+                ($workers[0].routes[0] | type) == "object" and
+                $workers[0].routes[0].pattern == $route and
+                $workers[0].routes[0].script == $worker
               )
             )
           ' "$RUNNER_TEMP/workers-before-upload.json" > /dev/null

--- a/docs/worker-preview-control-plane.md
+++ b/docs/worker-preview-control-plane.md
@@ -1,31 +1,32 @@
 # Preview Worker release controls
 
-This guide moves one reviewed website build onto the isolated
-`zenml-io-v2-worker-preview` Worker without exposing it to visitors. Upload,
-activation, and routing are separate actions. Completing one never authorizes
-the next.
+This guide moves one reviewed website build onto the protected staging Worker.
+Upload and activation are separate actions. Completing upload never authorizes
+activation.
 
 The preview Worker has no `workers.dev` address, no version preview URL, no
-custom domain, and no Worker route. Activating a version changes what the
-Worker would serve if it received traffic, but it does not send traffic to the
-Worker.
+custom domain, and exactly one Worker route:
+`astro-workers-staging.zenml.io/*`. Cloudflare Access protects that hostname.
+Uploading a version leaves staging traffic on the current version. Activating
+a version changes what authenticated staging visitors receive.
 
 ## Hard boundaries
 
-The three preview workflows:
+The upload and activation workflows:
 
 - run only from trusted `main`;
 - share one lock, so they cannot change the preview Worker concurrently;
 - use only the `worker-preview` GitHub environment;
 - target only `zenml-io-v2-worker-preview`;
-- never receive the Worker-routes token;
+- never receive the Worker-routes token and cannot change the fixed staging
+  route;
 - never change DNS, Pages, Access, custom domains, or production;
 - never print secret values.
 
 The Cloudflare Workers token is account-scoped because Cloudflare does not
-offer per-Worker script permissions. The fixed Worker name, trusted workflow
-code, environment branch policy, and absence of route authority are therefore
-security controls, not conveniences.
+offer per-Worker script permissions. The fixed Worker name, exact staging-route
+guard, trusted workflow code, environment branch policy, and absence of route
+mutation authority are therefore security controls, not conveniences.
 
 ## Required GitHub gate before merge
 
@@ -94,9 +95,10 @@ Pause and capture a timestamped read-only snapshot:
    trusted uploader dispatch commit and live `main` tip.
 2. The preview Worker exists.
 3. Its `workers.dev` endpoint and version preview URLs are disabled.
-4. It has no custom domain and no Worker route.
-5. `astro-workers-staging.zenml.io` still reaches retained Pages through
-   Cloudflare Access.
+4. It has no custom domain and owns exactly
+   `astro-workers-staging.zenml.io/*`, with no other route.
+5. An unauthenticated request to `astro-workers-staging.zenml.io` receives the
+   expected Cloudflare Access 302 login redirect and challenge header.
 6. `zenml.io` redirects normally and `www.zenml.io` serves the production
    site.
 7. `cloud.zenml.io`, `staging.cloud.zenml.io`, and the recorded platform-service
@@ -126,8 +128,9 @@ build commit used the immutable reviewed artifact workflow. A `main` artifact
 is accepted only when its branch and commit exactly match the trusted uploader
 dispatch commit and the live `main` tip. It then
 checks its checksum and manifest, rejects unsafe archive or Wrangler
-configuration, confirms the preview Worker is private and route-less, and
-uploads one inactive version with the two non-production form secrets.
+configuration, confirms the preview Worker has only the protected staging
+route, rechecks the anonymous Access challenge, and uploads one inactive
+version with the two non-production form secrets.
 
 The upload does not deploy the version. Its summary records the version ID and
 provenance. The workflow also preserves partial upload metadata even when a
@@ -144,7 +147,8 @@ inactive version.
 4. Its secret binding names include `TURNSTILE_SECRET_KEY` and
    `SEGMENT_FORMS_WRITE_KEY`; do not read or record their values.
 5. The active deployment is unchanged.
-6. Public Worker endpoints, custom domains, and routes remain absent.
+6. Public Worker endpoints and custom domains remain absent, and the exact
+   staging route is unchanged.
 7. Production, retained Pages, staging Access, and platform-service baselines
    remain unchanged.
 
@@ -170,9 +174,10 @@ Enter the six values recorded by the upload:
 - explicit self-review confirmation.
 
 The workflow inspects that exact version, verifies its provenance and secret
-binding names, saves the current deployment metadata, and deploys only that
-version at 100 percent on the preview Worker. It then confirms the Worker still
-has no public endpoint.
+binding names, saves the current deployment metadata, and rechecks the exact
+route plus anonymous Access challenge immediately before deploying only that
+version at 100 percent. It then confirms the route and Access protection remain
+unchanged.
 
 ### Pause and verify after activation
 
@@ -181,29 +186,23 @@ has no public endpoint.
    version metadata.
 3. The newest preview deployment contains only the approved version at
    100 percent.
-4. The preview Worker remains without public endpoints, custom domains, or
-   routes.
+4. The preview Worker remains without public Worker endpoints or custom
+   domains and still owns only the exact protected staging route.
 5. Production, retained Pages, staging Access, and platform-service baselines
    remain unchanged.
 
-At this point the new site code is active inside an unreachable Worker. There
-is still no browser URL for it. Attaching only
-`astro-workers-staging.zenml.io/*` is the next separate mutation and requires a
-fresh before-state, exact route review, explicit approval, and immediate
-after-state verification. That future route workflow must use the same
-`zenml-io-worker-preview` concurrency group so GitHub cannot interleave route
-attachment with upload or activation.
+At this point the new site code is active on the Access-protected staging URL.
+Pause for manual browser, content, form, API, redirect, header, 404, island,
+visual, and accessibility checks before any production-enablement work.
 
 ## Rollback boundaries
 
 - **Failed inactive upload:** no traffic changed. Leave the version inactive
   and stop.
-- **Failed or bad activation before a route exists:** the version may already
-  be active even if the run failed. Inspect the Worker read-only, keep the
-  route absent, and stop. The inert bootstrap version is not an accepted
-  serving fallback.
-- **Problem after the staging route is later attached:** remove only the exact
-  recorded staging route to restore retained Pages. Do not edit DNS or delete
-  Pages.
+- **Failed or bad activation:** the version may already be active even if the
+  run failed. Inspect the Worker read-only. If staging is unhealthy, restore
+  only the recorded accepted Astro 6 staging version at 100 percent. Preserve
+  the exact staging route, DNS, Access application, and retained Pages
+  fallback. Stop after verifying the restored deployment and Access challenge.
 - **Production:** these workflows cannot change it. Production cutover and
   rollback use separate controls and approvals.

--- a/docs/worker-release-runbook.md
+++ b/docs/worker-release-runbook.md
@@ -8,7 +8,7 @@ remains available beneath the Worker route as the deeper fallback. No release
 workflow attaches or removes a route, changes a custom domain, edits DNS,
 changes Access, or removes Pages.
 
-The release controls now have six paths:
+The release controls now have seven paths:
 
 1. `Website CI and Worker Artifact` builds once without credentials, validates
    that output, and publishes the exact archive plus checksum and provenance.
@@ -24,17 +24,23 @@ The release controls now have six paths:
 3. `Upload Exact Preview Worker Version` is manually dispatched from `main`
    after explicit review. It consumes either one successful same-repository PR
    artifact or the successful `push` artifact for the exact current `main`
-   commit, then uploads an inactive, unreachable version to
-   `zenml-io-v2-worker-preview`.
-4. `Upload Worker Production Candidate` is manually dispatched from `main` with
+   commit, then uploads an inactive version to `zenml-io-v2-worker-preview`
+   without changing the version currently served at the Access-protected
+   `astro-workers-staging.zenml.io/*` route. Its topology guard requires exactly
+   that one route and rejects every extra or reassigned route.
+4. `Activate Exact Preview Worker Version` is manually dispatched from `main`
+   with the inactive version's exact provenance. It rechecks the same single
+   protected staging route before and after activating that version at 100
+   percent. It does not attach, remove, or edit the route.
+5. `Upload Worker Production Candidate` is manually dispatched from `main` with
    an exact successful CI run, branch, and commit. It uploads an inactive
    version to `zenml-io-v2-worker` with public preview URLs disabled. This is a
    retained pre-cutover control and intentionally rejects the current live
    route topology.
-5. `Activate Exact Worker Version` is manually dispatched from `main` with an
+6. `Activate Exact Worker Version` is manually dispatched from `main` with an
    exact version ID and matching provenance. It is also a retained pre-cutover
    control and intentionally refuses to activate a routed Worker.
-6. `Publish Worker PR Preview` consumes successful same-repository,
+7. `Publish Worker PR Preview` consumes successful same-repository,
    non-draft PR artifacts from trusted `main` and publishes stable public
    aliases on the separate, route-less `zenml-io-v2-pr-preview` Worker. It
    never rebuilds the artifact or receives production, route, DNS, or Pages

--- a/scripts/check-worker-runtime.ts
+++ b/scripts/check-worker-runtime.ts
@@ -334,26 +334,6 @@ async function runChecks(baseUrl: string): Promise<CheckResult[]> {
   );
   await unverifiedForm.body?.cancel();
 
-  const stars = await requestWithTransientServiceRetry(
-    baseUrl,
-    "/api/github-stars",
-    {},
-  );
-  const starsPayload =
-    stars.status === 200
-      ? ((await stars.json()) as Record<string, unknown>)
-      : undefined;
-  check(
-    results,
-    "GitHub stars API returns a live, cached, or fallback snapshot",
-    stars.status === 200 &&
-      typeof starsPayload?.stars === "number" &&
-      ["github", "cache", "fallback"].includes(String(starsPayload.source)) &&
-      stars.headers.get("cache-control") !== null,
-    `status ${stars.status}, source ${String(starsPayload?.source)}`,
-  );
-  if (stars.status !== 200) await stars.body?.cancel();
-
   const csp = await requestWithTransientServiceRetry(
     baseUrl,
     "/api/csp-report",

--- a/tests/config/workerPreviewControlPlane.test.ts
+++ b/tests/config/workerPreviewControlPlane.test.ts
@@ -49,7 +49,9 @@ interface ManualPreviewWorkflow {
     group: string;
   };
   env: {
+    ACCESS_LOGIN_PREFIX: string;
     SOURCE_RUN_PREDICATE: string;
+    STAGING_URL: string;
     STAGING_ROUTE: string;
     WORKER_NAME: string;
   };
@@ -128,6 +130,16 @@ function expectJqResult(
   } else {
     expect(execute).toThrow();
   }
+}
+
+function expectAccessGate(step: WorkflowStep, headersFile: string): void {
+  expect(step.run).toContain(`--dump-header "$RUNNER_TEMP/${headersFile}"`);
+  expect(step.run).toContain('--write-out "%{http_code}"');
+  expect(step.run).toContain('test "$access_status" = "302"');
+  expect(step.run).toContain('grep -Fqi -- "location: $ACCESS_LOGIN_PREFIX"');
+  expect(step.run).toContain(
+    'grep -Fqi -- "www-authenticate: Cloudflare-Access"',
+  );
 }
 
 describe("preview Worker bootstrap workflow", () => {
@@ -488,6 +500,12 @@ describe("preview Worker upload workflow", () => {
     expect(uploadWorkflow.env.STAGING_ROUTE).toBe(
       "astro-workers-staging.zenml.io/*",
     );
+    expect(uploadWorkflow.env.STAGING_URL).toBe(
+      "https://astro-workers-staging.zenml.io/",
+    );
+    expect(uploadWorkflow.env.ACCESS_LOGIN_PREFIX).toBe(
+      "https://zenml.cloudflareaccess.com/cdn-cgi/access/login/astro-workers-staging.zenml.io",
+    );
     expect(
       uploadWorkflowText.match(/zenml-io-v2-worker-preview/g),
     ).toHaveLength(1);
@@ -503,6 +521,7 @@ describe("preview Worker upload workflow", () => {
       "/workers/domains?service=$WORKER_NAME&per_page=100",
     );
     expect(workerStep.run).toContain(".result_info.total_count == 0");
+    expectAccessGate(workerStep, "staging-access-before-upload.headers");
     expect(configStep.run).toContain("name: env.WORKER_NAME");
     expect(configStep.run).toContain("workers_dev: false");
     expect(configStep.run).toContain("preview_urls: false");
@@ -985,10 +1004,17 @@ describe("preview Worker activation workflow", () => {
     expect(activationWorkflow.env.STAGING_ROUTE).toBe(
       "astro-workers-staging.zenml.io/*",
     );
+    expect(activationWorkflow.env.STAGING_URL).toBe(
+      "https://astro-workers-staging.zenml.io/",
+    );
+    expect(activationWorkflow.env.ACCESS_LOGIN_PREFIX).toBe(
+      "https://zenml.cloudflareaccess.com/cdn-cgi/access/login/astro-workers-staging.zenml.io",
+    );
     expect(workerStep.run).toContain(
       "/workers/domains?service=$WORKER_NAME&per_page=100",
     );
     expect(workerStep.run).toContain(".result_info.total_count == 0");
+    expectAccessGate(workerStep, "staging-access-before-activation.headers");
     expect(inspectStep.run).toContain('wrangler versions view "$VERSION_ID"');
     expect(inspectStep.run).toContain('--name "$WORKER_NAME"');
     expect(provenanceStep.run).toContain('select(.type == "secret_text")');
@@ -1022,6 +1048,7 @@ describe("preview Worker activation workflow", () => {
     expect(activateStep.run).toContain("worker-subdomain-before-deploy.json");
     expect(activateStep.run).toContain("workers-before-deploy.json");
     expect(activateStep.run).toContain("worker-domains-before-deploy.json");
+    expectAccessGate(activateStep, "staging-access-before-deploy.headers");
     expect(activateStep.run).toContain(
       "/workers/domains?service=$WORKER_NAME&per_page=100",
     );
@@ -1037,6 +1064,7 @@ describe("preview Worker activation workflow", () => {
     );
     expect(verifyStep.run).toContain("workers-after-activation.json");
     expect(verifyStep.run).toContain("worker-domains-after-activation.json");
+    expectAccessGate(verifyStep, "staging-access-after-activation.headers");
     expect(activationWorkflowText).not.toContain(
       "secrets.CLOUDFLARE_WORKERS_PRODUCTION_TOKEN",
     );

--- a/tests/config/workerPreviewControlPlane.test.ts
+++ b/tests/config/workerPreviewControlPlane.test.ts
@@ -50,6 +50,7 @@ interface ManualPreviewWorkflow {
   };
   env: {
     SOURCE_RUN_PREDICATE: string;
+    STAGING_ROUTE: string;
     WORKER_NAME: string;
   };
   jobs: Record<
@@ -472,7 +473,7 @@ describe("preview Worker upload workflow", () => {
 
   it("uploads one private inactive version to only the fixed preview Worker", () => {
     const workerStep = uploadStep(
-      "Verify the preview Worker is private and route-less",
+      "Verify the preview Worker has only the protected staging route",
     );
     const configStep = uploadStep("Prepare trusted preview configuration");
     const captureDeploymentStep = uploadStep(
@@ -484,6 +485,9 @@ describe("preview Worker upload workflow", () => {
     );
 
     expect(uploadWorkflow.env.WORKER_NAME).toBe("zenml-io-v2-worker-preview");
+    expect(uploadWorkflow.env.STAGING_ROUTE).toBe(
+      "astro-workers-staging.zenml.io/*",
+    );
     expect(
       uploadWorkflowText.match(/zenml-io-v2-worker-preview/g),
     ).toHaveLength(1);
@@ -723,13 +727,20 @@ describe("preview Worker upload workflow", () => {
 
   it("executes the workflow privacy predicates against safe and public states", () => {
     const workerStep = uploadStep(
-      "Verify the preview Worker is private and route-less",
+      "Verify the preview Worker has only the protected staging route",
     );
     const run = workerStep.run ?? "";
     const subdomainProgram = jqProgramWritingTo(run, "worker-subdomain.json");
     const routesProgram = jqProgramWritingTo(run, "workers-before-upload.json");
     const domainsProgram = jqProgramWritingTo(run, "worker-domains.json");
-    const workerArgs = ["--arg", "worker", "zenml-io-v2-worker-preview"];
+    const workerArgs = [
+      "--arg",
+      "route",
+      "astro-workers-staging.zenml.io/*",
+      "--arg",
+      "worker",
+      "zenml-io-v2-worker-preview",
+    ];
 
     expectJqResult(
       subdomainProgram,
@@ -751,7 +762,17 @@ describe("preview Worker upload workflow", () => {
     expectJqResult(
       routesProgram,
       {
-        result: [{ id: "zenml-io-v2-worker-preview", routes: [] }],
+        result: [
+          {
+            id: "zenml-io-v2-worker-preview",
+            routes: [
+              {
+                pattern: "astro-workers-staging.zenml.io/*",
+                script: "zenml-io-v2-worker-preview",
+              },
+            ],
+          },
+        ],
         success: true,
       },
       true,
@@ -768,9 +789,57 @@ describe("preview Worker upload workflow", () => {
         ],
         success: true,
       },
+      true,
+      workerArgs,
+    );
+    expectJqResult(
+      routesProgram,
+      {
+        result: [
+          {
+            id: "zenml-io-v2-worker-preview",
+            routes: [],
+          },
+        ],
+        success: true,
+      },
       false,
       workerArgs,
     );
+    for (const routes of [
+      [
+        {
+          pattern: "www.zenml.io/*",
+          script: "zenml-io-v2-worker-preview",
+        },
+      ],
+      [
+        {
+          pattern: "astro-workers-staging.zenml.io/*",
+          script: "zenml-io-v2-worker",
+        },
+      ],
+      [
+        {
+          pattern: "astro-workers-staging.zenml.io/*",
+          script: "zenml-io-v2-worker-preview",
+        },
+        {
+          pattern: "extra.zenml.io/*",
+          script: "zenml-io-v2-worker-preview",
+        },
+      ],
+    ]) {
+      expectJqResult(
+        routesProgram,
+        {
+          result: [{ id: "zenml-io-v2-worker-preview", routes }],
+          success: true,
+        },
+        false,
+        workerArgs,
+      );
+    }
 
     expectJqResult(
       domainsProgram,
@@ -895,7 +964,7 @@ describe("preview Worker activation workflow", () => {
   it("validates inputs and inspects exact private-version provenance", () => {
     const validationStep = activationStep("Validate activation identifiers");
     const workerStep = activationStep(
-      "Verify the preview Worker is private and route-less",
+      "Verify the preview Worker has only the protected staging route",
     );
     const inspectStep = activationStep("Inspect the exact preview version");
     const provenanceStep = activationStep(
@@ -913,6 +982,9 @@ describe("preview Worker activation workflow", () => {
       ".result.enabled == false and .result.previews_enabled == false",
     );
     expect(workerStep.run).toContain('has("routes")');
+    expect(activationWorkflow.env.STAGING_ROUTE).toBe(
+      "astro-workers-staging.zenml.io/*",
+    );
     expect(workerStep.run).toContain(
       "/workers/domains?service=$WORKER_NAME&per_page=100",
     );
@@ -972,6 +1044,105 @@ describe("preview Worker activation workflow", () => {
     expect(activationWorkflowText).not.toContain("wrangler dns");
     expect(activationWorkflowText).not.toContain("wrangler pages");
     expect(activationWorkflowText).not.toContain("wrangler delete");
+  });
+
+  it("requires the exact protected staging route throughout activation", () => {
+    const routeChecks = [
+      [
+        activationStep(
+          "Verify the preview Worker has only the protected staging route",
+        ),
+        "workers-before-activation.json",
+      ],
+      [
+        activationStep("Activate exact preview version"),
+        "workers-before-deploy.json",
+      ],
+      [
+        activationStep("Verify exact activation and private endpoints"),
+        "workers-after-activation.json",
+      ],
+    ] as const;
+    const args = [
+      "--arg",
+      "route",
+      "astro-workers-staging.zenml.io/*",
+      "--arg",
+      "worker",
+      "zenml-io-v2-worker-preview",
+    ];
+    const acceptedWorker = {
+      id: "zenml-io-v2-worker-preview",
+      routes: [
+        {
+          pattern: "astro-workers-staging.zenml.io/*",
+          script: "zenml-io-v2-worker-preview",
+        },
+      ],
+    };
+    const rejectedWorkers = [
+      { ...acceptedWorker, routes: [] },
+      {
+        ...acceptedWorker,
+        routes: [
+          {
+            pattern: "astro-workers-staging.zenml.io/*",
+            script: "zenml-io-v2-worker",
+          },
+        ],
+      },
+      {
+        ...acceptedWorker,
+        routes: [
+          {
+            pattern: "www.zenml.io/*",
+            script: "zenml-io-v2-worker-preview",
+          },
+        ],
+      },
+      {
+        ...acceptedWorker,
+        routes: [
+          ...acceptedWorker.routes,
+          {
+            pattern: "extra.zenml.io/*",
+            script: "zenml-io-v2-worker-preview",
+          },
+        ],
+      },
+    ];
+
+    for (const [workflowStep, filename] of routeChecks) {
+      const program = jqProgramWritingTo(workflowStep.run ?? "", filename);
+      expectJqResult(
+        program,
+        { result: [acceptedWorker], success: true },
+        true,
+        args,
+      );
+      expectJqResult(
+        program,
+        {
+          result: [
+            {
+              ...acceptedWorker,
+              routes: ["astro-workers-staging.zenml.io/*"],
+            },
+          ],
+          success: true,
+        },
+        true,
+        args,
+      );
+      for (const worker of rejectedWorkers) {
+        expectJqResult(
+          program,
+          { result: [worker], success: true },
+          false,
+          args,
+        );
+      }
+    }
   });
 
   it("accepts only the newest exact 100-percent deployment", () => {


### PR DESCRIPTION
## Summary

The trusted staging upload and activation workflows can now operate against the accepted protected staging topology instead of stopping on their obsolete route-less assumption.

- Require exactly `astro-workers-staging.zenml.io/*` on `zenml-io-v2-worker-preview` before upload, before activation, and after activation.
- Continue rejecting missing routes, extra routes, the production hostname, a route assigned to another Worker, public `workers.dev` access, preview URLs, and custom domains.
- Accept both route shapes returned by Cloudflare's scripts API, matching the established production guard.
- Require the anonymous staging request to receive the expected Cloudflare Access 302 login redirect and challenge header before upload, immediately before activation, and after activation.
- Document that upload creates an inactive version without changing staging traffic, while activation changes only the version served through the fixed protected route.
- Keep the local Worker gate deterministic by removing its reintroduced live GitHub request; the GitHub stars route remains covered by API tests and the deployed production smoke check.

This PR does not upload or activate a Worker, change DNS, routes, Access, bindings, production eligibility, application code, or production traffic.

## Review focus

- Confirm the exact-route predicate stays fail-closed for every topology except the one accepted staging route.
- Confirm Access removal or misconfiguration stops activation before staging traffic changes.
- Confirm the executable tests run the actual embedded `jq` programs at all four workflow checkpoints.
- Confirm the local Worker gate no longer depends on GitHub availability while deployed release verification still exercises `/api/github-stars`.

## Validation

- `pnpm test` (192 tests passed)
- `pnpm check:tests`
- `pnpm lint`
- `pnpm build`
- `pnpm check:worker` (16 checks passed on three consecutive runs against the same built artifact)
- `actionlint .github/workflows/upload-worker-preview.yml .github/workflows/activate-worker-preview.yml`
- Live read-only Cloudflare inspection confirmed the current object-shaped route response and the expected route-to-Worker assignment before implementation.
- Live anonymous staging inspection confirmed the expected Access 302 redirect, ZenML Access login endpoint, and `WWW-Authenticate: Cloudflare-Access` challenge used by the new guard.

## Post-Deploy Monitoring & Validation

No production deployment occurs from this PR. After merge, repeat the read-only Worker, route, DNS, Access, and current-main artifact preflight before dispatching the inactive staging upload. Stop if staging no longer has exactly the accepted route, production changes, or any workflow guard fails; the accepted Astro 6 staging version remains the rollback target.
