### PR TITLE
Fix Kitaru code showcase labels

### DIFF
--- a/scripts/check-island-hydration.ts
+++ b/scripts/check-island-hydration.ts
@@ -54,12 +54,11 @@
  *   would have to select them positionally — brittle, for a low-traffic page.
  * All four are still covered structurally by the island manifest in
  * check-dist-smoke.ts. Please do not "helpfully" add them back here.
- * - Of the /product/kitaru islands, only OneImport is checked. They are all
- *   client:visible siblings on one page sharing the same bundle pipeline, so one
- *   check proves the page hydrates. The others have nothing better to assert on:
- *   Hero's sole interaction is a clipboard write (permission-gated in headless),
- *   CodeShowcase's lang toggle is a near-identical sibling of OneImport's tabs,
- *   KitaruGrain is a WebGL shader, AgentDriven/SocialProof render static content
+ * - Of the remaining /product/kitaru islands, OneImport and CodeShowcase cover
+ *   the interactive contracts that have regressed. The others have nothing better
+ *   to assert on: Hero's sole interaction is a clipboard write (permission-gated
+ *   in headless), KitaruGrain is a WebGL shader, and AgentDriven/SocialProof
+ *   render static content
  *   through Reveal wrappers, and ScenarioStrip's only state is a decorative
  *   hover-linked highlight — a progressive enhancement we accept going untested
  *   rather than asserting on hover-driven class flips.
@@ -355,6 +354,70 @@ const CHECKS: IslandCheck[] = [
 
       await page.waitForSelector(`${tab(2)}[aria-selected="true"]`);
       await page.waitForSelector(`${tab(1)}[aria-selected="false"]`);
+    },
+  },
+  {
+    name: "CodeShowcase switches language-specific annotations without a trailing panel",
+    route: "/product/kitaru#code-showcase",
+    island: "CodeShowcase",
+    seedConsent: true,
+    async assert(page, root) {
+      const annotations = page.locator(`${root} [data-kitaru-annotations]`);
+      const pythonModelLabel = annotations.getByText(
+        'ReplayOverride(model="claude-haiku-4.5")',
+        { exact: true },
+      );
+      await pythonModelLabel.waitFor({ state: "visible" });
+
+      await page
+        .locator(root)
+        .getByRole("button", { name: "TypeScript", exact: true })
+        .click();
+      await page.waitForSelector(
+        `${root} button[aria-pressed="true"]:has-text("TypeScript")`,
+      );
+      await annotations
+        .getByText('override: { model: "claude-haiku-4.5" }', { exact: true })
+        .waitFor({ state: "visible" });
+      await pythonModelLabel.waitFor({ state: "detached" });
+
+      const trailingGap = await annotations.evaluate((column) => {
+        const boundary = column.closest("[data-kitaru-showcase-grid]");
+        if (boundary === null) return Number.POSITIVE_INFINITY;
+
+        const last = column.querySelector(
+          "[data-kitaru-annotation]:last-child",
+        );
+        if (last === null) return Number.POSITIVE_INFINITY;
+
+        const lastBottom = last.getBoundingClientRect().bottom;
+        let paintedBottom = lastBottom;
+        for (
+          let element: Element | null = column;
+          element !== null && element !== boundary;
+          element = element.parentElement
+        ) {
+          const style = getComputedStyle(element);
+          const hasBackground =
+            (style.backgroundColor !== "rgba(0, 0, 0, 0)" &&
+              style.backgroundColor !== "transparent") ||
+            style.backgroundImage !== "none";
+          if (hasBackground) {
+            paintedBottom = Math.max(
+              paintedBottom,
+              element.getBoundingClientRect().bottom,
+            );
+          }
+        }
+
+        return paintedBottom - lastBottom;
+      });
+
+      if (Math.abs(trailingGap) > 1) {
+        throw new Error(
+          `annotation column leaves a ${trailingGap}px trailing background panel`,
+        );
+      }
     },
   },
 ];

--- a/src/components/kitaru/islands/AgentDriven.tsx
+++ b/src/components/kitaru/islands/AgentDriven.tsx
@@ -17,40 +17,14 @@ const agentIcons: Record<string, typeof AnthropicIcon> = {
 
 export const AGENT_TRANSCRIPT = [
   {
-    text: "kitaru_workflow_start({",
+    text: 'kitaru_workflow_start({ "operation": "experiment_run", "experiment_id": "$EXPERIMENT_ID", "cohort_version_id": "$COHORT_VERSION_ID", "agent_version_id": "$V1_AGENT_VERSION_ID" })',
     kind: "agent",
   },
-  {
-    text: '"operation": "experiment_run",',
-    kind: "agent",
-  },
-  {
-    text: '"experiment_id": "$EXPERIMENT_ID", "cohort_version_id": "$COHORT_VERSION_ID",',
-    kind: "agent",
-  },
-  {
-    text: '"agent_version_id": "$V1_AGENT_VERSION_ID"',
-    kind: "agent",
-  },
-  { text: "})", kind: "agent" },
   { text: "90 sessions · cited-superseded-doc true 90 · false 0", kind: "out" },
   {
-    text: "kitaru_workflow_start({",
+    text: 'kitaru_workflow_start({ "operation": "experiment_run", "experiment_id": "$EXPERIMENT_ID", "cohort_version_id": "$COHORT_VERSION_ID", "agent_version_id": "$CANDIDATE_AGENT_VERSION_ID" })',
     kind: "agent",
   },
-  {
-    text: '"operation": "experiment_run",',
-    kind: "agent",
-  },
-  {
-    text: '"experiment_id": "$EXPERIMENT_ID", "cohort_version_id": "$COHORT_VERSION_ID",',
-    kind: "agent",
-  },
-  {
-    text: '"agent_version_id": "$CANDIDATE_AGENT_VERSION_ID"',
-    kind: "agent",
-  },
-  { text: "})", kind: "agent" },
   { text: "cited-superseded-doc true 4 · false 86", kind: "good" },
   { text: "4 still failing — opening these for you to read", kind: "bad" },
 ] as const;

--- a/src/components/kitaru/islands/AgentDriven.tsx
+++ b/src/components/kitaru/islands/AgentDriven.tsx
@@ -17,7 +17,11 @@ const agentIcons: Record<string, typeof AnthropicIcon> = {
 
 export const AGENT_TRANSCRIPT = [
   {
-    text: 'kitaru_workflow_start { "operation": "experiment_run",',
+    text: "kitaru_workflow_start({",
+    kind: "agent",
+  },
+  {
+    text: '"operation": "experiment_run",',
     kind: "agent",
   },
   {
@@ -25,12 +29,17 @@ export const AGENT_TRANSCRIPT = [
     kind: "agent",
   },
   {
-    text: '"agent_version_id": "$V1_AGENT_VERSION_ID" }',
+    text: '"agent_version_id": "$V1_AGENT_VERSION_ID"',
     kind: "agent",
   },
+  { text: "})", kind: "agent" },
   { text: "90 sessions · cited-superseded-doc true 90 · false 0", kind: "out" },
   {
-    text: 'kitaru_workflow_start { "operation": "experiment_run",',
+    text: "kitaru_workflow_start({",
+    kind: "agent",
+  },
+  {
+    text: '"operation": "experiment_run",',
     kind: "agent",
   },
   {
@@ -38,9 +47,10 @@ export const AGENT_TRANSCRIPT = [
     kind: "agent",
   },
   {
-    text: '"agent_version_id": "$CANDIDATE_AGENT_VERSION_ID" }',
+    text: '"agent_version_id": "$CANDIDATE_AGENT_VERSION_ID"',
     kind: "agent",
   },
+  { text: "})", kind: "agent" },
   { text: "cited-superseded-doc true 4 · false 86", kind: "good" },
   { text: "4 still failing — opening these for you to read", kind: "bad" },
 ] as const;

--- a/src/components/kitaru/islands/CodeShowcase.tsx
+++ b/src/components/kitaru/islands/CodeShowcase.tsx
@@ -536,7 +536,10 @@ export function CodeShowcase() {
           </p>
         </Reveal>
 
-        <div className="mt-14 grid grid-cols-1 gap-8 lg:grid-cols-[1.25fr_1fr]">
+        <div
+          data-kitaru-showcase-grid
+          className="mt-14 grid grid-cols-1 gap-8 lg:grid-cols-[1.25fr_1fr]"
+        >
           <Reveal variant="left" delay={80}>
             <div className="overflow-hidden rounded-xl border border-white/10 bg-night-surface">
               <div className="flex items-center gap-4 border-b border-white/10 px-4 py-3">
@@ -551,7 +554,10 @@ export function CodeShowcase() {
                       key={l}
                       type="button"
                       aria-pressed={lang === l}
-                      onClick={() => setLang(l)}
+                      onClick={() => {
+                        setLang(l);
+                        setHot(null);
+                      }}
                       className={cn(
                         "rounded px-2.5 py-1 font-mono text-[11px] transition-colors cursor-pointer",
                         lang === l
@@ -590,40 +596,42 @@ export function CodeShowcase() {
             </div>
           </Reveal>
 
-          <Reveal
-            variant="right"
-            delay={140}
-            className="flex flex-col gap-px bg-white/10"
-          >
-            {ANNOTATIONS.map((a) => (
-              // biome-ignore lint/a11y/noStaticElementInteractions: decorative hover highlight, not a keyboard control
-              <div
-                key={a.key}
-                onMouseEnter={() => setHot(a.key)}
-                onMouseLeave={() => setHot(null)}
-                className="relative isolate overflow-hidden bg-night px-5 py-4"
-              >
-                {/* blend={false}: text renders above this grain, and Safari
-                    mis-stacks mix-blend layers over z-indexed siblings. */}
-                <KitaruGrain
-                  variant="dark"
-                  blend={false}
-                  active={hot === a.key}
-                  className="z-0"
-                />
-                <code
-                  className={cn(
-                    "relative z-10 font-mono text-[12px] transition-colors",
-                    hot === a.key ? "text-ember" : "text-night-text/70",
-                  )}
+          <Reveal variant="right" delay={140} className="self-start">
+            <div
+              data-kitaru-annotations
+              className="flex flex-col gap-px bg-white/10"
+            >
+              {ANNOTATIONS.map((a) => (
+                // biome-ignore lint/a11y/noStaticElementInteractions: decorative hover highlight, not a keyboard control
+                <div
+                  key={a.key}
+                  data-kitaru-annotation
+                  onMouseEnter={() => setHot(a.key)}
+                  onMouseLeave={() => setHot(null)}
+                  className="relative isolate overflow-hidden bg-night px-5 py-4"
                 >
-                  {a.label}
-                </code>
-                <p className="relative z-10 mt-2 text-[13px] leading-relaxed text-night-text/55">
-                  {a.body}
-                </p>
-              </div>
-            ))}
+                  {/* blend={false}: text renders above this grain, and Safari
+                      mis-stacks mix-blend layers over z-indexed siblings. */}
+                  <KitaruGrain
+                    variant="dark"
+                    blend={false}
+                    active={hot === a.key}
+                    className="z-0"
+                  />
+                  <code
+                    className={cn(
+                      "relative z-10 font-mono text-[12px] transition-colors",
+                      hot === a.key ? "text-ember" : "text-night-text/70",
+                    )}
+                  >
+                    {a.label[lang]}
+                  </code>
+                  <p className="relative z-10 mt-2 text-[13px] leading-relaxed text-night-text/55">
+                    {a.body}
+                  </p>
+                </div>
+              ))}
+            </div>
           </Reveal>
         </div>
       </div>

--- a/src/lib/kitaru-landing.ts
+++ b/src/lib/kitaru-landing.ts
@@ -91,32 +91,50 @@ export const GROUND_TRUTH_POINTS = [
 export const ANNOTATIONS = [
   {
     key: "cohort",
-    label: "cohort_version_id=...",
+    label: {
+      python: "cohort_version_id=...",
+      typescript: "cohort_version_id: ...",
+    },
     body: "An immutable set of sessions — a run depends on its cohort, so a mutable one would make old results meaningless.",
   },
   {
     key: "experiment",
-    label: "experiments.create(...)",
+    label: {
+      python: "experiments.create(...)",
+      typescript: "experiments.create(...)",
+    },
     body: "Pure configuration. Change the code and you get a new run; change the prompt and you get a new experiment.",
   },
   {
     key: "model",
-    label: 'ReplayOverride(model="claude-haiku-4.5")',
+    label: {
+      python: 'ReplayOverride(model="claude-haiku-4.5")',
+      typescript: 'override: { model: "claude-haiku-4.5" }',
+    },
     body: "The variable under test. A run that moved two things cannot tell you which one did it.",
   },
   {
     key: "policy",
-    label: 'HistoryConfig(scope="cohort_version")',
+    label: {
+      python: 'HistoryConfig(scope="cohort_version")',
+      typescript: '{ type: "history", scope: "cohort_version" }',
+    },
     body: "One of four policies — history, passthrough, static, llm. Every intercepted node is stamped with the one that answered it.",
   },
   {
     key: "run",
-    label: "experiments.start_run(...)",
+    label: {
+      python: "experiments.start_run(...)",
+      typescript: "experiments.startRun(...)",
+    },
     body: "Each replay creates a new session instead of overwriting the original, so the baseline survives intact.",
   },
   {
     key: "inspect",
-    label: "wait_for_run(...) / experimentRuns.wait(...)",
+    label: {
+      python: "wait_for_run(...)",
+      typescript: "experimentRuns.wait(...)",
+    },
     body: "Wait for both exact runs to settle, then inspect their comparison in Kitaru. It does not invent a verdict or a blended score.",
   },
 ] as const;

--- a/tests/lib/kitaruProductSnippets.test.ts
+++ b/tests/lib/kitaruProductSnippets.test.ts
@@ -365,25 +365,21 @@ describe("Kitaru product-page snippets", () => {
     const transcript = AGENT_TRANSCRIPT.map((line) => line.text).join("\n");
 
     expect(
-      AGENT_TRANSCRIPT.filter(
-        (line) => line.text === "kitaru_workflow_start({",
+      AGENT_TRANSCRIPT.filter((line) =>
+        line.text.startsWith("kitaru_workflow_start({"),
       ),
     ).toHaveLength(2);
-    expect(AGENT_TRANSCRIPT.filter((line) => line.text === "})")).toHaveLength(
-      2,
-    );
+    expect(
+      AGENT_TRANSCRIPT.filter(
+        (line) =>
+          line.text.startsWith("kitaru_workflow_start({") &&
+          line.text.endsWith("})"),
+      ),
+    ).toHaveLength(2);
     expect(transcript).toMatchInlineSnapshot(`
-      "kitaru_workflow_start({
-      "operation": "experiment_run",
-      "experiment_id": "$EXPERIMENT_ID", "cohort_version_id": "$COHORT_VERSION_ID",
-      "agent_version_id": "$V1_AGENT_VERSION_ID"
-      })
+      "kitaru_workflow_start({ "operation": "experiment_run", "experiment_id": "$EXPERIMENT_ID", "cohort_version_id": "$COHORT_VERSION_ID", "agent_version_id": "$V1_AGENT_VERSION_ID" })
       90 sessions · cited-superseded-doc true 90 · false 0
-      kitaru_workflow_start({
-      "operation": "experiment_run",
-      "experiment_id": "$EXPERIMENT_ID", "cohort_version_id": "$COHORT_VERSION_ID",
-      "agent_version_id": "$CANDIDATE_AGENT_VERSION_ID"
-      })
+      kitaru_workflow_start({ "operation": "experiment_run", "experiment_id": "$EXPERIMENT_ID", "cohort_version_id": "$COHORT_VERSION_ID", "agent_version_id": "$CANDIDATE_AGENT_VERSION_ID" })
       cited-superseded-doc true 4 · false 86
       4 still failing — opening these for you to read"
     `);

--- a/tests/lib/kitaruProductSnippets.test.ts
+++ b/tests/lib/kitaruProductSnippets.test.ts
@@ -9,7 +9,11 @@ import {
 import type { CodeLine } from "../../src/components/kitaru/islands/code-tokens";
 import { HERO_CODE_LINES } from "../../src/components/kitaru/islands/Hero";
 import { FRAMEWORKS } from "../../src/components/kitaru/islands/OneImport";
-import { KITARU_INSTALL_CMD, STEPS } from "../../src/lib/kitaru-landing";
+import {
+  ANNOTATIONS,
+  KITARU_INSTALL_CMD,
+  STEPS,
+} from "../../src/lib/kitaru-landing";
 import { GET as getKitaruMarkdown } from "../../src/pages/product/kitaru.md";
 
 function renderTokens(tokens: CodeLine): string {
@@ -330,17 +334,56 @@ describe("Kitaru product-page snippets", () => {
     expect(typescript).not.toContain("client.compare");
   });
 
+  it("labels each SDK workflow with its own syntax", () => {
+    expect(
+      ANNOTATIONS.map((annotation) => annotation.label.python),
+    ).toMatchInlineSnapshot(`
+        [
+          "cohort_version_id=...",
+          "experiments.create(...)",
+          "ReplayOverride(model="claude-haiku-4.5")",
+          "HistoryConfig(scope="cohort_version")",
+          "experiments.start_run(...)",
+          "wait_for_run(...)",
+        ]
+      `);
+    expect(
+      ANNOTATIONS.map((annotation) => annotation.label.typescript),
+    ).toMatchInlineSnapshot(`
+        [
+          "cohort_version_id: ...",
+          "experiments.create(...)",
+          "override: { model: "claude-haiku-4.5" }",
+          "{ type: "history", scope: "cohort_version" }",
+          "experiments.startRun(...)",
+          "experimentRuns.wait(...)",
+        ]
+      `);
+  });
+
   it("renders the complete exact-ID MCP transcript", () => {
     const transcript = AGENT_TRANSCRIPT.map((line) => line.text).join("\n");
 
+    expect(
+      AGENT_TRANSCRIPT.filter(
+        (line) => line.text === "kitaru_workflow_start({",
+      ),
+    ).toHaveLength(2);
+    expect(AGENT_TRANSCRIPT.filter((line) => line.text === "})")).toHaveLength(
+      2,
+    );
     expect(transcript).toMatchInlineSnapshot(`
-      "kitaru_workflow_start { "operation": "experiment_run",
+      "kitaru_workflow_start({
+      "operation": "experiment_run",
       "experiment_id": "$EXPERIMENT_ID", "cohort_version_id": "$COHORT_VERSION_ID",
-      "agent_version_id": "$V1_AGENT_VERSION_ID" }
+      "agent_version_id": "$V1_AGENT_VERSION_ID"
+      })
       90 sessions · cited-superseded-doc true 90 · false 0
-      kitaru_workflow_start { "operation": "experiment_run",
+      kitaru_workflow_start({
+      "operation": "experiment_run",
       "experiment_id": "$EXPERIMENT_ID", "cohort_version_id": "$COHORT_VERSION_ID",
-      "agent_version_id": "$CANDIDATE_AGENT_VERSION_ID" }
+      "agent_version_id": "$CANDIDATE_AGENT_VERSION_ID"
+      })
       cited-superseded-doc true 4 · false 86
       4 still failing — opening these for you to read"
     `);


### PR DESCRIPTION
## Summary

Follow-up to #235. The TypeScript code showcase now uses TypeScript labels instead of Python API names, and the annotation background ends after the final row instead of stretching into an empty grey block. The MCP transcript now renders both workflow calls with complete `({ ... })` delimiters.

The regression coverage checks the default Python labels, the TypeScript labels after switching, the visible painted area below the final annotation, and the MCP opening and closing delimiters.

## Validation

- `pnpm lint:fix`
- `pnpm check`
- `pnpm test` (12 files, 201 tests)
- `pnpm build`
- `pnpm check:islands` (6 hydration flows)
- `pnpm smoke:dist`
- Browser verification of the TypeScript showcase and MCP transcript

## Reviewer Notes

1. Open `/product/kitaru#code-showcase`.
2. Switch from Python to TypeScript and confirm the right column uses TypeScript syntax.
3. Confirm the right column ends after `experimentRuns.wait(...)` with no grey block below it.
4. Scroll to "Your agent does the driving" and confirm each `kitaru_workflow_start` call ends with `})`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
