### PR TITLE
Hotfix: drop the Kitaru hero's secondary Book a demo link

### DIFF
--- a/src/components/kitaru/islands/Hero.tsx
+++ b/src/components/kitaru/islands/Hero.tsx
@@ -165,13 +165,6 @@ export function Hero() {
                 {KITARU_LINKS.signup.label}
                 <ArrowRight class="size-4 transition-transform group-hover:translate-x-0.5" />
               </a>
-              <a
-                href={KITARU_LINKS.demo.href}
-                data-analytics="Kitaru-Hero-Demo"
-                className="inline-flex items-center rounded-md border border-border bg-surface px-5 py-3 text-sm font-medium text-ink transition-colors hover:bg-secondary cursor-pointer"
-              >
-                {KITARU_LINKS.demo.label}
-              </a>
             </div>
             <p className="text-[12.5px] text-muted-foreground">
               {KITARU_TRIAL_NOTE}


### PR DESCRIPTION
## Summary

Cherry-pick of the single-signup-CTA decision so it ships now instead of waiting for the rest of the overhaul branch: the Kitaru hero loses its secondary "Book a demo" link. Kitaru's posture is self-serve — one primary action, "Sign up free".

## What changed

- `src/components/kitaru/islands/Hero.tsx` — removed the secondary demo CTA (7 deleted lines). Cherry-picked from `1f6db33` on the `kitaru-overhaul` branch; the commit's `Navigation.astro` half is already on `main` via #241, so the pick correctly reduces to just the hero change.

## What reviewers should focus on

- This intentionally duplicates a commit that still lives on `kitaru-overhaul`; when that branch merges, the identical change resolves cleanly.
- `KITARU_LINKS.demo` in `src/lib/productKitaru.ts` is intentionally left in place — `/book-your-demo/kitaru` remains a valid route and the constant may be referenced by other surfaces.

## Validation

- `pnpm check`, `pnpm lint`, `pnpm check:surface`, `pnpm build`, `pnpm smoke:dist`, `pnpm check:islands` — all pass.
- Built `dist/client/product/kitaru.html` inspected: 0 × "Book a demo", 4 × "Sign up free".
- Known pre-existing: 2 failures in `tests/config/deploymentWorkflows.test.ts` exist on clean `origin/main` (unrelated, see #244).

## Preview URLs / paths to check

- Preview URL + `/product/kitaru` — hero should show a single "Sign up free" CTA with the trial note, no demo link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)