### PR TITLE
Normalize automatic Worker release baselines

### DIFF
--- a/.github/workflows/release-worker.yml
+++ b/.github/workflows/release-worker.yml
@@ -278,28 +278,31 @@ jobs:
               select(.type == "secret_text") | .name] | sort) ==
             (["SEGMENT_FORMS_WRITE_KEY", "TURNSTILE_SECRET_KEY"] | sort)
           ' "$RUNNER_TEMP/previous-version-metadata.json" > /dev/null
-          read -r previous_source_commit previous_source_run_id < <(
+          read -r previous_source_commit previous_source_run_id \
+            previous_source_run_attempt < <(
             jq -r '
               .annotations["workers/message"] |
               capture(
-                "^source_commit=(?<commit>[0-9a-f]{40}) source_branch=main source_run_id=(?<run_id>[1-9][0-9]*) "
+                "^source_commit=(?<commit>[0-9a-f]{40}) source_branch=main source_run_id=(?<run_id>[1-9][0-9]*) source_run_attempt=(?<run_attempt>[1-9][0-9]*) "
               ) |
-              [.commit, .run_id] | @tsv
+              [.commit, .run_id, .run_attempt] | @tsv
             ' "$RUNNER_TEMP/previous-version-metadata.json"
           )
           gh api \
-            "repos/$GITHUB_REPOSITORY/actions/runs/$previous_source_run_id" \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$previous_source_run_id/attempts/$previous_source_run_attempt" \
             > "$RUNNER_TEMP/previous-source-run.json"
           jq -e \
             --arg commit "$previous_source_commit" \
-            --arg repository "$GITHUB_REPOSITORY" '
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg run_attempt "$previous_source_run_attempt" '
             .name == "Website CI and Worker Artifact" and
             .path == ".github/workflows/deploy.yml" and
             .conclusion == "success" and
             .event == "push" and
             .head_branch == "main" and
             .head_repository.full_name == $repository and
-            .head_sha == $commit
+            .head_sha == $commit and
+            .run_attempt == ($run_attempt | tonumber)
           ' "$RUNNER_TEMP/previous-source-run.json" > /dev/null
           echo "previous_version_id=$previous_version_id" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release-worker.yml
+++ b/.github/workflows/release-worker.yml
@@ -21,7 +21,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  ACCEPTED_PREVIOUS_VERSION_ID: 02cc10fa-da8c-4d0d-97bb-f6c12ed4a40f
   ACCEPTED_WORKER_ROUTES_JSON: '["www.zenml.io/*"]'
   WORKER_NAME: zenml-io-v2-worker
 
@@ -247,6 +246,7 @@ jobs:
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_PRODUCTION_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           worker_name="$WORKER_NAME"
@@ -265,10 +265,42 @@ jobs:
             ' "$RUNNER_TEMP/deployments-before-upload.json"
           )"
           [[ "$previous_version_id" =~ ^[0-9a-f-]{36}$ ]]
-          if [ "$previous_version_id" != "$ACCEPTED_PREVIOUS_VERSION_ID" ]; then
-            echo "Production is not on the accepted Astro 6 rollback version." >&2
-            exit 1
-          fi
+
+          wrangler versions view "$previous_version_id" \
+            --name "$worker_name" \
+            --json > "$RUNNER_TEMP/previous-version-metadata.json"
+          jq -e '
+            .annotations["workers/tag"] == "automatic-main-release" and
+            (.annotations["workers/message"] | test(
+              "^source_commit=[0-9a-f]{40} source_branch=main source_run_id=[1-9][0-9]* source_run_attempt=[1-9][0-9]* artifact_sha256=[0-9a-f]{64}$"
+            )) and
+            ([.resources.bindings[]? |
+              select(.type == "secret_text") | .name] | sort) ==
+            (["SEGMENT_FORMS_WRITE_KEY", "TURNSTILE_SECRET_KEY"] | sort)
+          ' "$RUNNER_TEMP/previous-version-metadata.json" > /dev/null
+          read -r previous_source_commit previous_source_run_id < <(
+            jq -r '
+              .annotations["workers/message"] |
+              capture(
+                "^source_commit=(?<commit>[0-9a-f]{40}) source_branch=main source_run_id=(?<run_id>[1-9][0-9]*) "
+              ) |
+              [.commit, .run_id] | @tsv
+            ' "$RUNNER_TEMP/previous-version-metadata.json"
+          )
+          gh api \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$previous_source_run_id" \
+            > "$RUNNER_TEMP/previous-source-run.json"
+          jq -e \
+            --arg commit "$previous_source_commit" \
+            --arg repository "$GITHUB_REPOSITORY" '
+            .name == "Website CI and Worker Artifact" and
+            .path == ".github/workflows/deploy.yml" and
+            .conclusion == "success" and
+            .event == "push" and
+            .head_branch == "main" and
+            .head_repository.full_name == $repository and
+            .head_sha == $commit
+          ' "$RUNNER_TEMP/previous-source-run.json" > /dev/null
           echo "previous_version_id=$previous_version_id" >> "$GITHUB_OUTPUT"
 
           curl \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,20 +3,17 @@
 ## Project Overview
 
 This repository powers the live [zenml.io](https://www.zenml.io) marketing
-website. The source tree is on the production-eligible Astro 7 checkpoint after
-protected-staging acceptance. The accepted Astro 6 Cloudflare Worker continues
-to serve production until the guarded current-main release succeeds. The site
-is generated from the Astro content collections defined in
-`src/content.config.ts`.
+website. The accepted Astro 7 Cloudflare Worker serves production through the
+guarded current-main release path. The site is generated from the Astro content
+collections defined in `src/content.config.ts`.
 
 The site markets **two sub-products under one paid umbrella (ZenML Pro)**:
 - **ZenML** — ML workflow orchestration (the original product)
 - **Kitaru** — durable runtime for AI agents (folded in from `kitaru.ai`)
 
 - **Production URL**: https://www.zenml.io
-- **Hosting**: The accepted Astro 6 Cloudflare Worker serves production until
-  guarded Astro 7 promotion succeeds. Cloudflare Pages remains available as
-  the deeper fallback.
+- **Hosting**: The accepted Astro 7 Cloudflare Worker serves production.
+  Cloudflare Pages remains available as the deeper fallback.
 - **Scale**: content collections defined in `src/content.config.ts`, ~2,350 content items, ~2,560 assets on R2
 - **History**: Migrated from Webflow in Feb 2026 (`docs/MIGRATION.md`). Unified with `kitaru.ai` in May 2026 (`MERGE_PLAN.md`).
 - **Private details**: See `CLAUDE.private.md` (gitignored) for infrastructure IDs, traffic numbers, and internal docs index

--- a/docs/worker-release-runbook.md
+++ b/docs/worker-release-runbook.md
@@ -2,8 +2,8 @@
 
 ## Current boundary
 
-The accepted Astro 6 Worker serves `www.zenml.io/*`. The accepted Astro 5
-Worker version remains the immediate version rollback, and Cloudflare Pages
+The accepted Astro 7 Worker serves `www.zenml.io/*`. The accepted Astro 6
+Worker version remains the recorded migration rollback, and Cloudflare Pages
 remains available beneath the Worker route as the deeper fallback. No release
 workflow attaches or removes a route, changes a custom domain, edits DNS,
 changes Access, or removes Pages.
@@ -53,22 +53,21 @@ review-only public versions on a dedicated Worker; they cannot promote a branch
 artifact to production. Explicitly approved branch-built production promotion
 remains a separate follow-up.
 
-The Astro 6 production checkpoint was accepted on 2026-08-02. Exact Astro 7
-version `628ad246-8b6d-4c62-84bc-7d9c97e5176d` was then activated on the
-Access-protected staging Worker by workflow run `30807893758` and manually
-accepted in an incognito browser session on 2026-08-03. The artifact manifest
-therefore sets `production_release_eligible` to `true`. After this focused
-enablement change merges, successful `main` CI may enter the guarded automatic
-release sequence below. The release must retain Astro 6 version
-`02cc10fa-da8c-4d0d-97bb-f6c12ed4a40f` as its immediate rollback and leave the
-retained Pages project as the deeper fallback.
+Astro 7 production was accepted on 2026-08-03 after exact `main` CI run
+`30809674875`, automatic release run `30809998564`, and manual incognito
+testing. Exact Worker version `d6bf9c06-95e3-498d-991e-1897c3c18469` serves
+100 percent of production traffic. Recorded Astro 6 version
+`02cc10fa-da8c-4d0d-97bb-f6c12ed4a40f` remains available as the migration
+rollback, and the retained Pages project remains the deeper fallback.
 
 Only an exact `push` artifact from `main` is production-eligible. Pull-request,
 branch, and mismatched-commit artifacts remain ineligible for the manual
-candidate path. For this first Astro 7 release, the workflow also requires
-production to start on the accepted Astro 6 version above before it uploads a
-candidate. Remove or update that migration-specific baseline only in a later
-reviewed PR after Astro 7 production acceptance.
+candidate path. For each routine release, the workflow records the single
+version serving 100 percent immediately before upload, verifies that version's
+automatic-release tag, exact successful same-repository `main` CI provenance,
+and required bindings, then treats that exact version as the rollback target.
+It refuses unknown or mixed starting deployments instead of relying on a
+framework-specific pinned version.
 
 ## Automatic current-main release
 

--- a/tests/config/deploymentWorkflows.test.ts
+++ b/tests/config/deploymentWorkflows.test.ts
@@ -1621,7 +1621,7 @@ describe("automatic post-cutover production release", () => {
       '.annotations["workers/tag"] == "automatic-main-release"',
     );
     expect(baselineRun).toContain(
-      '"repos/$GITHUB_REPOSITORY/actions/runs/$previous_source_run_id"',
+      '"repos/$GITHUB_REPOSITORY/actions/runs/$previous_source_run_id/attempts/$previous_source_run_attempt"',
     );
     const metadataProgram = jqProgramReadingFrom(
       baselineRun,
@@ -1685,6 +1685,7 @@ describe("automatic post-cutover production release", () => {
       head_sha: sourceCommit,
       name: "Website CI and Worker Artifact",
       path: ".github/workflows/deploy.yml",
+      run_attempt: 1,
     };
     const sourceRunArgs = [
       "--arg",
@@ -1693,6 +1694,9 @@ describe("automatic post-cutover production release", () => {
       "--arg",
       "repository",
       "zenml-io/zenml-io-v2",
+      "--arg",
+      "run_attempt",
+      "1",
     ];
     expectJqResult(sourceRunProgram, trustedSourceRun, true, sourceRunArgs);
     expectJqResult(
@@ -1719,6 +1723,12 @@ describe("automatic post-cutover production release", () => {
     expectJqResult(
       sourceRunProgram,
       { ...trustedSourceRun, head_sha: "c".repeat(40) },
+      false,
+      sourceRunArgs,
+    );
+    expectJqResult(
+      sourceRunProgram,
+      { ...trustedSourceRun, run_attempt: 2 },
       false,
       sourceRunArgs,
     );

--- a/tests/config/deploymentWorkflows.test.ts
+++ b/tests/config/deploymentWorkflows.test.ts
@@ -1546,11 +1546,181 @@ describe("automatic post-cutover production release", () => {
     expect(deployWorkflow).toContain(
       '--argjson production_release_eligible "$production_release_eligible"',
     );
-    expect(releaseWorkflow).toContain(
-      "ACCEPTED_PREVIOUS_VERSION_ID: 02cc10fa-da8c-4d0d-97bb-f6c12ed4a40f",
+    expect(releaseWorkflow).not.toContain("ACCEPTED_PREVIOUS_VERSION_ID");
+    expect(releaseWorkflow).not.toContain(
+      "Production is not on the accepted Astro 6 rollback version.",
     );
     expect(releaseWorkflow).toContain(
-      'previous_version_id" != "$ACCEPTED_PREVIOUS_VERSION_ID',
+      'echo "previous_version_id=$previous_version_id" >> "$GITHUB_OUTPUT"',
+    );
+  });
+
+  it("captures only a trusted single-version production baseline", () => {
+    const baselineStep = workflowStep(
+      releaseUploadSteps,
+      "Capture accepted production baseline",
+    );
+    const baselineRun = baselineStep.run ?? "";
+    const programStart = baselineRun.indexOf(
+      "jq -er '\n",
+      baselineRun.indexOf('previous_version_id="$('),
+    );
+    const programEnd = baselineRun.indexOf(
+      '\' "$RUNNER_TEMP/deployments-before-upload.json"',
+      programStart,
+    );
+    expect(programStart).toBeGreaterThan(-1);
+    expect(programEnd).toBeGreaterThan(programStart);
+    const deploymentProgram = baselineRun.slice(programStart + 8, programEnd);
+    const versionId = "11111111-1111-1111-1111-111111111111";
+    const newerVersionId = "22222222-2222-2222-2222-222222222222";
+    const selectBaseline = (deployments: unknown): string =>
+      execFileSync("jq", ["-er", deploymentProgram], {
+        encoding: "utf8",
+        input: JSON.stringify(deployments),
+        stdio: ["pipe", "pipe", "pipe"],
+      }).trim();
+
+    expect(
+      selectBaseline([
+        {
+          created_on: "2026-08-02T00:00:00Z",
+          versions: [{ percentage: 100, version_id: versionId }],
+        },
+        {
+          created_on: "2026-08-03T00:00:00Z",
+          versions: [{ percentage: 100, version_id: newerVersionId }],
+        },
+      ]),
+    ).toBe(newerVersionId);
+    expect(() =>
+      selectBaseline([
+        {
+          created_on: "2026-08-03T00:00:00Z",
+          versions: [
+            { percentage: 100, version_id: versionId },
+            { percentage: 0, version_id: newerVersionId },
+          ],
+        },
+      ]),
+    ).toThrow();
+    expect(() =>
+      selectBaseline([
+        {
+          created_on: "2026-08-03T00:00:00Z",
+          versions: [{ percentage: 50, version_id: versionId }],
+        },
+      ]),
+    ).toThrow();
+
+    expect(baselineStep.env?.GH_TOKEN).toBe("$" + "{{ github.token }}");
+    expect(baselineRun).toContain(
+      'wrangler versions view "$previous_version_id"',
+    );
+    expect(baselineRun).toContain(
+      '.annotations["workers/tag"] == "automatic-main-release"',
+    );
+    expect(baselineRun).toContain(
+      '"repos/$GITHUB_REPOSITORY/actions/runs/$previous_source_run_id"',
+    );
+    const metadataProgram = jqProgramReadingFrom(
+      baselineRun,
+      '"$RUNNER_TEMP/previous-version-metadata.json"',
+    );
+    const trustedMetadata = {
+      annotations: {
+        "workers/message": `source_commit=${"a".repeat(40)} source_branch=main source_run_id=123 source_run_attempt=1 artifact_sha256=${"b".repeat(64)}`,
+        "workers/tag": "automatic-main-release",
+      },
+      resources: {
+        bindings: REQUIRED_WORKER_SECRETS.map((name) => ({
+          name,
+          type: "secret_text",
+        })),
+      },
+    };
+    expectJqResult(metadataProgram, trustedMetadata, true);
+    expectJqResult(
+      metadataProgram,
+      {
+        ...trustedMetadata,
+        annotations: {
+          ...trustedMetadata.annotations,
+          "workers/tag": "manual-release",
+        },
+      },
+      false,
+    );
+    expectJqResult(
+      metadataProgram,
+      {
+        ...trustedMetadata,
+        resources: { bindings: trustedMetadata.resources.bindings.slice(0, 1) },
+      },
+      false,
+    );
+    expectJqResult(
+      metadataProgram,
+      {
+        ...trustedMetadata,
+        annotations: {
+          ...trustedMetadata.annotations,
+          "workers/message":
+            "source_commit=untrusted source_branch=main source_run_id=123",
+        },
+      },
+      false,
+    );
+
+    const sourceRunProgram = jqProgramReadingFrom(
+      baselineRun,
+      '"$RUNNER_TEMP/previous-source-run.json"',
+    );
+    const sourceCommit = "a".repeat(40);
+    const trustedSourceRun = {
+      conclusion: "success",
+      event: "push",
+      head_branch: "main",
+      head_repository: { full_name: "zenml-io/zenml-io-v2" },
+      head_sha: sourceCommit,
+      name: "Website CI and Worker Artifact",
+      path: ".github/workflows/deploy.yml",
+    };
+    const sourceRunArgs = [
+      "--arg",
+      "commit",
+      sourceCommit,
+      "--arg",
+      "repository",
+      "zenml-io/zenml-io-v2",
+    ];
+    expectJqResult(sourceRunProgram, trustedSourceRun, true, sourceRunArgs);
+    expectJqResult(
+      sourceRunProgram,
+      { ...trustedSourceRun, conclusion: "failure" },
+      false,
+      sourceRunArgs,
+    );
+    expectJqResult(
+      sourceRunProgram,
+      { ...trustedSourceRun, head_branch: "feature" },
+      false,
+      sourceRunArgs,
+    );
+    expectJqResult(
+      sourceRunProgram,
+      {
+        ...trustedSourceRun,
+        head_repository: { full_name: "fork/zenml-io-v2" },
+      },
+      false,
+      sourceRunArgs,
+    );
+    expectJqResult(
+      sourceRunProgram,
+      { ...trustedSourceRun, head_sha: "c".repeat(40) },
+      false,
+      sourceRunArgs,
     );
   });
 


### PR DESCRIPTION
## Summary

Routine Worker releases can now proceed from the accepted Astro 7 production baseline without keeping a one-release Astro 6 version pin. The workflow still fails closed unless production has exactly one trusted automatic `main` release at 100 percent, and it records that exact version for zero-traffic preflight and automatic rollback.

## Changes

- Replace the fixed Astro 6 baseline ID with verification of the active version's `automatic-main-release` tag, exact release annotations, required bindings, and successful same-repository `main` CI provenance.
- Keep the existing refusal of mixed, partial, stale, or concurrently changed deployments and preserve exact dynamic rollback through both inline and recovery paths.
- Execute the deployment, Worker-metadata, and GitHub-run predicates against positive and negative fixtures so weakening any baseline trust check fails CI.
- Record Astro 7 as the accepted production baseline while retaining Astro 6 as the migration rollback and Pages as the deeper fallback.

Related: #128

## What reviewers should focus on

- Confirm that an arbitrary manually deployed 100-percent version cannot become the automatic rollback baseline.
- Confirm that the captured trusted version still flows unchanged through zero-traffic activation, inline rollback, and recovery.
- Confirm that no route, DNS, Access, custom-domain, binding, secret, compatibility-date, or Pages behavior changes.

## Validation

- `pnpm check`
- `pnpm check:tests`
- `pnpm check:surface`
- `pnpm check:alt`
- `pnpm lint`
- `pnpm test` (194 tests passed)
- `pnpm build`
- `pnpm smoke:dist`
- `pnpm check:worker` (16 runtime checks passed)
- `pnpm check:islands` (4 Chromium hydration checks passed)
- `actionlint .github/workflows/release-worker.yml`
- Independent correctness, standards/testing, and adversarial reliability review completed with no remaining actionable findings.

## Merge and release behavior

Merging this PR does not switch traffic immediately. The resulting successful `main` CI run will produce a new validated Astro 7 artifact and trigger the normal automatic release. That release should verify the currently active Astro 7 version as its trusted baseline, upload the new version inactive, test it at zero traffic, promote it, and retain the previously active Astro 7 version for automatic rollback.

This PR deliberately does not close #128. The Astro 7 release is complete, but that issue still tracks the observation window and separate rollback/Pages-retention decisions.

## Post-Deploy Monitoring & Validation

Alex and Codex should watch the resulting `Website CI and Worker Artifact` run and its `Release Worker to Production` follow-up through completion. Healthy signals are a trusted Astro 7 baseline, successful inactive upload, preserved production before activation, passing zero-traffic marker and asset checks, successful 100-percent promotion, passing public smoke checks, and a skipped recovery job. Stop rather than rerun blindly if baseline provenance, bindings, topology, marker, assets, or smoke verification fails; if activation fails, confirm the workflow restored the previously active Astro 7 version. After automation succeeds, verify representative production pages in an incognito browser before marking the normalized release path accepted.
