### PR TITLE
Scope pricing VPC block to ZenML workspace; switch Kitaru install to uv

### DIFF
--- a/src/components/compare/kitaru/graphics/dbos/StackDeployment.astro
+++ b/src/components/compare/kitaru/graphics/dbos/StackDeployment.astro
@@ -40,7 +40,7 @@
     </div>
     <div class="flow">
       <div class="cmd">
-        <span class="mono accent">pip install kitaru-pydantic-ai</span>
+        <span class="mono accent">uv add kitaru-pydantic-ai</span>
         <span class="mono dim">or the adapter for your framework</span>
       </div>
       <svg class="arrow" viewBox="0 0 24 24" aria-hidden="true">

--- a/src/content/compare-kitaru/kitaru-vs-restate.mdx
+++ b/src/content/compare-kitaru/kitaru-vs-restate.mdx
@@ -92,7 +92,7 @@ The two layers don't compete. A Restate-run agent can still be wrapped by a Kita
   Both tools have a server. The wedge is whether your agent's request path has to cross it.
 
   <Fragment slot="bullets">
-    - **Kitaru:** `pip install kitaru`, wrap the agent with an adapter, and it runs in your process exactly as before. The Kitaru server stores session metadata and powers replay, the UI, the CLI, and auth &mdash; it isn't a proxy every invocation crosses.
+    - **Kitaru:** `uv add kitaru`, wrap the agent with an adapter, and it runs in your process exactly as before. The Kitaru server stores session metadata and powers replay, the UI, the CLI, and auth &mdash; it isn't a proxy every invocation crosses.
     - **Restate:** handlers register with `restate-server`, and invocations flow through it. The server journals progress, routes requests, handles retries, and drives replay. That's not incidental; it's the durability model.
     - **Different jobs, different shapes.** Restate's server is in the request path because durability requires it. Kitaru's server holds metadata because recording doesn't.
   </Fragment>

--- a/src/lib/productKitaru.ts
+++ b/src/lib/productKitaru.ts
@@ -1,4 +1,4 @@
-export const KITARU_INSTALL_CMD = "pip install kitaru";
+export const KITARU_INSTALL_CMD = "uv add kitaru";
 export const KITARU_LICENSE = "Apache 2.0";
 
 /**
@@ -90,7 +90,7 @@ export const PRODUCT_KITARU_MARKDOWN = {
   journey: [
     {
       name: "Act 1 — Get in",
-      body: "`pip install kitaru` then `kitaru login`. Two questions decide your path: do you have a repo with an agent, and do you have traces? No repo, or an unrecognised framework, and you start from the template repo — a small PydanticAI agent already wrapped, with a trace file beside it. Registering the agent stores an entrypoint module path server-side; nothing is written into your repo. Then `kitaru worker start` runs a plain Python process in your virtualenv, which polls — the server never connects inbound.",
+      body: "`uv add kitaru` then `kitaru login`. Two questions decide your path: do you have a repo with an agent, and do you have traces? No repo, or an unrecognised framework, and you start from the template repo — a small PydanticAI agent already wrapped, with a trace file beside it. Registering the agent stores an entrypoint module path server-side; nothing is written into your repo. Then `kitaru worker start` runs a plain Python process in your virtualenv, which polls — the server never connects inbound.",
     },
     {
       name: "Act 2 — Traces in",

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -109,8 +109,11 @@ const pricingJsonLd = buildPricingJsonLd();
       </div>
     </section>
 
-    {/* Compliance: "Your VPC, your data" */}
-    <section class="bg-white py-16 sm:py-20">
+    {/* Compliance: "Your VPC, your data" — ZenML-workspace only. The claim
+        (metadata-only control plane, ZenML SOC2 posture) is specific to the
+        ZenML side, so it rides the same [data-workspace-panel] toggle as the
+        plan cards and comparison table above. */}
+    <section data-workspace-panel="zenml" hidden class="bg-white py-16 sm:py-20">
       <div class="mx-auto max-w-5xl px-4 text-center sm:px-6 lg:px-8">
         <p class="text-sm font-semibold uppercase tracking-wider text-zenml-500">
           {PRICING_COMPLIANCE.eyebrow}


### PR DESCRIPTION
## Summary

Two small site fixes. The "Your VPC, your data" compliance block on `/pricing` was showing for both workspaces even though the claim is ZenML-specific, so it now only renders when the ZenML tab is selected. And every Kitaru install command on the site now reads `uv add kitaru` instead of `pip install kitaru`.

## What changed

**Pricing — VPC block is ZenML-only**

- `src/pages/pricing.astro` — the compliance section now carries `data-workspace-panel="zenml" hidden`, so it joins the same toggle that already drives the plan cards and the comparison table. No new JS: the handler in `PricingPlanCards.astro` queries every `[data-workspace-panel]` on the page generically, and the existing `<noscript>` fallback (`[data-workspace-panel][hidden] { display: block }`) unhides it when scripting is off.

**Kitaru install command → `uv add`**

- `src/lib/productKitaru.ts` — `KITARU_INSTALL_CMD` flipped to `uv add kitaru`. This covers the Kitaru hero, the Kitaru CTA, both compare-page CTA/hero blocks, the Restate `EmbeddedVsServerRegistered` graphic, and `GET_STARTED_KITARU`.
- `src/lib/productKitaru.ts` — the prose `body` in the same file that spelled out `pip install kitaru` inline.
- `src/components/compare/kitaru/graphics/dbos/StackDeployment.astro` — `pip install kitaru-pydantic-ai` → `uv add kitaru-pydantic-ai`.
- `src/content/compare-kitaru/kitaru-vs-restate.mdx` — one inline mention in the body copy.

## What reviewers should focus on

- **Blog posts were deliberately left alone.** `pip install kitaru` still appears in four published posts (`kitaru-launch`, `kitaru-open-source`, `agents-are-not-microservices`, `from-zenml-to-kitaru`). Those are dated narratives rather than live install instructions, so rewriting them would be editing published writing. Happy to change that call if you'd rather the whole site be consistent.
- **`compareDefaults.ts` was intentionally not touched** — its "Start locally with pip install" line is about ZenML pipelines, not Kitaru.
- **The VPC block's default state.** Kitaru is the default tab on `/pricing`, so the block is hidden on first paint and appears on switching to ZenML. Worth a look if the intent was the other way round.

## Validation

All local gates run: `pnpm check` (0 errors, 2 pre-existing hints), `pnpm check:tests`, `pnpm check:surface`, `pnpm check:alt`, `pnpm lint`, `pnpm test`, `pnpm build`, `pnpm smoke:dist`, `pnpm check:worker`, `pnpm check:islands`.

Known pre-existing failure: `tests/config/deploymentWorkflows.test.ts` fails 2 tests ("executes rollback after a post-activation failure and not after success", "executes recovery reconciliation and fails closed when recovery cannot complete"). Both fail identically on a clean `main` checkout — confirmed by stashing the diff and re-running. Not related to this change.

Also drove the built `dist/client` in real Chromium to confirm the toggle: VPC block hidden on the default Kitaru tab, visible after clicking ZenML, hidden again on switching back. And grepped the built HTML — no `pip install kitaru` remains on any non-blog page.

## Preview URLs / paths to check

- `/pricing` — toggle between the Kitaru and ZenML tabs and watch the "Your VPC, your data" section
- `/product/kitaru` — hero + CTA install commands
- `/compare/kitaru-vs-restate` — hero, CTA, body copy, and the embedded-vs-server graphic
- `/compare/kitaru-vs-dbos` — hero, CTA, and the stack deployment graphic

🤖 Generated with [Claude Code](https://claude.com/claude-code)