### PR TITLE
Enable guarded Astro 7 production release

### DIFF
--- a/.github/trusted/worker-artifact-workflow.yml
+++ b/.github/trusted/worker-artifact-workflow.yml
@@ -156,6 +156,12 @@ jobs:
           deploy_config_sha256="$(
             sha256sum .wrangler/deploy/config.json | cut -d ' ' -f 1
           )"
+          production_release_eligible=false
+          if [ "$EVENT_NAME" = "push" ] &&
+             [ "$SOURCE_BRANCH" = "main" ] &&
+             [ "$SOURCE_COMMIT" = "$BUILD_COMMIT" ]; then
+            production_release_eligible=true
+          fi
           jq -n \
             --arg artifact_sha256 "$(cut -d ' ' -f 1 worker-dist.sha256)" \
             --arg artifact_contract "$artifact_contract" \
@@ -164,7 +170,7 @@ jobs:
             --arg event_name "$EVENT_NAME" \
             --arg generated_config_sha256 "$generated_config_sha256" \
             --arg lockfile_sha256 "$(sha256sum pnpm-lock.yaml | cut -d ' ' -f 1)" \
-            --argjson production_release_eligible false \
+            --argjson production_release_eligible "$production_release_eligible" \
             --arg run_attempt "$RUN_ATTEMPT" \
             --arg run_id "$RUN_ID" \
             --arg source_branch "$SOURCE_BRANCH" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -156,6 +156,12 @@ jobs:
           deploy_config_sha256="$(
             sha256sum .wrangler/deploy/config.json | cut -d ' ' -f 1
           )"
+          production_release_eligible=false
+          if [ "$EVENT_NAME" = "push" ] &&
+             [ "$SOURCE_BRANCH" = "main" ] &&
+             [ "$SOURCE_COMMIT" = "$BUILD_COMMIT" ]; then
+            production_release_eligible=true
+          fi
           jq -n \
             --arg artifact_sha256 "$(cut -d ' ' -f 1 worker-dist.sha256)" \
             --arg artifact_contract "$artifact_contract" \
@@ -164,7 +170,7 @@ jobs:
             --arg event_name "$EVENT_NAME" \
             --arg generated_config_sha256 "$generated_config_sha256" \
             --arg lockfile_sha256 "$(sha256sum pnpm-lock.yaml | cut -d ' ' -f 1)" \
-            --argjson production_release_eligible false \
+            --argjson production_release_eligible "$production_release_eligible" \
             --arg run_attempt "$RUN_ATTEMPT" \
             --arg run_id "$RUN_ID" \
             --arg source_branch "$SOURCE_BRANCH" \

--- a/.github/workflows/release-worker.yml
+++ b/.github/workflows/release-worker.yml
@@ -21,6 +21,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  ACCEPTED_PREVIOUS_VERSION_ID: 02cc10fa-da8c-4d0d-97bb-f6c12ed4a40f
   ACCEPTED_WORKER_ROUTES_JSON: '["www.zenml.io/*"]'
   WORKER_NAME: zenml-io-v2-worker
 
@@ -264,6 +265,10 @@ jobs:
             ' "$RUNNER_TEMP/deployments-before-upload.json"
           )"
           [[ "$previous_version_id" =~ ^[0-9a-f-]{36}$ ]]
+          if [ "$previous_version_id" != "$ACCEPTED_PREVIOUS_VERSION_ID" ]; then
+            echo "Production is not on the accepted Astro 6 rollback version." >&2
+            exit 1
+          fi
           echo "previous_version_id=$previous_version_id" >> "$GITHUB_OUTPUT"
 
           curl \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,18 +3,20 @@
 ## Project Overview
 
 This repository powers the live [zenml.io](https://www.zenml.io) marketing
-website. The source tree is on the production-ineligible Astro 7 checkpoint;
-the accepted Astro 6 Cloudflare Worker still serves production until the later
-staging and production-enablement checkpoints complete. The site is generated
-from the Astro content collections defined in `src/content.config.ts`.
+website. The source tree is on the production-eligible Astro 7 checkpoint after
+protected-staging acceptance. The accepted Astro 6 Cloudflare Worker continues
+to serve production until the guarded current-main release succeeds. The site
+is generated from the Astro content collections defined in
+`src/content.config.ts`.
 
 The site markets **two sub-products under one paid umbrella (ZenML Pro)**:
 - **ZenML** — ML workflow orchestration (the original product)
 - **Kitaru** — durable runtime for AI agents (folded in from `kitaru.ai`)
 
 - **Production URL**: https://www.zenml.io
-- **Hosting**: The accepted Astro 6 Cloudflare Worker serves production.
-  Cloudflare Pages remains available as the deeper fallback.
+- **Hosting**: The accepted Astro 6 Cloudflare Worker serves production until
+  guarded Astro 7 promotion succeeds. Cloudflare Pages remains available as
+  the deeper fallback.
 - **Scale**: content collections defined in `src/content.config.ts`, ~2,350 content items, ~2,560 assets on R2
 - **History**: Migrated from Webflow in Feb 2026 (`docs/MIGRATION.md`). Unified with `kitaru.ai` in May 2026 (`MERGE_PLAN.md`).
 - **Private details**: See `CLAUDE.private.md` (gitignored) for infrastructure IDs, traffic numbers, and internal docs index

--- a/docs/worker-release-runbook.md
+++ b/docs/worker-release-runbook.md
@@ -53,12 +53,22 @@ review-only public versions on a dedicated Worker; they cannot promote a branch
 artifact to production. Explicitly approved branch-built production promotion
 remains a separate follow-up.
 
-The Astro 6 production checkpoint was accepted on 2026-08-02. During the Astro
-7 checkpoint, the artifact manifest sets `production_release_eligible` to
-`false`. Successful `main` CI still builds and publishes the exact validated
-artifact, but the automatic release workflow stops before any credentialed
-Cloudflare upload or activation. Re-enabling production release requires a
-later, separately reviewed PR after preview and protected-staging acceptance.
+The Astro 6 production checkpoint was accepted on 2026-08-02. Exact Astro 7
+version `628ad246-8b6d-4c62-84bc-7d9c97e5176d` was then activated on the
+Access-protected staging Worker by workflow run `30807893758` and manually
+accepted in an incognito browser session on 2026-08-03. The artifact manifest
+therefore sets `production_release_eligible` to `true`. After this focused
+enablement change merges, successful `main` CI may enter the guarded automatic
+release sequence below. The release must retain Astro 6 version
+`02cc10fa-da8c-4d0d-97bb-f6c12ed4a40f` as its immediate rollback and leave the
+retained Pages project as the deeper fallback.
+
+Only an exact `push` artifact from `main` is production-eligible. Pull-request,
+branch, and mismatched-commit artifacts remain ineligible for the manual
+candidate path. For this first Astro 7 release, the workflow also requires
+production to start on the accepted Astro 6 version above before it uploads a
+candidate. Remove or update that migration-specific baseline only in a later
+reviewed PR after Astro 7 production acceptance.
 
 ## Automatic current-main release
 

--- a/tests/config/deploymentWorkflows.test.ts
+++ b/tests/config/deploymentWorkflows.test.ts
@@ -104,6 +104,10 @@ function actionReferences(workflow: string): string[] {
 }
 
 describe("Worker compatibility contract", () => {
+  it("keeps the branch-controlled and trusted artifact producers byte-identical", () => {
+    expect(trustedArtifactWorkflow).toBe(deployWorkflow);
+  });
+
   it.each([
     ["artifact producer", deployWorkflow],
     ["trusted artifact producer", trustedArtifactWorkflow],
@@ -1396,7 +1400,7 @@ describe("trusted production activation workflow", () => {
 });
 
 describe("automatic post-cutover production release", () => {
-  it("labels only reviewed Astro 6 or 7 artifacts and pauses production release", () => {
+  it("labels only reviewed Astro 6 or 7 artifacts and enables the accepted production release", () => {
     const packageStep = workflowStep(
       deploySteps,
       "Package the validated Worker artifact",
@@ -1438,8 +1442,53 @@ describe("automatic post-cutover production release", () => {
       '--arg artifact_contract "$artifact_contract"',
     );
     expect(deployWorkflow).toContain(
-      "--argjson production_release_eligible false",
+      '--argjson production_release_eligible "$production_release_eligible"',
     );
+    const eligibilityStart = packageRun.indexOf(
+      "production_release_eligible=false",
+    );
+    const eligibilityEnd = packageRun.indexOf("jq -n", eligibilityStart);
+    const eligibilityProgram = packageRun.slice(
+      eligibilityStart,
+      eligibilityEnd,
+    );
+    const productionEligibilityFor = (
+      eventName: string,
+      sourceBranch: string,
+      sourceCommit: string,
+      buildCommit: string,
+    ): string =>
+      execFileSync(
+        "bash",
+        [
+          "-c",
+          `set -euo pipefail\n${eligibilityProgram}\nprintf '%s' "$production_release_eligible"`,
+        ],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            BUILD_COMMIT: buildCommit,
+            EVENT_NAME: eventName,
+            SOURCE_BRANCH: sourceBranch,
+            SOURCE_COMMIT: sourceCommit,
+          },
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+    const commit = "a".repeat(40);
+    expect(productionEligibilityFor("push", "main", commit, commit)).toBe(
+      "true",
+    );
+    expect(
+      productionEligibilityFor("pull_request", "feature", commit, commit),
+    ).toBe("false");
+    expect(productionEligibilityFor("push", "feature", commit, commit)).toBe(
+      "false",
+    );
+    expect(
+      productionEligibilityFor("push", "main", commit, "b".repeat(40)),
+    ).toBe("false");
     expect(deployWorkflow).not.toContain(
       '--arg artifact_contract "astro-cloudflare-v6"',
     );
@@ -1495,7 +1544,13 @@ describe("automatic post-cutover production release", () => {
     expect(releaseWorkflow).toContain("eligible=false");
     expect(releaseWorkflow).toContain(".production_release_eligible == true");
     expect(deployWorkflow).toContain(
-      "--argjson production_release_eligible false",
+      '--argjson production_release_eligible "$production_release_eligible"',
+    );
+    expect(releaseWorkflow).toContain(
+      "ACCEPTED_PREVIOUS_VERSION_ID: 02cc10fa-da8c-4d0d-97bb-f6c12ed4a40f",
+    );
+    expect(releaseWorkflow).toContain(
+      'previous_version_id" != "$ACCEPTED_PREVIOUS_VERSION_ID',
     );
   });
 

--- a/tests/config/workerPreviewControlPlane.test.ts
+++ b/tests/config/workerPreviewControlPlane.test.ts
@@ -410,15 +410,15 @@ describe("preview Worker upload workflow", () => {
     }
   });
 
-  it("pins the reviewed artifact producer without enabling it on main", () => {
-    // Keep the inactive trusted copy byte-identical to the reviewed producer.
+  it("pins the reviewed production-eligible artifact producer on main", () => {
+    // Keep the trusted copy byte-identical to the reviewed producer.
     const gitBlobSha = createHash("sha1")
       .update(
         `blob ${Buffer.byteLength(trustedArtifactWorkflowText)}\0${trustedArtifactWorkflowText}`,
       )
       .digest("hex");
 
-    expect(gitBlobSha).toBe("713fbaf5160a1a3b710ccb89b2a4a3837cad9a21");
+    expect(gitBlobSha).toBe("0e651cfdeeee565110a047cd7d731c85bf374f40");
     expect(trustedArtifactWorkflowText).toBe(artifactWorkflowText);
     expect(trustedArtifactWorkflowText).toContain(
       "name: Website CI and Worker Artifact",


### PR DESCRIPTION
## Summary

This enables the accepted Astro 7 build to enter the existing guarded production release after a successful `main` CI run. Only an exact `push` artifact from `main` is eligible, and the first release stops before upload unless production is still serving the accepted Astro 6 rollback version.

## Changes

- Keep pull-request, feature-branch, and mismatched-commit artifacts production-ineligible while allowing the exact validated current-`main` artifact.
- Require the accepted Astro 6 version `02cc10fa-da8c-4d0d-97bb-f6c12ed4a40f` as the starting production baseline for this migration release.
- Preserve the existing inactive upload, 100/0 preflight, exact-version verification, promotion, smoke checks, automatic rollback, and retained Pages fallback.
- Record the accepted protected-staging evidence and update contract tests for the eligibility and rollback gates.

## What reviewers should focus on

- Confirm that eligibility is limited to `push` + `main` + matching source/build commit, so preview and branch artifacts cannot reach the production workflow.
- Confirm that production drift from the accepted Astro 6 version fails closed before any candidate upload.
- Confirm that the two artifact-producer workflow files remain byte-identical and that the guarded release and recovery behavior is otherwise unchanged.

## Validation

- `pnpm check`
- `pnpm check:tests`
- `pnpm check:surface`
- `pnpm check:alt`
- `pnpm lint`
- `pnpm test` (193 tests passed)
- `pnpm build`
- `pnpm smoke:dist`
- `pnpm check:worker` (16 runtime checks passed)
- `pnpm check:islands` (4 Chromium hydration checks passed)
- `actionlint .github/workflows/deploy.yml .github/trusted/worker-artifact-workflow.yml .github/workflows/release-worker.yml`

## Merge and release behavior

Merging this PR does not switch traffic immediately. A successful resulting `main` CI run packages the exact validated artifact; the trusted release then rechecks provenance, bindings, route topology, current `main`, and the accepted Astro 6 baseline before uploading Astro 7 inactive, testing it at zero traffic, and promoting that exact version. Any failed release check stops the rollout, and a failed post-activation verification restores the recorded Astro 6 version.

After merge, watch the resulting `Website CI and Worker Artifact` run and its `Release Worker to Production` follow-up. Stop rather than rerun blindly if provenance, baseline, binding, topology, marker, asset, or smoke verification fails. When automation succeeds, manually verify representative production pages and APIs in an incognito browser before recording Astro 7 as accepted production.
