### PR TITLE
Fix Kitaru product code examples

### DIFF
--- a/scripts/check-dist-smoke.ts
+++ b/scripts/check-dist-smoke.ts
@@ -7,6 +7,7 @@ const AGENT_SKILLS_INDEX_PATH = ".well-known/agent-skills/index.json";
 const REQUIRED_FILES = [
   "index.html",
   "product/kitaru.html",
+  "product/kitaru.md",
   "product/zenml.html",
   "compare.html",
   "blog.html",
@@ -150,8 +151,19 @@ const CONTENT_MARKER_CHECKS: ContentMarkerCheck[] = [
   },
   {
     file: "product/kitaru.html",
-    markers: ['data-app="kitaru"', 'id="kitaru-main"'],
-    message: "dist/product/kitaru.html contains Kitaru page identity markers",
+    markers: [
+      'data-app="kitaru"',
+      'id="kitaru-main"',
+      "kitaru/kitaru-jsonl@latest",
+      "kitaru experiment run start baseline",
+      "kitaru_workflow_start",
+    ],
+    message: "dist/product/kitaru.html contains current Kitaru code markers",
+  },
+  {
+    file: "product/kitaru.md",
+    markers: ['uv add "kitaru[cli,worker]" kitaru-pydantic-ai'],
+    message: "dist/product/kitaru.md contains the page-local install command",
   },
   {
     file: "product/zenml.html",

--- a/src/components/kitaru/Features.astro
+++ b/src/components/kitaru/Features.astro
@@ -104,10 +104,10 @@ import HighlightPanel from "./_HighlightPanel.astro";
           {s.n === "03" && (
             <HighlightPanel>
               <div class="relative z-10 border-b border-border/60 pb-2">
-                <div class="fh-pop font-mono text-[10.5px] font-medium" style="--fh-delay: 250ms">cheap-model</div>
+                <div class="fh-pop font-mono text-[10.5px] font-medium" style="--fh-delay: 250ms">same cohort &middot; same agent version</div>
                 <div class="mt-1.5 flex flex-col gap-1 font-mono text-[10px]">
-                  <span class="fh-pop flex items-center gap-1.5 text-muted-foreground" style="--fh-delay: 330ms"><span class="size-1.5 shrink-0 rounded-full bg-border"></span>#1 &middot; claude-sonnet-4.5</span>
-                  <span class="fh-pop flex items-center gap-1.5 text-ember-deep" style="--fh-delay: 410ms"><span class="size-1.5 shrink-0 rounded-full bg-ember"></span>#2 &middot; claude-haiku-4.5</span>
+                  <span class="fh-pop flex items-center gap-1.5 text-muted-foreground" style="--fh-delay: 330ms"><span class="size-1.5 shrink-0 rounded-full bg-border"></span>baseline &middot; claude-sonnet-4.5</span>
+                  <span class="fh-pop flex items-center gap-1.5 text-ember-deep" style="--fh-delay: 410ms"><span class="size-1.5 shrink-0 rounded-full bg-ember"></span>cheap-model &middot; claude-haiku-4.5</span>
                 </div>
               </div>
               <div class="relative z-10 flex flex-1 flex-col justify-evenly">
@@ -142,21 +142,7 @@ import HighlightPanel from "./_HighlightPanel.astro";
             </HighlightPanel>
           )}
 
-          {/* Whitespace inside <pre> renders literally in .astro templates, so the
-              content below must stay free of raw newlines/indentation. */}
-          <pre class="mt-3 block overflow-x-auto rounded-md border border-border bg-night px-3.5 py-2.5 font-mono text-[11.5px] text-night-text/85"><code class="code-syntax">{
-            s.n === "01" && (
-              <><span class="fn">kitaru</span> cohort <span class="fn">create</span> <span class="str">"checkout-flow"</span></>
-            )
-          }{
-            s.n === "02" && (
-              <><span class="fn">kitaru</span> experiment <span class="fn">create</span> cheap-model</>
-            )
-          }{
-            s.n === "03" && (
-              <><span class="fn">kitaru</span> experiment <span class="fn">run</span> cheap-model</>
-            )
-          }</code></pre>
+          <pre class="mt-3 block overflow-x-auto rounded-md border border-border bg-night px-3.5 py-2.5 font-mono text-[11.5px] text-night-text/85"><code>{s.command}</code></pre>
         </div>
       ))}
     </div>

--- a/src/components/kitaru/islands/AgentDriven.tsx
+++ b/src/components/kitaru/islands/AgentDriven.tsx
@@ -15,13 +15,32 @@ const agentIcons: Record<string, typeof AnthropicIcon> = {
   "Gemini CLI": GeminiIcon,
 };
 
-const transcript = [
+export const AGENT_TRANSCRIPT = [
   {
-    text: 'run cheap-model · cohort="checkout-flow" · version="v1"',
+    text: 'kitaru_workflow_start { "operation": "experiment_run",',
+    kind: "agent",
+  },
+  {
+    text: '"experiment_id": "$EXPERIMENT_ID", "cohort_version_id": "$COHORT_VERSION_ID",',
+    kind: "agent",
+  },
+  {
+    text: '"agent_version_id": "$V1_AGENT_VERSION_ID" }',
     kind: "agent",
   },
   { text: "90 sessions · cited-superseded-doc true 90 · false 0", kind: "out" },
-  { text: 'run cheap-model · version="pr-311"', kind: "agent" },
+  {
+    text: 'kitaru_workflow_start { "operation": "experiment_run",',
+    kind: "agent",
+  },
+  {
+    text: '"experiment_id": "$EXPERIMENT_ID", "cohort_version_id": "$COHORT_VERSION_ID",',
+    kind: "agent",
+  },
+  {
+    text: '"agent_version_id": "$CANDIDATE_AGENT_VERSION_ID" }',
+    kind: "agent",
+  },
   { text: "cited-superseded-doc true 4 · false 86", kind: "good" },
   { text: "4 still failing — opening these for you to read", kind: "bad" },
 ] as const;
@@ -80,7 +99,7 @@ export function AgentDriven() {
               </span>
             </div>
             <div className="flex flex-col gap-2.5 px-5 py-6 font-mono text-[12.5px] leading-relaxed">
-              {transcript.map((l, i) => (
+              {AGENT_TRANSCRIPT.map((l, i) => (
                 <div
                   key={i}
                   className={

--- a/src/components/kitaru/islands/CodeShowcase.tsx
+++ b/src/components/kitaru/islands/CodeShowcase.tsx
@@ -14,234 +14,509 @@ import { Reveal } from "./Reveal";
 
 type Line = { tokens: CodeLine; key?: string; dim?: boolean };
 
-const python: Line[] = [
-  { tokens: [{ kw: "import" }, " kitaru"], dim: true },
-  { tokens: [] },
+export const PYTHON_SHOWCASE: Line[] = [
   {
-    tokens: ["client ", { op: "=" }, " kitaru.", { fn: "KitaruClient" }, "()"],
-  },
-  { tokens: [] },
-  {
-    tokens: [{ cmt: "# the sessions that matter, frozen as a named set" }],
+    tokens: [{ kw: "import" }, " asyncio"],
     dim: true,
   },
   {
-    tokens: ["cohort ", { op: "=" }, " client.cohorts.", { fn: "create" }, "("],
-    key: "cohort",
+    tokens: [
+      { kw: "from" },
+      " kitaru.api_models.v1.experiment ",
+      { kw: "import" },
+      " ExperimentCreateRequest",
+    ],
+    dim: true,
+  },
+  {
+    tokens: [
+      { kw: "from" },
+      " kitaru.api_models.v1.experiment_run ",
+      { kw: "import" },
+      " ExperimentRunCreateRequest, ExperimentRunStatus",
+    ],
+    dim: true,
+  },
+  {
+    tokens: [
+      { kw: "from" },
+      " kitaru.api_models.v1.replay_config ",
+      { kw: "import" },
+      " EvaluatorConfig, HistoryConfig, ReplayOverride, ToolPolicy",
+    ],
+    dim: true,
+  },
+  {
+    tokens: [
+      { kw: "from" },
+      " kitaru.client ",
+      { kw: "import" },
+      " KitaruAPIClient",
+    ],
+    dim: true,
+  },
+  { tokens: [] },
+  {
+    tokens: [
+      "TERMINAL ",
+      { op: "=" },
+      " {ExperimentRunStatus.COMPLETED, ExperimentRunStatus.FAILED,",
+    ],
+    dim: true,
+  },
+  {
+    tokens: ["    ExperimentRunStatus.CANCELED}"],
+    dim: true,
+  },
+  {
+    tokens: [
+      { kw: "async def" },
+      " ",
+      { fn: "wait_for_run" },
+      "(client, run_id):",
+    ],
+    dim: true,
+  },
+  {
+    tokens: ["    ", { kw: "while True" }, ":"],
+    dim: true,
+  },
+  {
+    tokens: [
+      "        run ",
+      { op: "=" },
+      " ",
+      { kw: "await" },
+      " client.experiment_runs.",
+      { fn: "get" },
+      "(run_id)",
+    ],
+    dim: true,
+  },
+  {
+    tokens: [
+      "        ",
+      { kw: "if" },
+      " run.status ",
+      { kw: "in" },
+      " TERMINAL:",
+    ],
+    dim: true,
+  },
+  {
+    tokens: ["            ", { kw: "return" }, " run"],
+    dim: true,
+  },
+  {
+    tokens: ["        ", { kw: "await" }, " ", { fn: "asyncio.sleep" }, "(1)"],
+    dim: true,
+  },
+  { tokens: [] },
+  {
+    tokens: [
+      "policy ",
+      { op: "=" },
+      " ",
+      { fn: "ToolPolicy" },
+      "(default",
+      { op: "=" },
+      { fn: "HistoryConfig" },
+      "(",
+    ],
+    key: "policy",
+  },
+  {
+    tokens: [
+      "    scope",
+      { op: "=" },
+      { str: '"cohort_version"' },
+      ", on_miss",
+      { op: "=" },
+      { str: '"fail"' },
+      "))",
+    ],
+    key: "policy",
+  },
+  {
+    tokens: [
+      "evaluator ",
+      { op: "=" },
+      " ",
+      { fn: "EvaluatorConfig" },
+      "(evaluator",
+      { op: "=" },
+      { str: '"response-quality"' },
+      ", version",
+      { op: "=" },
+      "1)",
+    ],
+  },
+  { tokens: [] },
+  {
+    tokens: [{ kw: "async def" }, " ", { fn: "main" }, "():"],
   },
   {
     tokens: [
       "    ",
-      { str: '"checkout-flow"' },
-      ", sessions",
-      { op: "=" },
-      "session_ids,",
+      { kw: "async with" },
+      " ",
+      { fn: "KitaruAPIClient" },
+      "() ",
+      { kw: "as" },
+      " client:",
     ],
-    key: "cohort",
-  },
-  { tokens: [")"], key: "cohort" },
-  { tokens: [] },
-  {
-    tokens: [{ cmt: "# configuration only — no cohort, no version" }],
-    dim: true,
   },
   {
     tokens: [
-      "experiment ",
+      "        baseline ",
       { op: "=" },
+      " ",
+      { kw: "await" },
       " client.experiments.",
       { fn: "create" },
       "(",
     ],
     key: "experiment",
   },
-  { tokens: ["    ", { str: '"cheap-model"' }, ","], key: "experiment" },
   {
-    tokens: ["    model", { op: "=" }, { str: '"glm-5.4"' }, ","],
+    tokens: [
+      "            ",
+      { fn: "ExperimentCreateRequest" },
+      "(name",
+      { op: "=" },
+      { str: '"baseline"' },
+      ", agent_id",
+      { op: "=" },
+      "AGENT_ID,",
+    ],
+    key: "experiment",
+  },
+  {
+    tokens: [
+      "                tool_policy",
+      { op: "=" },
+      "policy, evaluators",
+      { op: "=" },
+      "[evaluator]))",
+    ],
+    key: "experiment",
+  },
+  {
+    tokens: [
+      "        candidate ",
+      { op: "=" },
+      " ",
+      { kw: "await" },
+      " client.experiments.",
+      { fn: "create" },
+      "(",
+    ],
+    key: "experiment",
+  },
+  {
+    tokens: [
+      "            ",
+      { fn: "ExperimentCreateRequest" },
+      "(name",
+      { op: "=" },
+      { str: '"cheap-model"' },
+      ", agent_id",
+      { op: "=" },
+      "AGENT_ID,",
+    ],
+    key: "experiment",
+  },
+  {
+    tokens: [
+      "                override",
+      { op: "=" },
+      { fn: "ReplayOverride" },
+      "(model",
+      { op: "=" },
+      { str: '"claude-haiku-4.5"' },
+      "),",
+    ],
     key: "model",
   },
   {
     tokens: [
-      "    tool_policy",
+      "                tool_policy",
       { op: "=" },
-      { fn: "History" },
-      "(scope",
+      "policy, evaluators",
       { op: "=" },
-      { str: '"cohort"' },
-      ", on_miss",
-      { op: "=" },
-      { str: '"fail"' },
-      "),",
+      "[evaluator]))",
     ],
-    key: "policy",
+    key: "experiment",
   },
-  { tokens: [")"], key: "experiment" },
   { tokens: [] },
-  { tokens: [{ cmt: "# a run is config + cohort + version." }], dim: true },
   {
     tokens: [
-      "before ",
+      "        run_spec ",
       { op: "=" },
-      " experiment.",
-      { fn: "run" },
-      "(cohort",
+      " ",
+      { fn: "ExperimentRunCreateRequest" },
+      "(",
+    ],
+    key: "cohort",
+  },
+  {
+    tokens: [
+      "            cohort_version_id",
       { op: "=" },
-      "cohort, version",
+      "COHORT_VERSION_ID, agent_version_id",
       { op: "=" },
-      { str: '"v1"' },
+      "AGENT_VERSION_ID,",
+    ],
+    key: "cohort",
+  },
+  {
+    tokens: [
+      "            evaluate_baselines",
+      { op: "=" },
+      { kw: "True" },
       ")",
+    ],
+    key: "cohort",
+  },
+  {
+    tokens: [
+      "        before, after ",
+      { op: "=" },
+      " ",
+      { kw: "await" },
+      " ",
+      { fn: "asyncio.gather" },
+      "(",
     ],
     key: "run",
   },
   {
     tokens: [
-      "after ",
-      { op: "=" },
-      " experiment.",
-      { fn: "run" },
-      "(cohort",
-      { op: "=" },
-      "cohort, version",
-      { op: "=" },
-      { str: '"pr-311"' },
-      ")",
+      "            client.experiments.",
+      { fn: "start_run" },
+      "(baseline.id, run_spec),",
     ],
     key: "run",
   },
+  {
+    tokens: [
+      "            client.experiments.",
+      { fn: "start_run" },
+      "(candidate.id, run_spec),",
+    ],
+    key: "run",
+  },
+  { tokens: ["        )"], key: "run" },
   { tokens: [] },
-  { tokens: ["client.", { fn: "compare" }, "(before, after)"], key: "compare" },
+  {
+    tokens: [
+      "        ",
+      { kw: "async with" },
+      " ",
+      { fn: "asyncio.timeout" },
+      "(300):",
+    ],
+    key: "inspect",
+  },
+  {
+    tokens: [
+      "            before, after ",
+      { op: "=" },
+      " ",
+      { kw: "await" },
+      " ",
+      { fn: "asyncio.gather" },
+      "(",
+    ],
+    key: "inspect",
+  },
+  {
+    tokens: [
+      "                ",
+      { fn: "wait_for_run" },
+      "(client, before.id),",
+    ],
+    key: "inspect",
+  },
+  {
+    tokens: ["                ", { fn: "wait_for_run" }, "(client, after.id),"],
+    key: "inspect",
+  },
+  { tokens: ["            )"], key: "inspect" },
+  { tokens: [] },
+  {
+    tokens: [{ fn: "asyncio.run" }, "(", { fn: "main" }, "())"],
+  },
 ];
 
-const typescript: Line[] = [
+export const TYPESCRIPT_SHOWCASE: Line[] = [
   {
     tokens: [
       { kw: "import" },
-      " { KitaruClient, History } ",
+      " { createKitaruClient } ",
       { kw: "from" },
       " ",
-      { str: '"@zenml-io/kitaru"' },
+      { str: '"@zenml-io/kitaru/node"' },
       ";",
     ],
     dim: true,
   },
-  { tokens: [] },
   {
     tokens: [
       { kw: "const" },
       " client ",
       { op: "=" },
       " ",
-      { kw: "new" },
+      { kw: "await" },
       " ",
-      { fn: "KitaruClient" },
+      { fn: "createKitaruClient" },
       "();",
     ],
   },
   { tokens: [] },
   {
-    tokens: [{ cmt: "// the sessions that matter, frozen as a named set" }],
-    dim: true,
+    tokens: [{ kw: "const" }, " common ", { op: "=" }, " { agent_id: agentId,"],
+    key: "experiment",
+  },
+  {
+    tokens: ["  tool_policy: { default: { type: ", { str: '"history"' }, ","],
+    key: "policy",
   },
   {
     tokens: [
-      { kw: "const" },
-      " cohort ",
-      { op: "=" },
-      " ",
-      { kw: "await" },
-      " client.cohorts.",
-      { fn: "create" },
-      "(",
+      "    scope: ",
+      { str: '"cohort_version"' },
+      ", on_miss: ",
+      { str: '"fail"' },
+      " } },",
     ],
-    key: "cohort",
+    key: "policy",
   },
   {
-    tokens: ["    ", { str: '"checkout-flow"' }, ", { sessions: sessionIds },"],
-    key: "cohort",
+    tokens: [
+      "  evaluators: [{ evaluator: ",
+      { str: '"response-quality"' },
+      ", version: 1 }],",
+    ],
   },
-  { tokens: [");"], key: "cohort" },
+  { tokens: ["};"], key: "experiment" },
   { tokens: [] },
   {
-    tokens: [{ cmt: "// configuration only — no cohort, no version" }],
-    dim: true,
-  },
-  {
     tokens: [
       { kw: "const" },
-      " experiment ",
+      " baseline ",
       { op: "=" },
       " ",
       { kw: "await" },
       " client.experiments.",
       { fn: "create" },
-      "(",
-      { str: '"cheap-model"' },
-      ", {",
+      "({",
     ],
     key: "experiment",
   },
-  { tokens: ["    model: ", { str: '"glm-5.4"' }, ","], key: "model" },
+  {
+    tokens: ["  name: ", { str: '"baseline"' }, ", ...common });"],
+    key: "experiment",
+  },
   {
     tokens: [
-      "    toolPolicy: ",
-      { fn: "History" },
-      "({ scope: ",
-      { str: '"cohort"' },
-      ", onMiss: ",
-      { str: '"fail"' },
-      " }),",
+      { kw: "const" },
+      " candidate ",
+      { op: "=" },
+      " ",
+      { kw: "await" },
+      " client.experiments.",
+      { fn: "create" },
+      "({",
     ],
-    key: "policy",
+    key: "experiment",
+  },
+  {
+    tokens: ["  name: ", { str: '"cheap-model"' }, ", ...common,"],
+    key: "experiment",
+  },
+  {
+    tokens: ["  override: { model: ", { str: '"claude-haiku-4.5"' }, " },"],
+    key: "model",
   },
   { tokens: ["});"], key: "experiment" },
   { tokens: [] },
-  { tokens: [{ cmt: "// a run is config + cohort + version." }], dim: true },
   {
     tokens: [
       { kw: "const" },
-      " before ",
+      " runSpec ",
+      { op: "=" },
+      " { cohort_version_id: cohortVersionId,",
+    ],
+    key: "cohort",
+  },
+  {
+    tokens: [
+      "  agent_version_id: agentVersionId, evaluate_baselines: ",
+      { kw: "true" },
+      " };",
+    ],
+    key: "cohort",
+  },
+  {
+    tokens: [
+      { kw: "const" },
+      " [before, after] ",
       { op: "=" },
       " ",
       { kw: "await" },
-      " experiment.",
-      { fn: "run" },
-      "({ cohort, version: ",
-      { str: '"v1"' },
-      " });",
+      " ",
+      { fn: "Promise.all" },
+      "([",
     ],
     key: "run",
   },
   {
     tokens: [
-      { kw: "const" },
-      " after ",
-      { op: "=" },
-      " ",
-      { kw: "await" },
-      " experiment.",
-      { fn: "run" },
-      "({ cohort, version: ",
-      { str: '"pr-311"' },
-      " });",
+      "  client.experiments.",
+      { fn: "startRun" },
+      "(baseline.id, runSpec),",
     ],
     key: "run",
   },
+  {
+    tokens: [
+      "  client.experiments.",
+      { fn: "startRun" },
+      "(candidate.id, runSpec),",
+    ],
+    key: "run",
+  },
+  { tokens: ["]);"], key: "run" },
   { tokens: [] },
   {
     tokens: [
+      { kw: "const" },
+      " [beforeResult, afterResult] ",
+      { op: "=" },
+      " ",
       { kw: "await" },
-      " client.",
-      { fn: "compare" },
-      "(before, after);",
+      " ",
+      { fn: "Promise.all" },
+      "([",
     ],
-    key: "compare",
+    key: "inspect",
   },
+  {
+    tokens: ["  client.experimentRuns.", { fn: "wait" }, "(before.id),"],
+    key: "inspect",
+  },
+  {
+    tokens: ["  client.experimentRuns.", { fn: "wait" }, "(after.id),"],
+    key: "inspect",
+  },
+  { tokens: ["]);"], key: "inspect" },
 ];
 
 export function CodeShowcase() {
   const [lang, setLang] = useState<"python" | "typescript">("python");
   const [hot, setHot] = useState<string | null>(null);
-  const lines = lang === "python" ? python : typescript;
+  const lines = lang === "python" ? PYTHON_SHOWCASE : TYPESCRIPT_SHOWCASE;
 
   return (
     <section
@@ -255,8 +530,9 @@ export function CodeShowcase() {
             One cohort, one changed variable, two runs.
           </h2>
           <p className="mt-5 max-w-2xl text-base leading-relaxed text-night-text/60 md:text-lg">
-            An experiment holds the configuration; a run pins it to a cohort and
-            a version. Same model in Python and TypeScript. Hover any line.
+            Each experiment holds one configuration; each run pins it to the
+            same cohort and agent version. The workflow is available in Python
+            and TypeScript. Hover any line.
           </p>
         </Reveal>
 

--- a/src/components/kitaru/islands/Hero.tsx
+++ b/src/components/kitaru/islands/Hero.tsx
@@ -10,24 +10,33 @@ import { KitaruGrain } from "./KitaruGrain";
 import { CopyCommand } from "./primitives";
 import { Reveal } from "./Reveal";
 
-const codeLines: Array<{ text: string; kind?: "cmt" | "hl" | "out" | "cont" }> =
-  [
-    { text: "# 1 · wrap the agent you already have", kind: "cmt" },
-    { text: "agent = KitaruAgent(intake_agent)", kind: "hl" },
-    { text: "" },
-    { text: "# 2 · the runs it already made, imported", kind: "cmt" },
-    { text: "kitaru session import ./traces.jsonl \\" },
-    { text: "  --agent intake-agent", kind: "cont" },
-    { text: "" },
-    { text: "# 3 · get interviewed, in your coding agent", kind: "cmt" },
-    { text: "walk me through 20 of these", kind: "hl" },
-    { text: '→ cohort "dropped the hazmat flag" · 9', kind: "out" },
-    { text: "→ evaluator hazmat-flag-preserved", kind: "out" },
-    { text: "" },
-    { text: "# 4 · change the agent, compare the runs", kind: "cmt" },
-    { text: "kitaru experiment run fix-validation \\", kind: "hl" },
-    { text: "  --cohort hazmat-all --version pr-311", kind: "cont" },
-  ];
+export const HERO_CODE_LINES: Array<{
+  text: string;
+  kind?: "cmt" | "hl" | "out" | "cont";
+}> = [
+  { text: "# 1 · wrap the agent you already have", kind: "cmt" },
+  { text: "from kitaru_pydantic_ai import KitaruAgent" },
+  { text: "agent = KitaruAgent(intake_agent, agent_id=AGENT_ID)", kind: "hl" },
+  { text: "" },
+  { text: "# 2 · the runs it already made, imported", kind: "cmt" },
+  { text: "kitaru session import ./traces.jsonl \\" },
+  {
+    text: "  --importer kitaru/kitaru-jsonl@latest --agent intake-agent@latest --wait",
+    kind: "cont",
+  },
+  { text: "" },
+  { text: "# 3 · get interviewed, in your coding agent", kind: "cmt" },
+  { text: "walk me through 20 of these", kind: "hl" },
+  { text: '→ cohort "dropped the hazmat flag" · 9', kind: "out" },
+  { text: "→ evaluator hazmat-flag-preserved", kind: "out" },
+  { text: "" },
+  { text: "# 4 · change the agent, compare the runs", kind: "cmt" },
+  { text: "kitaru experiment run start fix-validation \\", kind: "hl" },
+  {
+    text: "  --cohort-version $COHORT_VERSION_ID --agent intake-agent@pr-311 --wait",
+    kind: "cont",
+  },
+];
 
 const diffRows = [
   { label: "Your notes, 20 read", value: "1 evaluator, 3 cohorts" },
@@ -177,7 +186,7 @@ export function Hero() {
 
             <pre className="code-syntax overflow-x-auto px-5 py-5 font-mono text-[12px] leading-[1.75]">
               <code>
-                {codeLines.map((l, i) => (
+                {HERO_CODE_LINES.map((l, i) => (
                   <CodeLine key={i} text={l.text} kind={l.kind} />
                 ))}
               </code>

--- a/src/components/kitaru/islands/OneImport.tsx
+++ b/src/components/kitaru/islands/OneImport.tsx
@@ -29,16 +29,18 @@ type Framework = {
   label: string;
   /** Filename shown in the code block chrome — carries the language. */
   file: string;
+  install: string;
   before: CodeLine[];
   after: CodeLine[];
 };
 
-const frameworks: Framework[] = [
+export const FRAMEWORKS: Framework[] = [
   {
     id: "pydanticai",
     Icon: PydanticIcon,
     label: "PydanticAI",
     file: "agent.py",
+    install: 'uv add "kitaru-pydantic-ai[openai]"',
     before: [
       [{ kw: "from" }, " pydantic_ai ", { kw: "import" }, " Agent"],
       [],
@@ -89,7 +91,7 @@ const frameworks: Framework[] = [
         ",",
       ],
       ["    tools", { op: "=" }, "[search_docs, fetch_policy],"],
-      ["))"],
+      ["), agent_id", { op: "=" }, "AGENT_ID)"],
       [],
       [
         "result ",
@@ -107,6 +109,7 @@ const frameworks: Framework[] = [
     Icon: OpenAIIcon,
     label: "OpenAI Agents SDK",
     file: "agent.py",
+    install: "uv add kitaru-openai-agents",
     before: [
       [{ kw: "from" }, " agents ", { kw: "import" }, " Agent, Runner"],
       [],
@@ -176,6 +179,7 @@ const frameworks: Framework[] = [
     Icon: LangChainIcon,
     label: "LangGraph",
     file: "agent.py",
+    install: "uv add kitaru-langgraph",
     before: [
       [
         { kw: "from" },
@@ -238,7 +242,9 @@ const frameworks: Framework[] = [
         { fn: "KitaruGraphRunner" },
         "(builder.",
         { fn: "compile" },
-        "())",
+        "(), agent_id",
+        { op: "=" },
+        "AGENT_ID)",
       ],
       [
         "result ",
@@ -256,6 +262,7 @@ const frameworks: Framework[] = [
     Icon: MastraIcon,
     label: "Mastra",
     file: "agent.ts",
+    install: "pnpm add @zenml-io/kitaru-mastra @mastra/core@1.51.0",
     before: [
       [
         { kw: "import" },
@@ -350,6 +357,8 @@ const frameworks: Framework[] = [
     Icon: VercelIcon,
     label: "Vercel AI SDK",
     file: "agent.ts",
+    install:
+      "pnpm add @zenml-io/kitaru-vercel-ai ai@7.0.65 @ai-sdk/openai@4.0.20 zod@4.4.3",
     before: [
       [
         { kw: "import" },
@@ -431,22 +440,22 @@ const frameworks: Framework[] = [
 ];
 
 export function OneImport() {
-  const [active, setActive] = useState<string>(frameworks[0].id);
-  const fw = frameworks.find((f) => f.id === active) ?? frameworks[0];
+  const [active, setActive] = useState<string>(FRAMEWORKS[0].id);
+  const fw = FRAMEWORKS.find((f) => f.id === active) ?? FRAMEWORKS[0];
 
   // WAI-ARIA tabs pattern: arrow keys move selection with roving focus, so
   // the tablist is one Tab stop instead of five.
   const onTablistKeyDown = (event: KeyboardEvent) => {
-    const index = frameworks.findIndex((f) => f.id === active);
+    const index = FRAMEWORKS.findIndex((f) => f.id === active);
     let next = -1;
-    if (event.key === "ArrowRight") next = (index + 1) % frameworks.length;
+    if (event.key === "ArrowRight") next = (index + 1) % FRAMEWORKS.length;
     else if (event.key === "ArrowLeft")
-      next = (index - 1 + frameworks.length) % frameworks.length;
+      next = (index - 1 + FRAMEWORKS.length) % FRAMEWORKS.length;
     else if (event.key === "Home") next = 0;
-    else if (event.key === "End") next = frameworks.length - 1;
+    else if (event.key === "End") next = FRAMEWORKS.length - 1;
     if (next === -1) return;
     event.preventDefault();
-    const id = frameworks[next].id;
+    const id = FRAMEWORKS[next].id;
     setActive(id);
     document.getElementById(`one-import-tab-${id}`)?.focus();
   };
@@ -472,7 +481,7 @@ export function OneImport() {
           className="flex flex-wrap gap-2"
           onKeyDown={onTablistKeyDown}
         >
-          {frameworks.map((f) => (
+          {FRAMEWORKS.map((f) => (
             <button
               key={f.id}
               id={`one-import-tab-${f.id}`}
@@ -502,6 +511,12 @@ export function OneImport() {
         aria-labelledby={`one-import-tab-${fw.id}`}
         className="mt-8 grid grid-cols-1 items-center gap-5 lg:grid-cols-[1fr_auto_1fr]"
       >
+        <p className="col-span-full overflow-x-auto rounded-lg border border-border bg-surface px-4 py-3 font-mono text-xs text-ink-soft">
+          <span className="mr-3 uppercase tracking-wider text-ember">
+            Install
+          </span>
+          {fw.install}
+        </p>
         <Reveal delay={120} variant="left" key={`${fw.id}-before`}>
           <CodeBlock
             code={renderCodeLines(fw.before)}

--- a/src/lib/kitaru-landing.ts
+++ b/src/lib/kitaru-landing.ts
@@ -1,11 +1,14 @@
 // Re-export shared constants from productKitaru to avoid duplication
 export {
-  KITARU_INSTALL_CMD,
   KITARU_LICENSE,
   KITARU_LINKS,
   KITARU_TRIAL_DAYS,
   KITARU_TRIAL_NOTE,
 } from "./productKitaru";
+
+/** Install the CLI and worker exercised by this landing page. */
+export const KITARU_INSTALL_CMD =
+  'uv add "kitaru[cli,worker]" kitaru-pydantic-ai';
 
 // Note: PRODUCT_KITARU_SEO is retained in productKitaru.ts as it serves the page's meta tags
 
@@ -50,18 +53,23 @@ export const STEPS = [
     tag: "Cohort",
     title: "Freeze the sessions that matter",
     body: "The sessions you care about, frozen as a named set. Immutable, so a run's result keeps meaning what it meant.",
+    command:
+      "COHORT_VERSION_ID=$(kitaru cohort create checkout-flow --agent checkout-agent --sessions-file session-ids.txt --output json --machine --non-interactive --no-browser | jq -r '.item.version.id')",
   },
   {
     n: "02",
     tag: "Experiment",
-    title: "State one hypothesis",
-    body: "Just configuration: model, system prompt, tool policy. Swap the model and you have stated a different hypothesis.",
+    title: "State the two hypotheses",
+    body: "Each experiment is just configuration. Keep the baseline fixed, then change only the model in the candidate.",
+    command: `kitaru experiment create baseline --agent checkout-agent --tool-policy '{"default":{"type":"history","scope":"cohort_version","on_miss":"fail"}}' --evaluator response-quality@latest\nkitaru experiment create cheap-model --agent checkout-agent --override '{"model":"claude-haiku-4.5"}' --tool-policy '{"default":{"type":"history","scope":"cohort_version","on_miss":"fail"}}' --evaluator response-quality@latest`,
   },
   {
     n: "03",
     tag: "Two runs",
     title: "Compare like with like",
-    body: "Twice over the same cohort, one version apart. One variable moved, so the numbers mean what they look like.",
+    body: "Run the baseline and candidate over the same cohort and agent version. One model moved, so the numbers mean what they look like.",
+    command:
+      'kitaru experiment run start baseline --cohort-version "$COHORT_VERSION_ID" --agent checkout-agent@v1 --wait\nkitaru experiment run start cheap-model --cohort-version "$COHORT_VERSION_ID" --agent checkout-agent@v1 --wait',
   },
 ] as const;
 
@@ -83,33 +91,33 @@ export const GROUND_TRUTH_POINTS = [
 export const ANNOTATIONS = [
   {
     key: "cohort",
-    label: "cohorts.create()",
+    label: "cohort_version_id=...",
     body: "An immutable set of sessions — a run depends on its cohort, so a mutable one would make old results meaningless.",
   },
   {
     key: "experiment",
-    label: "experiments.create()",
+    label: "experiments.create(...)",
     body: "Pure configuration. Change the code and you get a new run; change the prompt and you get a new experiment.",
   },
   {
     key: "model",
-    label: 'model="glm-5.4"',
+    label: 'ReplayOverride(model="claude-haiku-4.5")',
     body: "The variable under test. A run that moved two things cannot tell you which one did it.",
   },
   {
     key: "policy",
-    label: 'History(scope="cohort")',
+    label: 'HistoryConfig(scope="cohort_version")',
     body: "One of four policies — history, passthrough, static, llm. Every intercepted node is stamped with the one that answered it.",
   },
   {
     key: "run",
-    label: "experiment.run()",
+    label: "experiments.start_run(...)",
     body: "Each replay creates a new session instead of overwriting the original, so the baseline survives intact.",
   },
   {
-    key: "compare",
-    label: "compare(before, after)",
-    body: "No verdict, no blended score. Two runs, side by side, read by you.",
+    key: "inspect",
+    label: "wait_for_run(...) / experimentRuns.wait(...)",
+    body: "Wait for both exact runs to settle, then inspect their comparison in Kitaru. It does not invent a verdict or a blended score.",
   },
 ] as const;
 

--- a/src/pages/product/kitaru.md.ts
+++ b/src/pages/product/kitaru.md.ts
@@ -5,6 +5,7 @@ import {
   markdownPreamble,
   markdownResponse,
 } from "../../lib/agentMarkdown";
+import { KITARU_INSTALL_CMD } from "../../lib/kitaru-landing";
 import {
   PRODUCT_KITARU_MARKDOWN,
   PRODUCT_KITARU_SEO,
@@ -22,7 +23,7 @@ export function GET(): Response {
     joinMarkdownSections(
       "## Summary",
       ...PRODUCT_KITARU_MARKDOWN.summary,
-      `Install: \`${PRODUCT_KITARU_MARKDOWN.installCmd}\``,
+      `Install: \`${KITARU_INSTALL_CMD}\``,
     ),
     joinMarkdownSections(
       "## Main CTAs",
@@ -30,9 +31,13 @@ export function GET(): Response {
     ),
     joinMarkdownSections(
       "## The five acts",
-      ...PRODUCT_KITARU_MARKDOWN.journey.map((step) =>
-        joinMarkdownSections(`### ${step.name}`, step.body),
-      ),
+      ...PRODUCT_KITARU_MARKDOWN.journey.map((step) => {
+        const body = step.body.replace(
+          `\`${PRODUCT_KITARU_MARKDOWN.installCmd}\``,
+          `\`${KITARU_INSTALL_CMD}\``,
+        );
+        return joinMarkdownSections(`### ${step.name}`, body);
+      }),
     ),
     joinMarkdownSections(
       "## The object model",

--- a/tests/lib/kitaruProductSnippets.test.ts
+++ b/tests/lib/kitaruProductSnippets.test.ts
@@ -1,0 +1,348 @@
+import { spawnSync } from "node:child_process";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+import { AGENT_TRANSCRIPT } from "../../src/components/kitaru/islands/AgentDriven";
+import {
+  PYTHON_SHOWCASE,
+  TYPESCRIPT_SHOWCASE,
+} from "../../src/components/kitaru/islands/CodeShowcase";
+import type { CodeLine } from "../../src/components/kitaru/islands/code-tokens";
+import { HERO_CODE_LINES } from "../../src/components/kitaru/islands/Hero";
+import { FRAMEWORKS } from "../../src/components/kitaru/islands/OneImport";
+import { KITARU_INSTALL_CMD, STEPS } from "../../src/lib/kitaru-landing";
+import { GET as getKitaruMarkdown } from "../../src/pages/product/kitaru.md";
+
+function renderTokens(tokens: CodeLine): string {
+  return tokens
+    .map((token) =>
+      typeof token === "string" ? token : (Object.values(token)[0] ?? ""),
+    )
+    .join("");
+}
+
+function renderLines(lines: Array<{ tokens: CodeLine }>): string {
+  return lines.map((line) => renderTokens(line.tokens)).join("\n");
+}
+
+function expectValidPython(source: string): void {
+  for (const executable of ["python3", "python"]) {
+    const result = spawnSync(
+      executable,
+      ["-c", "import ast, sys; ast.parse(sys.stdin.read())"],
+      { encoding: "utf8", input: source },
+    );
+    if (
+      (result.error as NodeJS.ErrnoException | undefined)?.code === "ENOENT"
+    ) {
+      continue;
+    }
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+    return;
+  }
+  throw new Error(
+    "Python is required to validate the displayed Python snippet",
+  );
+}
+
+function expectValidTypeScript(source: string): void {
+  const diagnostics =
+    ts.transpileModule(source, {
+      compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2022,
+      },
+      reportDiagnostics: true,
+    }).diagnostics ?? [];
+  expect(
+    diagnostics.map((diagnostic) =>
+      ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"),
+    ),
+  ).toEqual([]);
+}
+
+describe("Kitaru product-page snippets", () => {
+  it("installs the CLI and worker used by the page", () => {
+    expect(KITARU_INSTALL_CMD).toBe(
+      'uv add "kitaru[cli,worker]" kitaru-pydantic-ai',
+    );
+  });
+
+  it("uses the same page-local install command in the markdown alternate", async () => {
+    const markdown = await getKitaruMarkdown().text();
+    expect(
+      markdown.match(/uv add "kitaru\[cli,worker\]" kitaru-pydantic-ai/g),
+    ).toHaveLength(2);
+    expect(markdown).not.toContain("`uv add kitaru`");
+  });
+
+  it("renders the complete current CLI workflow", () => {
+    const hero = HERO_CODE_LINES.map((line) => line.text).join("\n");
+    const featureCommands = STEPS.map((step) => step.command).join("\n");
+
+    expect(hero).toMatchInlineSnapshot(`
+      "# 1 · wrap the agent you already have
+      from kitaru_pydantic_ai import KitaruAgent
+      agent = KitaruAgent(intake_agent, agent_id=AGENT_ID)
+
+      # 2 · the runs it already made, imported
+      kitaru session import ./traces.jsonl \\
+        --importer kitaru/kitaru-jsonl@latest --agent intake-agent@latest --wait
+
+      # 3 · get interviewed, in your coding agent
+      walk me through 20 of these
+      → cohort "dropped the hazmat flag" · 9
+      → evaluator hazmat-flag-preserved
+
+      # 4 · change the agent, compare the runs
+      kitaru experiment run start fix-validation \\
+        --cohort-version $COHORT_VERSION_ID --agent intake-agent@pr-311 --wait"
+    `);
+    expect(featureCommands).toMatchInlineSnapshot(`
+      "COHORT_VERSION_ID=$(kitaru cohort create checkout-flow --agent checkout-agent --sessions-file session-ids.txt --output json --machine --non-interactive --no-browser | jq -r '.item.version.id')
+      kitaru experiment create baseline --agent checkout-agent --tool-policy '{"default":{"type":"history","scope":"cohort_version","on_miss":"fail"}}' --evaluator response-quality@latest
+      kitaru experiment create cheap-model --agent checkout-agent --override '{"model":"claude-haiku-4.5"}' --tool-policy '{"default":{"type":"history","scope":"cohort_version","on_miss":"fail"}}' --evaluator response-quality@latest
+      kitaru experiment run start baseline --cohort-version "$COHORT_VERSION_ID" --agent checkout-agent@v1 --wait
+      kitaru experiment run start cheap-model --cohort-version "$COHORT_VERSION_ID" --agent checkout-agent@v1 --wait"
+    `);
+  });
+
+  it("renders the complete current adapter examples", () => {
+    const samples = Object.fromEntries(
+      FRAMEWORKS.map((framework) => {
+        const before = framework.before.map(renderTokens).join("\n");
+        const after = framework.after.map(renderTokens).join("\n");
+        const expectValid = framework.file.endsWith(".py")
+          ? expectValidPython
+          : expectValidTypeScript;
+        expectValid(before);
+        expectValid(after);
+        return [framework.id, { install: framework.install, before, after }];
+      }),
+    );
+
+    expect(samples).toMatchInlineSnapshot(`
+      {
+        "langgraph": {
+          "after": "from kitaru_langgraph import KitaruGraphRunner
+      from langgraph.graph import END, START, StateGraph
+
+      builder = StateGraph(SupportState)
+      builder.add_node("normalize", normalize)
+      builder.add_edge(START, "normalize")
+      builder.add_edge("normalize", END)
+
+      runner = KitaruGraphRunner(builder.compile(), agent_id=AGENT_ID)
+      result = runner.invoke({"request": task})",
+          "before": "from langgraph.graph import END, START, StateGraph
+
+      builder = StateGraph(SupportState)
+      builder.add_node("normalize", normalize)
+      builder.add_edge(START, "normalize")
+      builder.add_edge("normalize", END)
+
+      graph = builder.compile()
+      result = graph.invoke({"request": task})",
+          "install": "uv add kitaru-langgraph",
+        },
+        "mastra": {
+          "after": "import { Agent } from "@mastra/core/agent";
+      import { KitaruAgent } from "@zenml-io/kitaru-mastra";
+
+      const agent = new KitaruAgent(new Agent({
+        id: "support-agent",
+        name: "Support agent",
+        instructions: "Answer support requests.",
+        model: "openai/gpt-5-mini",
+        tools,
+      }), { agentId: AGENT_ID });
+
+      const result = await agent.generate(messages);",
+          "before": "import { Agent } from "@mastra/core/agent";
+
+      const agent = new Agent({
+        id: "support-agent",
+        name: "Support agent",
+        instructions: "Answer support requests.",
+        model: "openai/gpt-5-mini",
+        tools,
+      });
+
+      const result = await agent.generate(messages);",
+          "install": "pnpm add @zenml-io/kitaru-mastra @mastra/core@1.51.0",
+        },
+        "openai": {
+          "after": "from agents import Agent
+      from kitaru_openai_agents import KitaruRunner
+
+      agent = Agent(
+          name="Compliance Reviewer",
+          instructions="Answer briefly and accurately.",
+          model="gpt-5-mini",
+      )
+      runner = KitaruRunner(agent_id=AGENT_ID)
+
+      result = await runner.run(agent, task)",
+          "before": "from agents import Agent, Runner
+
+      agent = Agent(
+          name="Compliance Reviewer",
+          instructions="Answer briefly and accurately.",
+          model="gpt-5-mini",
+      )
+
+      result = await Runner.run(agent, task)",
+          "install": "uv add kitaru-openai-agents",
+        },
+        "pydanticai": {
+          "after": "from kitaru_pydantic_ai import KitaruAgent
+      from pydantic_ai import Agent
+
+      agent = KitaruAgent(Agent(
+          "openai:gpt-5-mini",
+          system_prompt="You are a compliance reviewer.",
+          tools=[search_docs, fetch_policy],
+      ), agent_id=AGENT_ID)
+
+      result = await agent.run(task)",
+          "before": "from pydantic_ai import Agent
+
+      agent = Agent(
+          "openai:gpt-5-mini",
+          system_prompt="You are a compliance reviewer.",
+          tools=[search_docs, fetch_policy],
+      )
+
+      result = await agent.run(task)",
+          "install": "uv add "kitaru-pydantic-ai[openai]"",
+        },
+        "vercel": {
+          "after": "import { openai } from "@ai-sdk/openai";
+      import { createKitaruGenerateText } from "@zenml-io/kitaru-vercel-ai";
+
+      const generateText = createKitaruGenerateText({ agentId: AGENT_ID });
+
+      const result = await generateText({
+        model: openai("gpt-5-nano"),
+        prompt: task,
+      });
+
+      console.log(result.text);",
+          "before": "import { openai } from "@ai-sdk/openai";
+      import { generateText } from "ai";
+
+      const result = await generateText({
+        model: openai("gpt-5-nano"),
+        prompt: task,
+      });
+
+      console.log(result.text);",
+          "install": "pnpm add @zenml-io/kitaru-vercel-ai ai@7.0.65 @ai-sdk/openai@4.0.20 zod@4.4.3",
+        },
+      }
+    `);
+  });
+
+  it("renders the complete current Python and TypeScript workflows", () => {
+    const python = renderLines(PYTHON_SHOWCASE);
+    const typescript = renderLines(TYPESCRIPT_SHOWCASE);
+
+    expectValidPython(python);
+    expectValidTypeScript(typescript);
+    expect(python).toMatchInlineSnapshot(`
+      "import asyncio
+      from kitaru.api_models.v1.experiment import ExperimentCreateRequest
+      from kitaru.api_models.v1.experiment_run import ExperimentRunCreateRequest, ExperimentRunStatus
+      from kitaru.api_models.v1.replay_config import EvaluatorConfig, HistoryConfig, ReplayOverride, ToolPolicy
+      from kitaru.client import KitaruAPIClient
+
+      TERMINAL = {ExperimentRunStatus.COMPLETED, ExperimentRunStatus.FAILED,
+          ExperimentRunStatus.CANCELED}
+      async def wait_for_run(client, run_id):
+          while True:
+              run = await client.experiment_runs.get(run_id)
+              if run.status in TERMINAL:
+                  return run
+              await asyncio.sleep(1)
+
+      policy = ToolPolicy(default=HistoryConfig(
+          scope="cohort_version", on_miss="fail"))
+      evaluator = EvaluatorConfig(evaluator="response-quality", version=1)
+
+      async def main():
+          async with KitaruAPIClient() as client:
+              baseline = await client.experiments.create(
+                  ExperimentCreateRequest(name="baseline", agent_id=AGENT_ID,
+                      tool_policy=policy, evaluators=[evaluator]))
+              candidate = await client.experiments.create(
+                  ExperimentCreateRequest(name="cheap-model", agent_id=AGENT_ID,
+                      override=ReplayOverride(model="claude-haiku-4.5"),
+                      tool_policy=policy, evaluators=[evaluator]))
+
+              run_spec = ExperimentRunCreateRequest(
+                  cohort_version_id=COHORT_VERSION_ID, agent_version_id=AGENT_VERSION_ID,
+                  evaluate_baselines=True)
+              before, after = await asyncio.gather(
+                  client.experiments.start_run(baseline.id, run_spec),
+                  client.experiments.start_run(candidate.id, run_spec),
+              )
+
+              async with asyncio.timeout(300):
+                  before, after = await asyncio.gather(
+                      wait_for_run(client, before.id),
+                      wait_for_run(client, after.id),
+                  )
+
+      asyncio.run(main())"
+    `);
+    expect(typescript).toMatchInlineSnapshot(`
+      "import { createKitaruClient } from "@zenml-io/kitaru/node";
+      const client = await createKitaruClient();
+
+      const common = { agent_id: agentId,
+        tool_policy: { default: { type: "history",
+          scope: "cohort_version", on_miss: "fail" } },
+        evaluators: [{ evaluator: "response-quality", version: 1 }],
+      };
+
+      const baseline = await client.experiments.create({
+        name: "baseline", ...common });
+      const candidate = await client.experiments.create({
+        name: "cheap-model", ...common,
+        override: { model: "claude-haiku-4.5" },
+      });
+
+      const runSpec = { cohort_version_id: cohortVersionId,
+        agent_version_id: agentVersionId, evaluate_baselines: true };
+      const [before, after] = await Promise.all([
+        client.experiments.startRun(baseline.id, runSpec),
+        client.experiments.startRun(candidate.id, runSpec),
+      ]);
+
+      const [beforeResult, afterResult] = await Promise.all([
+        client.experimentRuns.wait(before.id),
+        client.experimentRuns.wait(after.id),
+      ]);"
+    `);
+    expect(python).not.toContain("kitaru.KitaruClient");
+    expect(python).not.toContain("client.compare");
+    expect(typescript).not.toContain("new KitaruClient()");
+    expect(typescript).not.toContain("client.compare");
+  });
+
+  it("renders the complete exact-ID MCP transcript", () => {
+    const transcript = AGENT_TRANSCRIPT.map((line) => line.text).join("\n");
+
+    expect(transcript).toMatchInlineSnapshot(`
+      "kitaru_workflow_start { "operation": "experiment_run",
+      "experiment_id": "$EXPERIMENT_ID", "cohort_version_id": "$COHORT_VERSION_ID",
+      "agent_version_id": "$V1_AGENT_VERSION_ID" }
+      90 sessions · cited-superseded-doc true 90 · false 0
+      kitaru_workflow_start { "operation": "experiment_run",
+      "experiment_id": "$EXPERIMENT_ID", "cohort_version_id": "$COHORT_VERSION_ID",
+      "agent_version_id": "$CANDIDATE_AGENT_VERSION_ID" }
+      cited-superseded-doc true 4 · false 86
+      4 still failing — opening these for you to read"
+    `);
+  });
+});


### PR DESCRIPTION
## Summary

The Kitaru product page now shows commands, imports, and SDK calls that match Kitaru `develop` at `440a6e1b`. The old examples mixed removed v1 APIs with current product language, so readers could copy code that no longer imports or calls a public method.

The page now:

- uses the supported PydanticAI, OpenAI Agents, LangGraph, Mastra, and Vercel AI adapter packages, with the required agent IDs and install commands;
- uses current cohort, experiment, experiment-run, importer, and MCP command contracts;
- creates a baseline and candidate over the same cohort and agent version, with only the model changed;
- uses the async Python and TypeScript SDK resource APIs instead of removed root-client, decorator, replay, fake-tool, and comparison helpers;
- waits for both exact runs before directing the reader to inspect the comparison in Kitaru;
- keeps the HTML page and its Markdown alternate on the same page-local install command.

Focused contract tests flatten every displayed snippet, snapshot the complete examples, syntax-parse Python and TypeScript samples, and reject the retired comparison API. The dist smoke check also confirms that current Kitaru markers reach both generated outputs.

## Validation

- `pnpm test` (12 files, 200 tests)
- `pnpm check` (0 errors; 2 pre-existing hints)
- `pnpm lint`
- `pnpm check:tests`
- `pnpm check:surface`
- `pnpm check:alt`
- `pnpm build`
- `pnpm smoke:dist`
- `pnpm check:islands` (5 hydration flows)
- `pnpm check:worker` (16 runtime checks)

Independent and local code-review passes found no remaining actionable findings. Review artifact: `20260817-143335-2f5da0f0`.

## Reviewer Notes

Open `/product/kitaru` and check these paths:

1. Copy the hero and feature CLI examples. The cohort step must produce `COHORT_VERSION_ID`, and the two run commands must use the same cohort and agent version.
2. Switch through all five tabs under "One wrap, every call recorded." Each tab must show its adapter install command and a current wrapper import.
3. Toggle Python and TypeScript under "See the code." Both examples must create baseline and candidate experiments, start both runs concurrently, and wait for both exact run IDs.
4. Check the agent transcript for exact `kitaru_workflow_start` inputs rather than natural-language pseudo-commands.
5. Open `/product/kitaru.md`. Its install command must match the HTML page.

Scope is intentionally limited to this product page, its Markdown alternate, and focused tests/smoke assertions.

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required because this changes static product content and its build-time contracts. After deployment, the website owner should load `/product/kitaru` and `/product/kitaru.md` once and confirm that the current install command and adapter tabs render. A missing snippet, hydration error, or stale Markdown command is the rollback trigger; revert this commit while the page content is corrected.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
