### PR TITLE
Force `undici` 7.29.0 under both `miniflare` copies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "pnpm": {
     "overrides": {
       "@cloudflare/vite-plugin": "1.39.0",
-      "miniflare@<4.20260721.0>undici": "7.28.0",
+      "miniflare@<=4.20260721.0>undici": "7.29.0",
       "miniflare@<4.20260721.0>ws": "8.21.0",
       "@cloudflare/vite-plugin@1.39.0>ws": "8.21.0",
       "miniflare@<=4.20260721.0>sharp": "0.35.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@cloudflare/vite-plugin': 1.39.0
-  miniflare@<4.20260721.0>undici: 7.28.0
+  miniflare@<=4.20260721.0>undici: 7.29.0
   miniflare@<4.20260721.0>ws: 8.21.0
   '@cloudflare/vite-plugin@1.39.0>ws': 8.21.0
   miniflare@<=4.20260721.0>sharp: 0.35.3
@@ -3030,10 +3030,6 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
-
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
-    engines: {node: '>=20.18.1'}
 
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
@@ -6167,7 +6163,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.3(@types/node@22.20.1)
-      undici: 7.28.0
+      undici: 7.29.0
       workerd: 1.20260526.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
@@ -6180,7 +6176,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.3(@types/node@22.20.1)
-      undici: 7.28.0
+      undici: 7.29.0
       workerd: 1.20260721.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
@@ -6759,8 +6755,6 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.18.2: {}
-
-  undici@7.28.0: {}
 
   undici@7.29.0: {}
 


### PR DESCRIPTION
## Summary

Follow-up to #224, closing the security-alert audit for real this time. Right after #224 merged, five brand-new advisories (#79–#83, one high) were published against `undici < 7.29.0` — catching both the 7.28.0 that #224 forced under the older miniflare and wrangler's own miniflare copy (which the scoped selector deliberately excluded, because 7.28.0 was clean at the time).

## What changed

One line: the undici override widens from `miniflare@<4.20260721.0 → 7.28.0` to `miniflare@<=4.20260721.0 → 7.29.0`. With cheerio already at 7.29.0, the entire tree now dedupes to a **single undici 7.29.0**. Clears all 5 remaining open alerts → the Dependabot security tab goes to zero.

## What reviewers should focus on

- wrangler's miniflare (4.20260721.0) pins undici 7.28.0 exactly and now runs with 7.29.0 — a same-major minor force. `check:worker` boots it end-to-end (16 runtime checks) and passes.
- Selector still expires once wrangler moves past miniflare 4.20260721.0 (held until #216 lifts the wrangler pin).

## Validation

Full local gate, all green: `pnpm check`, `check:tests`, `check:surface`, `check:alt`, `lint`, `test` (194 passed), `build`, `smoke:dist`, `check:worker` (16 checks), `check:islands` (4 islands hydrate).