### PR TITLE
Hold `@types/node` majors past the pinned Node 22 runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,6 +78,13 @@ updates:
       # Lift criteria and boot-loop verification procedure: issue #216.
       - dependency-name: 'wrangler'
         versions: ['>=4.114.0']
+      # @types/node majors must match the pinned Node runtime major (22:
+      # .nvmrc, engines, deploy.yml). Types for a newer Node let code that
+      # uses newer-runtime-only APIs pass typecheck and then crash in CI
+      # (#219 closed for this reason). Lift to '>=25.0.0' as part of the
+      # Node 24 LTS runtime upgrade: issue #221.
+      - dependency-name: '@types/node'
+        versions: ['>=23.0.0']
     cooldown:
       default-days: 7
       semver-major-days: 14


### PR DESCRIPTION
## Summary

Adds a Dependabot `ignore` for `@types/node >=23.0.0`, making the hold from closed PR #219 durable — closing a bot PR only blocks that exact version, so the next 26.x patch release would have reopened it.

## Why hold it

The repo pins its Node runtime to 22 in three places (`.nvmrc` = 22.23.1, `engines` = `>=22.12.0 <23`, `deploy.yml` `node-version: 22.23.1`). The `@types/node` major should match the runtime major: types describing Node 26 on a Node 22 runtime let code using newer-Node-only APIs pass typecheck and then crash when CI actually runs it.

## What reviewers should check

- The ignore targets only `@types/node` (a standalone dependency, not a member of any Dependabot group), so this does not have the #136 group-corruption problem the comment above the wrangler ignore warns about.
- Lift criteria live in issue #221 (Node 24 LTS runtime upgrade); the ignore comment cites it.

## Validation

Config-only change (`.github/dependabot.yml`); no build/site behavior affected. YAML validated by inspection against the existing wrangler ignore entry that shipped in #217.