### PR TITLE
Kitaru launch hotfix: proper OG card + featured blog post

### DIFF
--- a/src/content/blog/introducing-the-new-kitaru.md
+++ b/src/content/blog/introducing-the-new-kitaru.md
@@ -2,6 +2,7 @@
 title: "Introducing the new Kitaru: from production traces to repeatable evals"
 slug: "introducing-the-new-kitaru"
 draft: false
+featured: true
 author: "hamza-tahir"
 category: "kitaru"
 tags:

--- a/src/lib/productKitaru.ts
+++ b/src/lib/productKitaru.ts
@@ -58,6 +58,8 @@ export const PRODUCT_KITARU_SEO = {
   title: "Kitaru: replay-based evals for AI agents | ZenML",
   description:
     "Replay-based evals for AI agents: your production traces, re-run against your next change. Built for agents that write into a system of record, where testing in production would create phantom bookings and duplicate claims. Import the runs your agent already made, turn what your team notices into an evaluator, then compare two experiment runs to see what a new model or prompt would have done. Open source, self-hosted, built by the ZenML team.",
+  // OG cards need JPEG, not AVIF — social platforms don't render AVIF (PR #73).
+  ogImage: "https://assets.zenml.io/content/og/439a52c0/kitaru-product-og.jpg",
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

Two small launch-day fixes: `/product/kitaru` now serves the designed Kitaru Open Graph card instead of the site-wide default, and the blog hero now features today's relaunch post.

## What changed

- **OG card** — `src/lib/productKitaru.ts`: added `ogImage` to `PRODUCT_KITARU_SEO`, pointing at the new card on R2 (`content/og/439a52c0/kitaru-product-og.jpg`). Uploaded as JPEG per the site convention for OG images (social platforms don't render AVIF — see PR #73); public URL verified with a 200 + `image/jpeg` response.
- **Featured post** — `src/content/blog/introducing-the-new-kitaru.md`: added `featured: true`, so the relaunch post takes the `/blog` hero slot. The feed picks the newest featured post, so the three older `featured: true` posts remain as fallbacks — no other frontmatter touched.

## What reviewers should focus on

- The featured post is deliberately `introducing-the-new-kitaru` (today's replay-evals relaunch), **not** `kitaru-launch` (the pre-pivot April durable-execution launch with a confusingly similar name).
- The OG image shows `cloud.kitaru.ai` in the corner — consistent with the live signup CTA in `KITARU_LINKS`.

## Validation

- `pnpm check`, `pnpm check:tests`, `pnpm check:surface`, `pnpm check:alt`, `pnpm lint`, `pnpm build`, `pnpm smoke:dist`, `pnpm check:worker`, `pnpm check:islands` — all pass.
- `pnpm test`: 2 failures in `tests/config/deploymentWorkflows.test.ts` are **pre-existing on `origin/main`** (verified by stashing this change and re-running) and unrelated to this diff.
- Built `dist/` inspected: `product/kitaru.html` emits the new `og:image`/`twitter:image`, and `blog.html` renders the relaunch post in the hero.

## Preview URLs / paths to check

- Preview URL + `/product/kitaru` — view source for the `og:image` meta, or drop the URL into a social-card debugger
- Preview URL + `/blog` — relaunch post in the hero slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)