### PR TITLE
Lift stale astro semver-major ignore from `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,22 +62,12 @@ updates:
         update-types:
           - minor
           - patch
-    ignore:
-      # Astro 5 -> 7 is a migration, not a bump: two majors, plus Vite 6 -> 8,
-      # plus a Node floor raise. Majors for astro and its integrations are held
-      # as a SET until that work happens (#128). Astro 5.x minor/patch and
-      # security updates still flow normally.
-      #
-      # These must be ignored together, not individually. An ignore is applied
-      # BEFORE grouping, so ignoring one member of the astro group does not hold
-      # the group back -- it silently drops that member out of the group PR. The
-      # previous @astrojs/preact-only ignore did exactly that, and produced #136:
-      # a PR bumping core to Astro 7 while pinning @astrojs/preact to an
-      # Astro-5-generation 4.x. Lift this whole block as step 1 of #128.
-      - dependency-name: 'astro'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@astrojs/*'
-        update-types: ['version-update:semver-major']
+    # The astro/@astrojs semver-major ignore block that used to sit here was
+    # lifted after the Astro 5 -> 7 migration landed (#128, merged in #204).
+    # If majors ever need holding again, ignore the WHOLE astro group together,
+    # never a single member: ignores apply BEFORE grouping, so ignoring one
+    # member silently drops it out of the group PR instead of holding the
+    # group back (that mistake produced #136).
     cooldown:
       default-days: 7
       semver-major-days: 14


### PR DESCRIPTION
## Summary

The `ignore` block in `.github/dependabot.yml` held all `astro` / `@astrojs/*` semver-major updates "until the Astro 5 → 7 migration happens (#128)". That migration landed in #204 and the Astro 7 Worker now serves production (#209), so the claim behind the ignore has expired. Per the block's own instruction ("Lift this whole block as step 1 of #128"), this PR removes it.

## What changed

- Removed the two `ignore` entries (`astro` and `@astrojs/*`, `version-update:semver-major`) from the npm ecosystem config.
- Left a short comment in their place preserving the load-bearing lesson: if majors ever need holding again, ignore the whole astro group together — ignores apply *before* grouping, so ignoring a single member silently drops it from the group PR instead of holding the group back (the mistake that produced #136).
- The `astro` group itself (astro + `@astrojs/*` + wrangler) is unchanged and still keeps core and integrations moving together.

## What reviewers should focus on

- Confirm the migration really is considered done: `package.json` has `astro` 7.1.6, `@astrojs/preact` 6.0.2, `@astrojs/cloudflare` 14.1.7 — all current-generation majors, so lifting the ignore opens **no** immediate update PRs; it only un-freezes future Astro 8-era majors, which will arrive as one grouped PR.

## Validation

- Config-only change; no package scripts affected. `Repo checks` CI on this PR exercises the full gate.
- Verified no test or script reads `dependabot.yml` (only a workflow-text assertion mentioning `dependabot[bot]`, unaffected).