### PR TITLE
Hold broken `wrangler` 4.114+ and unify `check:worker` transient retries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,6 +68,16 @@ updates:
     # never a single member: ignores apply BEFORE grouping, so ignoring one
     # member silently drops it out of the group PR instead of holding the
     # group back (that mistake produced #136).
+    ignore:
+      # wrangler 4.114.0-4.118.0 (miniflare/workerd 20260722 snapshot) drop
+      # local connections intermittently during `wrangler dev`, failing
+      # `check:worker` on most CI runs (PR #207 has the measured rates;
+      # tracked upstream at cloudflare/workers-sdk#15002). This ignore drops
+      # broken wrangler versions out of the astro group PR while astro and
+      # @astrojs/* keep flowing — deliberately, unlike the #136 mistake.
+      # Lift criteria and boot-loop verification procedure: issue #216.
+      - dependency-name: 'wrangler'
+        versions: ['>=4.114.0']
     cooldown:
       default-days: 7
       semver-major-days: 14

--- a/scripts/check-worker-runtime.ts
+++ b/scripts/check-worker-runtime.ts
@@ -10,8 +10,8 @@ const TEST_ENV_PATH = resolve(WRANGLER_STATE_DIR, "runtime-check.env");
 const START_TIMEOUT_MS = 30_000;
 const REQUEST_TIMEOUT_MS = 10_000;
 const COLD_START_REQUEST_TIMEOUT_MS = 30_000;
-const TRANSIENT_SERVICE_RETRY_ATTEMPTS = 3;
-const TRANSIENT_SERVICE_RETRY_DELAY_MS = 500;
+const TRANSIENT_RETRY_ATTEMPTS = 3;
+const TRANSIENT_RETRY_DELAY_MS = 500;
 
 type CheckResult = {
   name: string;
@@ -121,7 +121,7 @@ async function waitForWorker(
       await response.body?.cancel();
       return;
     } catch {
-      await new Promise((resolveWait) => setTimeout(resolveWait, 200));
+      await sleep(200);
     }
   }
 
@@ -150,58 +150,52 @@ async function stopWrangler(child: ChildProcess): Promise<void> {
   }
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolveWait) => setTimeout(resolveWait, ms));
+}
+
 async function request(
   baseUrl: string,
   pathname: string,
   init?: RequestInit,
   timeoutMs = REQUEST_TIMEOUT_MS,
 ): Promise<Response> {
-  const signal = AbortSignal.timeout(timeoutMs);
+  // workerd's local socket can drop mid-request ("Network connection lost"),
+  // surfacing either as a thrown "fetch failed" or as a spurious 5xx that has
+  // nothing to do with the endpoint. Both get a few attempts; the final
+  // attempt's 5xx response or thrown error still surfaces, so deterministic
+  // failures keep failing the gate. Timeouts fail immediately — they already
+  // waited timeoutMs. No check expects a 5xx, so retrying them is safe.
+  for (let attempt = 1; ; attempt += 1) {
+    const signal = AbortSignal.timeout(timeoutMs);
 
-  try {
-    return await fetch(`${baseUrl}${pathname}`, {
-      ...init,
-      redirect: init?.redirect ?? "manual",
-      signal,
-    });
-  } catch (error) {
-    if (signal.aborted) {
-      throw new Error(
-        `Timed out requesting ${pathname} from the Worker after ${timeoutMs}ms`,
-        { cause: error },
-      );
-    }
-    throw error;
-  }
-}
-
-async function requestWithTransientServiceRetry(
-  baseUrl: string,
-  pathname: string,
-  init: RequestInit,
-): Promise<Response> {
-  let response: Response | undefined;
-
-  for (
-    let attempt = 1;
-    attempt <= TRANSIENT_SERVICE_RETRY_ATTEMPTS;
-    attempt += 1
-  ) {
-    response = await request(baseUrl, pathname, init);
-    // Any 5xx counts as transient here: besides deliberate 503s, miniflare's
-    // internal socket to workerd can drop mid-request and surface as a 500
-    // ("Network connection lost") that has nothing to do with the endpoint.
-    if (response.status < 500 || attempt === TRANSIENT_SERVICE_RETRY_ATTEMPTS) {
-      return response;
+    try {
+      const response = await fetch(`${baseUrl}${pathname}`, {
+        ...init,
+        redirect: init?.redirect ?? "manual",
+        signal,
+      });
+      if (response.status < 500 || attempt === TRANSIENT_RETRY_ATTEMPTS) {
+        return response;
+      }
+      await response.body?.cancel();
+    } catch (error) {
+      if (signal.aborted) {
+        throw new Error(
+          `Timed out requesting ${pathname} from the Worker after ${timeoutMs}ms`,
+          { cause: error },
+        );
+      }
+      if (attempt === TRANSIENT_RETRY_ATTEMPTS) {
+        throw new Error(
+          `Network failure requesting ${pathname} after ${TRANSIENT_RETRY_ATTEMPTS} attempts`,
+          { cause: error },
+        );
+      }
     }
 
-    await response.body?.cancel();
-    await new Promise((resolveWait) =>
-      setTimeout(resolveWait, TRANSIENT_SERVICE_RETRY_DELAY_MS),
-    );
+    await sleep(TRANSIENT_RETRY_DELAY_MS);
   }
-
-  throw new Error(`No response received from ${pathname}`);
 }
 
 function check(
@@ -334,20 +328,16 @@ async function runChecks(baseUrl: string): Promise<CheckResult[]> {
   );
   await unverifiedForm.body?.cancel();
 
-  const csp = await requestWithTransientServiceRetry(
-    baseUrl,
-    "/api/csp-report",
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        "csp-report": {
-          "document-uri": "https://www.zenml.io/product/kitaru?private=removed",
-          "violated-directive": "script-src",
-        },
-      }),
-    },
-  );
+  const csp = await request(baseUrl, "/api/csp-report", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      "csp-report": {
+        "document-uri": "https://www.zenml.io/product/kitaru?private=removed",
+        "violated-directive": "script-src",
+      },
+    }),
+  });
   const cspFailureBody = csp.status === 204 ? "" : await csp.text();
   check(
     results,


### PR DESCRIPTION
## Summary

Follow-ups from today's Dependabot batch (#207): wrangler 4.114.0–4.118.0 ship a local-runtime regression that intermittently drops connections during `wrangler dev` (reported upstream: cloudflare/workers-sdk#15002). This PR stops Dependabot from re-proposing the broken range, and consolidates the `check:worker` retry logic so both manifestations of the drop are absorbed on every probe.

## What changed

- **`.github/dependabot.yml`** — new `ignore` entry for `wrangler >=4.114.0` in the npm config. This drops broken wrangler versions out of the astro group PR while `astro`/`@astrojs/*` keep flowing (deliberate, unlike the #136 single-member-ignore mistake — the comment spells out the distinction). Lift criteria live in #216.
- **`scripts/check-worker-runtime.ts`** — one retry loop in `request()` now handles both drop manifestations (thrown "fetch failed" and spurious 5xx responses) for **all** checks. Previously only the CSP probe retried 5xx (via `requestWithTransientServiceRetry`, now deleted) and nothing retried the thrown form; the two loops would also have stacked to 3×3 attempts on the CSP path. Duplicate constant pairs collapsed into `TRANSIENT_RETRY_ATTEMPTS`/`_DELAY_MS`; repeated inline sleep idiom extracted to a `sleep()` helper.

## What reviewers should focus on

- The behavioral widening in `check:worker`: every probe now retries transient 5xx (not just CSP). No check expects a 5xx (expected statuses across the suite: 200/204/301/302/307/308/403/404/405), and a deterministic 5xx still fails — the final attempt's response propagates. Timeouts are never retried (they already waited `timeoutMs`).
- The ignore range is open-ended (`>=4.114.0`) on purpose: one green CI run can't prove an intermittent bug fixed, so resuming at an arbitrary future version would ship an unverified wrangler. #216 carries the boot-loop verification procedure (25× `check:worker`, compare against 4.113.0's 0/25 baseline) and cites the upstream issue.

## Validation

- `pnpm lint`, `pnpm test` (194/194), `pnpm build`, then `pnpm check:worker` ×5 clean on wrangler 4.113.
- `/simplify` review loop ran on the diff (4 agents); its findings — duplicate constants, stacked retry loops, sleep-idiom copies, missing tracking issue — are what shaped the final form.
- Background: the regression measurement methodology and rates are in #207 and workers-sdk#15002 (4.113: 0/25; 4.114: 3/23 local, 3/4 CI; 4.118: 1/15).

Note: authored by the session agent, so it needs a human approve + merge (same as #215).